### PR TITLE
ics3a/encoder: use libvhal display protocol structures in buffer creation

### DIFF
--- a/sources/encoder/server/display_common.h
+++ b/sources/encoder/server/display_common.h
@@ -20,19 +20,10 @@
 #include <stdint.h>
 #include "api/irrv.h"
 
-typedef struct native_handle
-{
-    int version;        /* sizeof(native_handle_t) */
-    int numFds;         /* number of file-descriptors at &data[0] */
-    int numInts;        /* number of ints at &data[numFds] */
-    int data[0];        /* numFds + numInts ints */
-} native_handle_t;
-
-typedef native_handle_t* buffer_handle_t;
-
 #define MAX_HANDLE_COUNT 4
 typedef struct _disp_res {
-    buffer_handle_t local_handle;
+    vhal::client::buffer_handle_t local_handle;
+
     int             width;
     int             height;
     int             drm_format;
@@ -46,7 +37,7 @@ typedef struct _disp_res {
     uint32_t        fb_ids[MAX_HANDLE_COUNT];
 
     irr_surface_t*  surface;
-    
+
     bool is_reged;
 } disp_res_t;
 

--- a/sources/encoder/server/display_renderer.h
+++ b/sources/encoder/server/display_renderer.h
@@ -35,12 +35,11 @@ class DisplayRenderer {
 public :
     virtual ~DisplayRenderer()
     {
-        
     }
     virtual bool init(char *name, encoder_info_t *info)=0;
     virtual void deinit()=0;
 
-    virtual disp_res_t* createDispRes(buffer_handle_t handle, int format, int width, int height, int stride)=0;
+    virtual disp_res_t* createDispRes(vhal::client::cros_gralloc_handle_t handle)=0;
     virtual void destroyDispRes(disp_res_t* res)=0;
 
     virtual void drawDispRes(disp_res_t* res, int client_id, int client_count, std::unique_ptr<vhal::client::display_control_t> ctrl)=0;

--- a/sources/encoder/server/display_server_vhal.cpp
+++ b/sources/encoder/server/display_server_vhal.cpp
@@ -213,8 +213,7 @@ void DisplayServerVHAL::deinit()
 void DisplayServerVHAL::CreateBuffer(cros_gralloc_handle_t handle)
 {
     // Create DispRes
-    disp_res_t* dispRes = m_renderer->createDispRes((::buffer_handle_t)handle, handle->format, handle->width,
-                    handle->height, handle->height);
+    disp_res_t* dispRes = m_renderer->createDispRes(handle);
 
     auto ite = m_dispReses.find(handle);
     if (ite != m_dispReses.end())

--- a/sources/encoder/server/display_video_renderer.h
+++ b/sources/encoder/server/display_video_renderer.h
@@ -39,7 +39,7 @@ public :
     virtual bool init(char *name, encoder_info_t *info);
     virtual void deinit();
 
-    virtual disp_res_t* createDispRes(buffer_handle_t handle, int format, int width, int height, int stride);
+    virtual disp_res_t* createDispRes(vhal::client::cros_gralloc_handle_t);
     virtual void destroyDispRes(disp_res_t* res);
 
     virtual void drawDispRes(disp_res_t* res, int client_id, int client_count, std::unique_ptr<vhal::client::display_control_t> ctrl);


### PR DESCRIPTION
- Use cros_gralloc_handle_t structure (from libvhal/ display-protocol.h) directly in the function to create new buffers (DisplayVideoRenderer::createDispRes)

- This allows using  well-defined fields instead of indexing into an abstract memory buffer

- Use definition of native_handle_t, buffer_handle_t from display-protocol.h (and avoid local redefinition)