### PR TITLE
ics3a/encoder: Configure Tiling as per AIC specification

### DIFF
--- a/sources/encoder/server/display_common.h
+++ b/sources/encoder/server/display_common.h
@@ -32,6 +32,7 @@ typedef struct _disp_res {
     int             strides[MAX_HANDLE_COUNT];
     int             offsets[MAX_HANDLE_COUNT];
     unsigned int    seq_no;
+    uint64_t        format_modifiers[MAX_HANDLE_COUNT];
 
     uint32_t        gem_handles[MAX_HANDLE_COUNT];
     uint32_t        fb_ids[MAX_HANDLE_COUNT];

--- a/sources/encoder/server/display_video_renderer.cpp
+++ b/sources/encoder/server/display_video_renderer.cpp
@@ -117,8 +117,9 @@ disp_res_t* DisplayVideoRenderer::createDispRes(vhal::client::cros_gralloc_handl
             res->prime_fds[i]   = handle->fds[i];
             res->strides[i]     = handle->strides[i];
             res->offsets[i]     = handle->offsets[i];
+            res->format_modifiers[i] =
+                ((uint64_t)handle->format_modifiers[2*i]) | ((uint64_t)handle->format_modifiers[2*i + 1]);
         }
-
 
         SOCK_LOG(("%s:%d : create disp res for : \n", __func__, __LINE__));
         SOCK_LOG(("%s:%d : width = %d, height=%d, drm_format = 0x%x, android_format=%d, seq_no = %u\n", __func__, __LINE__,
@@ -147,6 +148,7 @@ disp_res_t* DisplayVideoRenderer::createDispRes(vhal::client::cros_gralloc_handl
             info.stride[i]   = res->strides[i];
             info.offset[i]   = res->offsets[i];
             info.fd[i]      = res->prime_fds[i];
+            info.format_modifier[i] = res->format_modifiers[i];
         }
         info.data_size  = 0;
         info.pdata      = NULL;

--- a/sources/encoder/shared/api/irrv.h
+++ b/sources/encoder/shared/api/irrv.h
@@ -106,6 +106,7 @@ typedef  struct _irr_surface_info {
     int stride[MAX_PLANE_NUM];
     int offset[MAX_PLANE_NUM];
     int fd[MAX_PLANE_NUM];                     ///< This is prime id, for example, it maybe got from vhal via sockets.
+    uint64_t format_modifier[MAX_PLANE_NUM];
     int data_size;
 
     unsigned char*  pdata;                ///< This is buff for store the data.

--- a/sources/encoder/shared/encoder.cpp
+++ b/sources/encoder/shared/encoder.cpp
@@ -530,6 +530,9 @@ static irr_surface_t* create_surface_from_fd(irr_surface_info_t* surface_info)
     va_attrib_extbuf.flags = VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME;
     va_attrib_extbuf.private_data = NULL;
 
+    if (surface_info->format_modifier[0] != 0)
+        va_attrib_extbuf.flags |= VA_SURFACE_EXTBUF_DESC_ENABLE_TILING;
+
     switch (surface_info->format) {
     case DRM_FORMAT_ABGR8888:
     case DRM_FORMAT_XBGR8888:
@@ -540,7 +543,6 @@ static irr_surface_t* create_surface_from_fd(irr_surface_info_t* surface_info)
         break;
     case DRM_FORMAT_NV12:
         va_attrib_extbuf.pixel_format = VA_FOURCC_NV12;
-        va_attrib_extbuf.flags |= VA_SURFACE_EXTBUF_DESC_ENABLE_TILING;
         va_attrib_extbuf.num_planes = 2;
         va_attrib_extbuf.pitches[1] = surface_info->stride[1];
         va_attrib_extbuf.offsets[1] = surface_info->offset[1];


### PR DESCRIPTION
Issue: VSMGWL-62308

- Tiled surfaces from AiC are observed to show better performance in terms of density for the Cloud Gaming Solution
- This change will allow for ICR to support tiled input surfaces in addition to the usual non-tiled surfaces, as per what AiC specifies in the "format_modifiers" field of the Display protocol for buffer creation.

Required-for: https://github.com/projectceladon/minigbm/pull/60