### PR TITLE
ics3a/encoder: update ffmpeg to n6.0 and support custom SEI messages

### DIFF
--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
@@ -66,7 +66,14 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout n6.0
+
+COPY patches/ffmpeg /opt/build/ffmpeg
+RUN cd /opt/build/ffmpeg && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \

--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile.m4
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile.m4
@@ -18,6 +18,7 @@ include(defs.m4)dnl
 define(`INTEL_GFX_FLAVOR_NAME',flex)
 include(begin.m4)
 define(`LIBVHAL_BUILD_EMU',ON)
+define(`FFMPEG_PATCH_PATH',patches/ffmpeg)
 include(intel-gfx.m4)
 include(ffmpeg.m4)
 include(libvhal-client.m4)

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -219,7 +219,14 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout n6.0
+
+COPY patches/ffmpeg /opt/build/ffmpeg
+RUN cd /opt/build/ffmpeg && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile.m4
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile.m4
@@ -18,6 +18,7 @@ include(defs.m4)dnl
 include(begin.m4)
 define(`ENABLE_PRODUCTION_KMD',ON)
 define(`LIBVHAL_BUILD_EMU',ON)
+define(`FFMPEG_PATCH_PATH',patches/ffmpeg)
 include(intel-gfx.m4)
 include(media-driver.m4)
 include(libva2-utils.m4)

--- a/patches/ffmpeg/0001-lavc-qsvenc-enlarge-the-maximum-number-of-mfxPayload.patch
+++ b/patches/ffmpeg/0001-lavc-qsvenc-enlarge-the-maximum-number-of-mfxPayload.patch
@@ -1,0 +1,30 @@
+From c6d0e620e329512469fd23664da099e2cd059e56 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 16 Mar 2022 12:30:09 +0800
+Subject: [PATCH 1/2] lavc/qsvenc: enlarge the maximum number of mfxPayload on
+ mfxEncodeCtrl
+
+The next commit and other commits in future may support more mfxPayload
+for encoding
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ libavcodec/qsv_internal.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
+index 5119ef4..3cc8a1b 100644
+--- a/libavcodec/qsv_internal.h
++++ b/libavcodec/qsv_internal.h
+@@ -50,7 +50,7 @@
+ 
+ #define ASYNC_DEPTH_DEFAULT 4       // internal parallelism
+ 
+-#define QSV_MAX_ENC_PAYLOAD 2       // # of mfxEncodeCtrl payloads supported
++#define QSV_MAX_ENC_PAYLOAD 8       // # of mfxEncodeCtrl payloads supported
+ #define QSV_MAX_ENC_EXTPARAM 8      // # of mfxEncodeCtrl extparam supported
+ 
+ #define QSV_MAX_ROI_NUM 256
+-- 
+1.8.3.1
+

--- a/patches/ffmpeg/0002-lavc-qsvenc_-h264-hevc-import-user-data-unregistered.patch
+++ b/patches/ffmpeg/0002-lavc-qsvenc_-h264-hevc-import-user-data-unregistered.patch
@@ -1,0 +1,155 @@
+From 98c8f0a48eee3eb4b35ab748f3374f825829934d Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Mon, 17 Oct 2022 13:48:34 +0800
+Subject: [PATCH 2/2] lavc/qsvenc_{h264,hevc}: import user data unregistered
+ SEIs if available
+
+option udu_sei is added, user should set udu_sei to true|on|1 if user
+data unregistered SEI is expected.
+
+Verify user data unregistered SEI with commands below:
+$ ffmpeg -y -f lavfi -i testsrc -vf "format=nv12" -c:v libx264 -frames:v 1
+a.h264
+$ ffmpeg -y -init_hw_device qsv -i a.h264 -c:v hevc_qsv -udu_sei 1 b.h265
+$ ffmpeg -y -init_hw_device qsv -i a.h264 -c:v hevc_qsv -udu_sei 0 c.h265
+
+$ ffmpeg -i b.h265 -vf showinfo -f null -
+$ ffmpeg -i c.h265 -vf showinfo -f null -
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ doc/encoders.texi        |  6 ++++++
+ libavcodec/qsvenc.c      | 47 +++++++++++++++++++++++++++++++++++++++++++++++
+ libavcodec/qsvenc.h      |  1 +
+ libavcodec/qsvenc_h264.c |  1 +
+ libavcodec/qsvenc_hevc.c |  1 +
+ 5 files changed, 56 insertions(+)
+
+diff --git a/doc/encoders.texi b/doc/encoders.texi
+index b02737b..6e9eaa3 100644
+--- a/doc/encoders.texi
++++ b/doc/encoders.texi
+@@ -3566,6 +3566,9 @@ skip_frame metadata indicates the number of missed frames before the current
+ frame.
+ @end table
+ 
++@item udu_sei @var{boolean}
++Import user data unregistered SEI if available into output. Default is 0 (off).
++
+ @end table
+ 
+ @subsection HEVC Options
+@@ -3771,6 +3774,9 @@ skip_frame metadata indicates the number of missed frames before the current
+ frame.
+ @end table
+ 
++@item udu_sei @var{boolean}
++Import user data unregistered SEI if available into output. Default is 0 (off).
++
+ @end table
+ 
+ @subsection MPEG2 Options
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index fc64a08..9e88fb5 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -2051,6 +2051,49 @@ static void set_skip_frame_encode_ctrl(AVCodecContext *avctx, const AVFrame *fra
+     return;
+ }
+ 
++static int set_udu_encode_ctrl(AVCodecContext *avctx,  QSVEncContext *q,
++                               const AVFrame *frame, mfxEncodeCtrl *enc_ctrl)
++{
++    if (!frame || !q->udu_sei)
++        return 0;
++
++    for (int i = 0; i < frame->nb_side_data && enc_ctrl->NumPayload < QSV_MAX_ENC_PAYLOAD; i++) {
++        AVFrameSideData *sd = NULL;
++        mfxPayload *payload = NULL;
++        mfxU8* sei_data;
++        int j;
++
++        sd = frame->side_data[i];
++        if (sd->type != AV_FRAME_DATA_SEI_UNREGISTERED)
++            continue;
++
++        /* SEI type: 1 byte, SEI size: sd->size / 255 + 1 bytes, SEI data: sd->size bytes */
++        payload = av_malloc(sizeof(*payload) + sd->size / 255 + 2 + sd->size);
++        if (!payload)
++            return AVERROR(ENOMEM);
++
++        memset(payload, 0, sizeof(*payload));
++        sei_data = (mfxU8 *)(payload + 1);
++        // SEI header
++        sei_data[0] = 5;
++        for (j = 0; j < sd->size / 255; j++)
++            sei_data[j + 1] = 0xff;
++        sei_data[j + 1] = sd->size % 255;
++        // SEI data
++        memcpy(&sei_data[sd->size / 255 + 2], sd->data, sd->size);
++
++        payload->BufSize = sd->size + sd->size / 255 + 2;
++        payload->NumBit = payload->BufSize * 8;
++        payload->Type = 5;
++        payload->Data = sei_data;
++
++        enc_ctrl->Payload[enc_ctrl->NumPayload] = payload;
++        enc_ctrl->NumPayload++;
++    }
++
++    return 0;
++}
++
+ static int update_qp(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     int updated = 0, new_qp = 0;
+@@ -2369,6 +2412,10 @@ static int encode_frame(AVCodecContext *avctx, QSVEncContext *q,
+         ret = set_roi_encode_ctrl(avctx, frame, enc_ctrl);
+         if (ret < 0)
+             goto free;
++
++        ret = set_udu_encode_ctrl(avctx, q, frame, enc_ctrl);
++        if (ret < 0)
++            goto free;
+     }
+     if ((avctx->codec_id == AV_CODEC_ID_H264 ||
+          avctx->codec_id == AV_CODEC_ID_H265) &&
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 4a6fa2c..5b66d31 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -255,6 +255,7 @@ typedef struct QSVEncContext {
+     int transform_skip;
+ 
+     int a53_cc;
++    int udu_sei;
+ 
+ #if QSV_HAVE_MF
+     int mfmode;
+diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
+index 071a9a7..31de8d7 100644
+--- a/libavcodec/qsvenc_h264.c
++++ b/libavcodec/qsvenc_h264.c
+@@ -166,6 +166,7 @@ static const AVOption options[] = {
+ #endif
+ 
+     { "repeat_pps", "repeat pps for every frame", OFFSET(qsv.repeat_pps), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
++    { "udu_sei",    "Use user data unregistered SEI if available", OFFSET(qsv.udu_sei), AV_OPT_TYPE_BOOL,   { .i64 = 0 }, 0, 1, VE },
+ 
+     { NULL },
+ };
+diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
+index 5e23ca9..5941c33 100644
+--- a/libavcodec/qsvenc_hevc.c
++++ b/libavcodec/qsvenc_hevc.c
+@@ -362,6 +362,7 @@ static const AVOption options[] = {
+     { "int_ref_cycle_size", "Number of frames in the intra refresh cycle",       OFFSET(qsv.int_ref_cycle_size),      AV_OPT_TYPE_INT, { .i64 = -1 },               -1, UINT16_MAX, VE },
+     { "int_ref_qp_delta",   "QP difference for the refresh MBs",                 OFFSET(qsv.int_ref_qp_delta),        AV_OPT_TYPE_INT, { .i64 = INT16_MIN }, INT16_MIN,  INT16_MAX, VE },
+     { "int_ref_cycle_dist",   "Distance between the beginnings of the intra-refresh cycles in frames",  OFFSET(qsv.int_ref_cycle_dist),      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, INT16_MAX, VE },
++    { "udu_sei",    "Use user data unregistered SEI if available", OFFSET(qsv.udu_sei), AV_OPT_TYPE_BOOL,   { .i64 = 0 }, 0, 1, VE },
+ 
+     { NULL },
+ };
+-- 
+1.8.3.1
+

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`FFMPEG_VER',`d79c240')
+DECLARE(`FFMPEG_VER',`n6.0')
 dnl Using github mirror to avoid pulling from different locations which minimizes
 dnl dnl impact on the CI in case of outages.
 DECLARE(`FFMPEG_REPO_URL',https://github.com/FFmpeg/FFmpeg.git)


### PR DESCRIPTION
Issue: VSMGWL-57980, VSMGWL-58092, VIZ-17730

This change adds custom patches over ffmpeg n6.0 to support custom SEI messages defined for ICS3A. Unfortunately media-driver currently has no guarantee whether any SEI messages (in terms of the message size) will be supported. Current driver does not take SEI message size into account and required space comes from other sources such as bitstream allocation alignment. Which gives a risk that encoder might return an error on certain SEI message sizes. On ICS3A we currently use very short SEI messages which has 86 bytes data plus SEI message headers, altogether under 128 bytes which is pretty small and somewhat reduces the risk, but does not eliminate it completely. This risk is the reason these patches can not be sent to ffmpeg upstream.