### PR TITLE
Support TCAE for AV1 encoding

### DIFF
--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout n6.0
+  git checkout 57afccc
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -219,7 +219,7 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout n6.0
+  git checkout 57afccc
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/sources/encoder/shared/CTransCoder.cpp
+++ b/sources/encoder/shared/CTransCoder.cpp
@@ -1185,13 +1185,13 @@ void CTransCoder::dynamicSetEncParameters(CEncoder *pEnc, AVFrame *pFrame, AVFra
     }
 
     if(m_setBitrate) {
-        m_Log->Info("set dynamic bitrate at framenum=%d, bitrate=%d\n", curEncFrames, m_bitrate);
+        m_Log->Debug("set dynamic bitrate at framenum=%d, bitrate=%d\n", curEncFrames, m_bitrate);
         ((CFFEncoder*)pEnc)->setBitrate(m_bitrate);
         m_setBitrate = 0;
     }
 
     if (m_setMaxBitrate) {
-        m_Log->Info("set dynamic max bitrate at framenum=%d, max_bitrate=%d\n", curEncFrames, m_maxBitrate);
+        m_Log->Debug("set dynamic max bitrate at framenum=%d, max_bitrate=%d\n", curEncFrames, m_maxBitrate);
         ((CFFEncoder*)pEnc)->setMaxBitrate(m_maxBitrate);
         m_setMaxBitrate = 0;
     }

--- a/sources/encoder/shared/tcae/enc_frame_settings_predictor.cpp
+++ b/sources/encoder/shared/tcae/enc_frame_settings_predictor.cpp
@@ -24,13 +24,13 @@ PredictorTcaeImpl::PredictorTcaeImpl() :
     m_features(),
     m_initialTargetDelayInMs(),
     m_maxSequentialDropsCount(),
-    m_minDropFramesDist(),
     m_maxFrameSizeInBytes(),
+    m_minDropFramesDist(),
+    m_framesSinceLastDrop(),
     m_idrRequested(),
     m_frameDropsCount(),
     m_lastKnownDelayInMs(),
     m_lastTransmittedSize(),
-    m_framesSinceLastDrop(),
     m_pLogger()
 {
 }

--- a/sources/encoder/shared/tcae/net_pred.cpp
+++ b/sources/encoder/shared/tcae/net_pred.cpp
@@ -31,8 +31,8 @@ NetPred::NetPred():
     m_exceptionThreshold(1.0),
     m_reverseBandWidth(1.0),
     m_propagotionDelay(0.0),
-    m_effectiveDataLen(2),
     m_effectiveSizeThreshold(1.0),
+    m_effectiveDataLen(2),
 #ifdef _DEBUG
     m_dumpflag(true),
 #else

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`FFMPEG_VER',`n6.0')
+DECLARE(`FFMPEG_VER',`57afccc') dnl tracking master
 dnl Using github mirror to avoid pulling from different locations which minimizes
 dnl dnl impact on the CI in case of outages.
 DECLARE(`FFMPEG_REPO_URL',https://github.com/FFmpeg/FFmpeg.git)


### PR DESCRIPTION
- Capture ffmpeg patch for av1 low delay BRC (TCBRC). This will
  match av1 to AVC and HEVC in terms of TCAE/TC-BRC implementation

  [55c8c94](https://github.com/FFmpeg/FFmpeg/commit/55c8c94) libavcodec/qsvenc: Add dynamic setting support of low_delay_brc to av1_qsv

- Move to 57afccc to pick up additional patch that was necessary
  for Media Delivery.

  [57afccc ](https://github.com/FFmpeg/FFmpeg/commit/57afccc) lavfi/vf_vpp_qsv: set the right timestamp for AVERROR_EOF