### PR TITLE
ics3a/encoder: update media stack to media 23.2.1 release (devel-647)

### DIFF
--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -90,10 +90,10 @@ RUN apt-get update && \
     wget && \
   rm -rf /var/lib/apt/lists/*
 # build media driver
-ARG MEDIA_DRIVER_REPO=https://github.com/intel/media-driver/archive/intel-media-23.1.4.tar.gz
+ARG MEDIA_DRIVER_REPO=https://github.com/intel/media-driver/archive/intel-media-23.2.1.tar.gz
 RUN cd /opt/build && \
   wget -O - ${MEDIA_DRIVER_REPO} | tar xz
-RUN cd /opt/build/media-driver-intel-media-23.1.4 && mkdir build && cd build && \
+RUN cd /opt/build/media-driver-intel-media-23.2.1 && mkdir build && cd build && \
   cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=/opt \
@@ -117,9 +117,9 @@ RUN apt-get update && \
     wget && \
   rm -rf /var/lib/apt/lists/*
 # build libva2-utils
-ARG LIBVA2_UTILS_REPO=https://github.com/intel/libva-utils/archive/2.17.1.tar.gz
+ARG LIBVA2_UTILS_REPO=https://github.com/intel/libva-utils/archive/2.18.1.tar.gz
 RUN cd /opt/build && wget -O - ${LIBVA2_UTILS_REPO} | tar xz
-RUN cd /opt/build/libva-utils-2.17.1 && \
+RUN cd /opt/build/libva-utils-2.18.1 && \
   ./autogen.sh --prefix=/opt --libdir=/opt/lib && \
   make -j$(nproc) && \
   make install DESTDIR=/opt/dist && \
@@ -137,11 +137,11 @@ RUN apt-get update && \
     cmake \
     dh-autoreconf && \
   rm -rf /var/lib/apt/lists/*
-ARG ONEVPL_REPO=https://github.com/oneapi-src/oneVPL/archive/v2023.1.3.tar.gz
+ARG ONEVPL_REPO=https://github.com/oneapi-src/oneVPL/archive/v2023.2.1.tar.gz
 RUN cd /opt/build && \
   wget -O - ${ONEVPL_REPO} | tar xz
 # build oneVPL
-RUN cd /opt/build/oneVPL-2023.1.3 && \
+RUN cd /opt/build/oneVPL-2023.2.1 && \
     mkdir build && cd build && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -162,11 +162,11 @@ RUN apt-get update && \
     cmake \
     make && \
   rm -rf /var/lib/apt/lists/*
-ARG ONEVPLGPU_REPO=https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-23.1.4.tar.gz
+ARG ONEVPLGPU_REPO=https://github.com/oneapi-src/oneVPL-intel-gpu/archive/intel-onevpl-23.2.1.tar.gz
 RUN cd /opt/build && \
   wget -O - ${ONEVPLGPU_REPO} | tar xz
 # build oneVPL gpu
-RUN cd /opt/build/oneVPL-intel-gpu-intel-onevpl-23.1.4 && \
+RUN cd /opt/build/oneVPL-intel-gpu-intel-onevpl-23.2.1 && \
     mkdir -p _build && cd _build && \
     cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -188,10 +188,10 @@ RUN apt-get update && \
     wget && \
   rm -rf /var/lib/apt/lists/*
 # build media sdk
-ARG MSDK_REPO=https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-23.1.4.tar.gz
+ARG MSDK_REPO=https://github.com/Intel-Media-SDK/MediaSDK/archive/intel-mediasdk-23.2.1.tar.gz
 RUN cd /opt/build && \
   wget -O - ${MSDK_REPO} | tar xz
-RUN cd /opt/build/MediaSDK-intel-mediasdk-23.1.4 && \
+RUN cd /opt/build/MediaSDK-intel-mediasdk-23.2.1 && \
   mkdir -p build && cd build && \
   cmake \
     -DCMAKE_BUILD_TYPE=Release \

--- a/templates/m4docker/components/libva2-utils.m4
+++ b/templates/m4docker/components/libva2-utils.m4
@@ -32,7 +32,7 @@ include(begin.m4)
 
 include(libva2.m4)
 
-DECLARE(`LIBVA2_UTILS_VER',2.17.1)
+DECLARE(`LIBVA2_UTILS_VER',2.18.1)
 
 ifelse(OS_NAME,ubuntu,`dnl
 define(`LIBVA2_UTILS_BUILD_DEPS',`automake ca-certificates gcc g++ libdrm-dev libtool make pkg-config wget')

--- a/templates/m4docker/components/media-driver.m4
+++ b/templates/m4docker/components/media-driver.m4
@@ -37,7 +37,7 @@ include(cmake.m4)
 include(libva2.m4)
 include(gmmlib.m4)
 
-DECLARE(`MEDIA_DRIVER_VER',intel-media-23.1.4)
+DECLARE(`MEDIA_DRIVER_VER',intel-media-23.2.1)
 DECLARE(`MEDIA_DRIVER_SRC_REPO',https://github.com/intel/media-driver/archive/MEDIA_DRIVER_VER.tar.gz)
 DECLARE(`ENABLE_PRODUCTION_KMD',OFF)
 

--- a/templates/m4docker/components/msdk.m4
+++ b/templates/m4docker/components/msdk.m4
@@ -36,7 +36,7 @@ include(centos-scl.m4)
 include(cmake.m4)
 include(libva2.m4)
 
-DECLARE(`MSDK_VER',intel-mediasdk-23.1.4)
+DECLARE(`MSDK_VER',intel-mediasdk-23.2.1)
 DECLARE(`MSDK_SRC_REPO',https://github.com/Intel-Media-SDK/MediaSDK/archive/MSDK_VER.tar.gz)
 DECLARE(`MSDK_BUILD_SAMPLES',OFF)
 

--- a/templates/m4docker/components/onevpl-gpu.m4
+++ b/templates/m4docker/components/onevpl-gpu.m4
@@ -32,7 +32,7 @@ include(begin.m4)
 include(libva2.m4)
 include(onevpl.m4)
 
-DECLARE(`ONEVPL_GPU_VER',23.1.4)
+DECLARE(`ONEVPL_GPU_VER',23.2.1)
 DECLARE(`MFX_ENABLE_AENC',OFF)
 
 ifelse(OS_NAME,ubuntu,`

--- a/templates/m4docker/components/onevpl.m4
+++ b/templates/m4docker/components/onevpl.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`ONEVPL_VER',2023.1.3)
+DECLARE(`ONEVPL_VER',2023.2.1)
 
 ifelse(OS_NAME,ubuntu,dnl
 `define(`ONEVPL_BUILD_DEPS',`automake ca-certificates gcc g++ make pkg-config wget cmake dh-autoreconf')'


### PR DESCRIPTION
Included versions:
* libva: 2.18.0 (same as before)
* libva-utils: 2.18.1 (was 2.17.1)
* gmmlib: 22.3.5 (same as before)
* media-driver: 23.2.1 (was 23.1.4)
* onevpl-gpu: 23.2.1 (was 23.1.4)
* mediasdk: 23.2.1 (was 23.1.4)
* oneVPL: v2023.2.1 (was v2023.1.3)