### PR TITLE
Fix logic in conversion of mono audio into stereo

### DIFF
--- a/sources/streamer/module/server-webrtc/aic-vhal-client/AudioPlayer.cpp
+++ b/sources/streamer/module/server-webrtc/aic-vhal-client/AudioPlayer.cpp
@@ -101,7 +101,7 @@ void AudioPlayer::OnData(const void *audio_data, int bits_per_sample,
     const uint16_t *data = reinterpret_cast<const uint16_t *>(audio_data);
 
     const auto sizeInBytes =
-        number_of_frames * number_of_channels * bits_per_sample / 8;
+        number_of_frames * mAudioConfig.channelCount * bits_per_sample / 8;
 
     if (mAudioConfig.channelCount == number_of_channels) {
         ga_logger(Severity::DBG, TAG "Same channelCount, copying Original data\n");


### PR DESCRIPTION
Recorded audio is at 2x speed when OWT sends mono audio. This is because sizeInBytes is calculated based on the incoming number_of_channels, and hence, even though the buffer holds stereo data, only 1 channel is sent to vhal.

To fix this, sizeInBytes has to be calculated based on the outgoing audio configuration: mAudioConfig.channelCount.

Tracked-On: OAM-105547
Signed-off-by: Anoob Anto K <anoob.anto.kodankandath@intel.com>