### PR TITLE
ics3a/encoder: Avoid needless revert to default bitrates

### DIFF
--- a/sources/encoder/shared/encoder.cpp
+++ b/sources/encoder/shared/encoder.cpp
@@ -412,7 +412,7 @@ int irr_check_rate_ctrl_options (encoder_info_t *encoder_info) {
         }
 
         if (!strcasecmp(rate_contrl_param.ratectrl, "VBR") || !strcasecmp(rate_contrl_param.ratectrl, "QVBR")) {
-            if (_bitrate >= _maxrate) {
+            if (_bitrate > _maxrate) {
                 e_Log->Error("%s : %d : bitrate must be smaller to maxrate in %s mode!\n", __func__, __LINE__, rate_contrl_param.ratectrl);
                 return AVERROR(EINVAL);
             }


### PR DESCRIPTION
Issue: VSMGWL-64696

- If cmd line parameters set -b option equal to '-maxrate', the option validator considers this an error and reverts to using default settings.

- This change limits reverting to defaults only if the target bitrate is specified to be in excess of the max rate.