### PR TITLE
ics3a/libvhal: update to 1b275c4 (fix command streamer exit path)

### DIFF
--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 3980f24 && \
+  git checkout 1b275c4 && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -246,7 +246,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 3980f24 && \
+  git checkout 1b275c4 && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/docker/streamer/ubuntu22.04/Dockerfile
+++ b/docker/streamer/ubuntu22.04/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 3980f24 && \
+  git checkout 1b275c4 && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/templates/libvhal-client.m4
+++ b/templates/libvhal-client.m4
@@ -31,7 +31,7 @@ dnl
 include(begin.m4)
 
 DECLARE(`LIBVHAL_SRC_REPO',https://github.com/projectceladon/libvhal-client.git)
-DECLARE(`LIBVHAL_CLIENT_VER',3980f24)
+DECLARE(`LIBVHAL_CLIENT_VER',1b275c4)
 DECLARE(`LIBVHAL_BUILD_EMU',OFF)
 
 define(`LIBVHAL_CLIENT_BUILD_DEPS',`ca-certificates cmake gcc g++ git dnl


### PR DESCRIPTION
Requires: https://github.com/projectceladon/libvhal-client/pull/8
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>