### PR TITLE
Simplify Encode fps control logic and fix race conditions

### DIFF
--- a/sources/encoder/server/display_renderer.h
+++ b/sources/encoder/server/display_renderer.h
@@ -43,7 +43,6 @@ public :
     virtual void destroyDispRes(disp_res_t* res)=0;
 
     virtual void drawDispRes(disp_res_t* res, int client_id, int client_count, std::unique_ptr<vhal::client::display_control_t> ctrl)=0;
-    virtual void drawBlankRes(int client_id, int client_count)=0;
 
     virtual void setVideoMode(int mode_info)=0;
 

--- a/sources/encoder/server/display_server_vhal.cpp
+++ b/sources/encoder/server/display_server_vhal.cpp
@@ -143,13 +143,6 @@ bool DisplayServerVHAL::init(char *id, encoder_info_t *info)
         }
     }
 
-
-    if (m_renderer)
-    {
-        sock_log("%s:%d : drawBlankRes!\n", __func__, __LINE__);
-        m_renderer->drawBlankRes(0, 0);
-    }
-
     m_vhalReceiver->start();
 
     // create private fifo

--- a/sources/encoder/server/display_video_renderer.cpp
+++ b/sources/encoder/server/display_video_renderer.cpp
@@ -37,8 +37,6 @@ DisplayVideoRenderer::DisplayVideoRenderer()
     m_width         = ENCODER_RESOLUTION_WIDTH_DEFAULT;
     m_height        = ENCODER_RESOLUTION_HEIGHT_DEFAULT;
     m_frameIdx      = 0;
-
-    m_blankSurface  = nullptr;
     m_curSurface    = nullptr;
 }
 
@@ -47,12 +45,6 @@ DisplayVideoRenderer::~DisplayVideoRenderer()
     SOCK_LOG_INIT();
 
     flushDelayDelRes();
-
-    if (m_blankSurface) {
-        m_blankSurface->ref_count = 1;
-        irr_encoder_unref_surface(m_blankSurface);
-        m_blankSurface = nullptr;
-    }
 }
 
 bool DisplayVideoRenderer::init(char *name, encoder_info_t *info)
@@ -190,26 +182,6 @@ void DisplayVideoRenderer::drawDispRes(disp_res_t* disp_res, int client_id, int 
         surface = disp_res->surface;
     }
 
-    if(!surface) {
-        // Use blank surface if disp_res is null, or disp_res->surface is null.
-        if(!m_blankSurface) {
-            irr_surface_info_t info;
-            memset(&info, 0, sizeof(info));
-
-            info.type       = FD;
-            info.width      = m_width;
-            info.height     = m_height;
-            for (int i = 0; i < MAX_PLANE_NUM; i++) {
-                info.fd[i]  = -1;
-            }
-            m_blankSurface = irr_encoder_create_blank_surface(&info);
-            if(!m_blankSurface) {
-                SOCK_LOG(("%s : %d : irr_encoder_create_blank_surface failed\n", __func__, __LINE__));
-            }
-        }
-        surface = m_blankSurface;
-    }
-
     if(surface) {
         int ret = 0;
         ATRACE_NAME("irr_encoder_write");
@@ -240,13 +212,6 @@ void DisplayVideoRenderer::drawDispRes(disp_res_t* disp_res, int client_id, int 
 
         m_curSurface = surface;
     }
-}
-
-void DisplayVideoRenderer::drawBlankRes(int client_id, int client_count)
-{
-
-    SOCK_LOG(("%s:%d : client_id = %d, client_count = %d\n", __func__, __LINE__, client_id, client_count));
-    drawDispRes(nullptr, client_id, client_count, nullptr);
 }
 
 void DisplayVideoRenderer::beginFrame()

--- a/sources/encoder/server/display_video_renderer.h
+++ b/sources/encoder/server/display_video_renderer.h
@@ -43,7 +43,6 @@ public :
     virtual void destroyDispRes(disp_res_t* res);
 
     virtual void drawDispRes(disp_res_t* res, int client_id, int client_count, std::unique_ptr<vhal::client::display_control_t> ctrl);
-    virtual void drawBlankRes(int client_id, int client_count);
 
     virtual void beginFrame();
     virtual void endFrame();
@@ -67,7 +66,6 @@ private :
     uint64_t m_frameIdx;
     std::list<std::pair<uint64_t, disp_res_t*>>    m_deletedReses;
 
-    irr_surface_t*    m_blankSurface;
     irr_surface_t*    m_curSurface;
 
     encoder_info_t m_currentInfo = {};

--- a/sources/encoder/shared/CDemux.h
+++ b/sources/encoder/shared/CDemux.h
@@ -30,7 +30,7 @@ struct IrrPacket {
 
 class CDemux {
 public:
-    CDemux() :m_isVASurfaceID(false), m_bRenderFpsEnc(true), m_MinFpsEnc(3), m_isQSVSurfaceID(false), m_bFirstStartEncoding(false), m_iFirstStartEncodingCnt(0){}
+    CDemux() :m_isVASurfaceID(false), m_bRenderFpsEnc(true), m_MinFpsEnc(0), m_isQSVSurfaceID(false), m_bFirstStartEncoding(false){}
     virtual ~CDemux() {}
     /**
      * @param format,pDict Extra informations for demux
@@ -65,7 +65,7 @@ public:
     virtual bool getRenderFpsEncFlag() { return m_bRenderFpsEnc; }
     virtual void setMinFpsEnc(int iMinFpsEnc) { m_MinFpsEnc = iMinFpsEnc; }
     virtual int  getMinFpsEnc() { return m_MinFpsEnc; }
-    virtual void  setFirstStartEncoding(bool bFirstStartEncoding) { m_bFirstStartEncoding = bFirstStartEncoding; }
+    virtual void setFirstStartEncoding(bool bFirstStartEncoding) { m_bFirstStartEncoding = bFirstStartEncoding; }
 
     virtual void stop() { }
 private:
@@ -76,7 +76,6 @@ private:
 
 protected:
     bool m_bFirstStartEncoding;
-    int  m_iFirstStartEncodingCnt;
 };
 
 #endif /* CDEMUX_H */

--- a/sources/encoder/shared/CDemux.h
+++ b/sources/encoder/shared/CDemux.h
@@ -30,7 +30,7 @@ struct IrrPacket {
 
 class CDemux {
 public:
-    CDemux() :m_isVASurfaceID(false), m_bLatencyOpt(true), m_bRenderFpsEnc(true), m_MinFpsEnc(3), m_isQSVSurfaceID(false), m_bFirstStartEncoding(false), m_iFirstStartEncodingCnt(0){}
+    CDemux() :m_isVASurfaceID(false), m_bRenderFpsEnc(true), m_MinFpsEnc(3), m_isQSVSurfaceID(false), m_bFirstStartEncoding(false), m_iFirstStartEncodingCnt(0){}
     virtual ~CDemux() {}
     /**
      * @param format,pDict Extra informations for demux
@@ -61,8 +61,6 @@ public:
     virtual bool getVASurfaceFlag() { return m_isVASurfaceID; }
     virtual void setQSVSurfaceFlag(bool bQSVSurfaceID) { m_isQSVSurfaceID = bQSVSurfaceID; }
     virtual bool getQSVSurfaceFlag() { return m_isQSVSurfaceID; }
-    virtual void setLatencyOptFlag(bool bLatencyOpt) { m_bLatencyOpt = bLatencyOpt; }
-    virtual bool getLatencyOptFlag() { return m_bLatencyOpt; }
     virtual void setRenderFpsEncFlag(bool bRenderFpsEnc) { m_bRenderFpsEnc = bRenderFpsEnc; }
     virtual bool getRenderFpsEncFlag() { return m_bRenderFpsEnc; }
     virtual void setMinFpsEnc(int iMinFpsEnc) { m_MinFpsEnc = iMinFpsEnc; }
@@ -72,7 +70,6 @@ public:
     virtual void stop() { }
 private:
     bool m_isVASurfaceID;
-    bool m_bLatencyOpt;
     bool m_bRenderFpsEnc;
     int  m_MinFpsEnc;
     bool m_isQSVSurfaceID;

--- a/sources/encoder/shared/CIrrVideoDemux.cpp
+++ b/sources/encoder/shared/CIrrVideoDemux.cpp
@@ -276,7 +276,7 @@ int CIrrVideoDemux::sendPacket(IrrPacket *pkt) {
 
     m_nLastFrameTs = curr_mcs;
 
-    lock.unlock();
+    bool notify = true;
     if (!getRenderFpsEncFlag()) {
 
         // For constant fps app,  the interval between post is almost constant.
@@ -284,21 +284,17 @@ int CIrrVideoDemux::sendPacket(IrrPacket *pkt) {
         // So we can't strictly compare it with frame time,  add 1ms time range here for workaround.
         // The better way is to record frame timestamp in post and pass the value to here.
         if (diff1_mcs >= (frame_mcs - 1000)) {
-            bool notify = true;
 
             if ((diff2_mcs > 0) && (diff2_mcs < 3000)) {
                 notify = false;
             }
-
-            if (notify) {
-                m_cv.notify_one();
-            }
         }
     }
-    else {
+
+    lock.unlock();
+    if (notify) {
         m_cv.notify_one();
     }
-
     return 0;
 }
 

--- a/sources/encoder/shared/CIrrVideoDemux.h
+++ b/sources/encoder/shared/CIrrVideoDemux.h
@@ -32,6 +32,8 @@ extern "C" {
 #include <map>
 #include <list>
 
+#define NEW_FRAME_WAIT_TIMEOUT_MCS 1000000 //1s
+
 class CIrrVideoDemux : public CDemux {
 public:
     CIrrVideoDemux(int w, int h, int format, float framerate, IrrPacket* pkt);
@@ -48,7 +50,7 @@ public:
 
     void updateDynamicChangedFramerate(int framerate);
 
-    void stop() {m_stop = true; }
+    void stop();
 
 private:
     std::mutex                  m_Lock;
@@ -56,9 +58,7 @@ private:
     CStreamInfo                 m_Info;
     IrrPacket                   m_Pkt;
     int64_t                     m_nPrevPts;
-    int64_t                     m_nLastFrameTs;
-    int64_t                     m_nLastEncodeFrameTs;
-    int64_t                     m_nLeftMcs;
+    int64_t                     m_totalWaitMcs;
     IORuntimeWriter::Ptr        mRuntimeWriter;
 
     ///< pkt_round: profile one round, mostly it is 1/fps, such as 40ms for 25fps
@@ -68,8 +68,8 @@ private:
     int m_nLatencyStats;
     bool m_bStartLatency;
 
-    uint64_t m_timeoutCount;
     bool m_stop;
+    volatile bool m_notified;
 
     std::unique_ptr<CTransLog> m_logger;
 };

--- a/sources/encoder/shared/CIrrVideoDemux.h
+++ b/sources/encoder/shared/CIrrVideoDemux.h
@@ -51,11 +51,6 @@ public:
     void stop() {m_stop = true; }
 
 private:
-    enum eFRC{
-        eFRC_CONST = 0,
-        eFRC_VARI,
-        eFRC_NUM
-    };
     std::mutex                  m_Lock;
     std::condition_variable     m_cv;
     CStreamInfo                 m_Info;
@@ -64,7 +59,6 @@ private:
     int64_t                     m_nLastFrameTs;
     int64_t                     m_nLastEncodeFrameTs;
     int64_t                     m_nLeftMcs;
-    eFRC                        m_eFrc;         ///< Framerate Control
     IORuntimeWriter::Ptr        mRuntimeWriter;
 
     ///< pkt_round: profile one round, mostly it is 1/fps, such as 40ms for 25fps

--- a/sources/encoder/shared/CIrrVideoDemux.h
+++ b/sources/encoder/shared/CIrrVideoDemux.h
@@ -19,6 +19,8 @@
 
 #include <mutex>
 #include <condition_variable>
+#include "api/irrv.h"
+
 extern "C" {
 #include <libavutil/time.h>
 #include <libavutil/imgutils.h>
@@ -32,7 +34,7 @@ extern "C" {
 
 class CIrrVideoDemux : public CDemux {
 public:
-    CIrrVideoDemux(int w, int h, int format, float framerate);
+    CIrrVideoDemux(int w, int h, int format, float framerate, IrrPacket* pkt);
     ~CIrrVideoDemux();
 
     int getNumStreams();
@@ -57,7 +59,7 @@ private:
     std::mutex                  m_Lock;
     std::condition_variable     m_cv;
     CStreamInfo                 m_Info;
-    IrrPacket                    m_Pkt;
+    IrrPacket                   m_Pkt;
     int64_t                     m_nPrevPts;
     int64_t                     m_nLastFrameTs;
     int64_t                     m_nLastEncodeFrameTs;
@@ -74,6 +76,8 @@ private:
 
     uint64_t m_timeoutCount;
     bool m_stop;
+
+    std::unique_ptr<CTransLog> m_logger;
 };
 
 #endif /* CIRRVIDEODEMUX_H */

--- a/sources/encoder/shared/IrrStreamer.cpp
+++ b/sources/encoder/shared/IrrStreamer.cpp
@@ -1176,17 +1176,7 @@ int IrrStreamer::InitBlankFramePacket(IrrPacket& pkt)
 
     Debug("Initializing Blank surface\n");
 
-    irr_surface_info_t info;
-    memset(&info, 0, sizeof(info));
-
-    info.type       = FD;
-    info.width      = getWidth();
-    info.height     = getHeight();
-    for (int i = 0; i < MAX_PLANE_NUM; i++) {
-        info.fd[i]  = -1;
-    }
-
-    m_blankSurface = irr_encoder_create_blank_surface(&info);
+    m_blankSurface = irr_encoder_create_blank_surface(getWidth(), getHeight());
     if(!m_blankSurface) {
         Error("%s : %d : irr_encoder_create_blank_surface failed\n", __func__, __LINE__);
         return -1;

--- a/sources/encoder/shared/IrrStreamer.cpp
+++ b/sources/encoder/shared/IrrStreamer.cpp
@@ -220,13 +220,6 @@ int IrrStreamer::start(IrrStreamInfo *param) {
         } while (expar.size());
     }
 
-    if (param->latency_opt == 0) {
-        m_pDemux->setLatencyOptFlag(false);
-    }
-    else {
-        m_pDemux->setLatencyOptFlag(true);
-    }
-
     if (param->renderfps_enc == 0) {
         m_pDemux->setRenderFpsEncFlag(false);
     }
@@ -1146,25 +1139,3 @@ int IrrStreamer::getRenderFpsEncFlag(void) {
     return m_pTrans->getRenderFpsEncFlag();
 }
 
-void IrrStreamer::setLatencyOptFlag(bool bLatencyOpt) {
-    lock_guard<mutex> lock(m_Lock);
-
-    if (!m_pDemux) {
-        Error("%s : %d : m_pDemux is null!\n", __func__, __LINE__);
-        return;
-    }
-
-    m_pDemux->setLatencyOptFlag(bLatencyOpt);
-    return;
-}
-
-int IrrStreamer::getLatencyOptFlag(void) {
-    lock_guard<mutex> lock(m_Lock);
-
-    if (!m_pDemux) {
-        Error("%s : %d : m_pDemux is null!\n", __func__, __LINE__);
-        return AVERROR(EINVAL);
-    }
-
-    return m_pDemux->getLatencyOptFlag();
-}

--- a/sources/encoder/shared/IrrStreamer.h
+++ b/sources/encoder/shared/IrrStreamer.h
@@ -149,6 +149,14 @@ private:
     AVBufferRef   *m_hw_frames_ctx;
     bool           m_tcaeEnabled;
 
+    /// A blank surface is allocated and used to initialize CIrrVideoDemux::m_Pkt
+    /// This is required for the scenario where app flow calls CIrrVideoDemux::readPacket
+    /// before CIrrVideoDemux::sendPacket. A valid packet is required for the encoder
+    irr_surface_t* m_blankSurface = nullptr;
+
+    int InitBlankFramePacket(IrrPacket& pkt);
+    int DeinitBlankFramePacket();
+
 #ifdef FFMPEG_v42
     static AVBufferRef* m_BufAlloc(void *opaque, int size);
 #else

--- a/sources/encoder/shared/IrrStreamer.h
+++ b/sources/encoder/shared/IrrStreamer.h
@@ -124,15 +124,6 @@ public:
     */
     int getRenderFpsEncFlag(void);
 
-    void setLatencyOptFlag(bool bLatencyOpt);
-
-    /**
-    * get the encoder latency optimization flag
-    *
-    * @return minus mean that the call of the function fail, 1 mean that optimization flag is trun on, 0 mean turn off.
-    */
-    int getLatencyOptFlag(void);
-
 private:
     CIrrVideoDemux *m_pDemux;
     CTransCoder    *m_pTrans;

--- a/sources/encoder/shared/IrrStreamer.h
+++ b/sources/encoder/shared/IrrStreamer.h
@@ -48,6 +48,7 @@ public:
     int   start(IrrStreamInfo *param);
     void  stop();
     int   write(irr_surface_t* surface);
+    int   generate_packet(irr_surface_t* surface, IrrPacket& pkt);
     int   force_key_frame(int force_key_frame);
     int   set_qp(int qp);
     int   set_bitrate(int bitrate);

--- a/sources/encoder/shared/api/irrv-internal.h
+++ b/sources/encoder/shared/api/irrv-internal.h
@@ -152,18 +152,6 @@ void irr_encoder_set_skipframe(bool bSkipFrame);
 */
 int irr_encoder_get_skipframe(void);
 
-/*
-* @Desc set the encoder latency optimization flag.
-* @param bLatencyOpt is true mean that flag turn on, false mean turn off.
-*/
-void irr_encoder_set_latency_optflag(bool bLatencyOpt);
-
-/*
-* @Desc get the encoder latency optimization flag.
-* @return minus mean call the function fail, 1 mean that flag turn on, 0 mean turn off.
-*/
-int irr_encoder_get_latency_optflag(void);
-
 struct IrrStreamInfo {
     int pix_format;            ///< fmt
     /* Output-only parameters */
@@ -378,15 +366,6 @@ void irr_stream_set_encode_renderfps_flag(bool bRenderFpsEnc);
 * @Desc get encode by reder fps flag, minus mean call the function fail, 1 mean that flag turn on, 0 mean turn off.
 */
 int irr_stream_get_encode_renderfps_flag(void);
-
-
-void irr_stream_set_latency_optflag(bool bLatencyOpt);
-
-/*
-* @Desc get the encoder latency optimization flag.
-* @return minus mean call the function fail, 1 mean that flag turn on, 0 mean turn off.
-*/
-int irr_stream_get_latency_optflag(void);
 
 #ifdef __cplusplus
 }

--- a/sources/encoder/shared/api/irrv.h
+++ b/sources/encoder/shared/api/irrv.h
@@ -209,7 +209,7 @@ int irr_encoder_change_codec(AVCodecID codec_type);
  * @desc                        create the irr_surface according to the surface info
  */
 irr_surface_t* irr_encoder_create_surface(irr_surface_info_t* surface_info);
-irr_surface_t* irr_encoder_create_blank_surface(irr_surface_info_t* surface_info);
+irr_surface_t* irr_encoder_create_blank_surface(int width, int height);
 
 /**
  *

--- a/sources/encoder/shared/encoder.cpp
+++ b/sources/encoder/shared/encoder.cpp
@@ -1167,20 +1167,26 @@ irr_surface_t* irr_encoder_create_surface(irr_surface_info_t* surface_info)
     return surface;
 }
 
-irr_surface_t* irr_encoder_create_blank_surface(irr_surface_info_t* surface_info)
+irr_surface_t* irr_encoder_create_blank_surface(int width, int height)
 {
-    e_Log->Debug("%s : %d : surface_info = %p\n", __func__, __LINE__, surface_info);
+    e_Log->Debug("%s : %d : w = %d, h = %d\n", __func__, __LINE__, width, height);
 
-    if (!(surface_info->width > 0 && surface_info->height > 0)) {
+    if (width <= 0 || height <= 0) {
         e_Log->Error("%s: %d: invalid dimensions provided: w=%d, h=%d\n", __func__, __LINE__,
-                     surface_info->width, surface_info->height);
+                     width, height);
     }
 
-    if (surface_info->type != INTERNAL) {
-        e_Log->Error("%s: %d: invalid surface type %d provided\n", __func__, __LINE__, surface_info->type);
+    irr_surface_info_t info;
+    memset(&info, 0, sizeof(info));
+
+    info.type       = INTERNAL;
+    info.width      = width;
+    info.height     = height;
+    for (int i = 0; i < MAX_PLANE_NUM; i++) {
+        info.fd[i]  = -1;
     }
 
-    return irr_encoder_create_surface(surface_info);
+    return irr_encoder_create_surface(&info);
 }
 
 void irr_encoder_destroy_surface(irr_surface_t* surface)

--- a/sources/encoder/shared/encoder.cpp
+++ b/sources/encoder/shared/encoder.cpp
@@ -974,15 +974,6 @@ int irr_encoder_start(int id, encoder_info_t *encoder_info) {
                 e_Log->Info("%s : %d : SEI host timestamp info enabled.\n", __func__, __LINE__);
         }
 
-        if (encoder_info->latency_opt == 0) {
-            sock_log("Encoding latency optimization disabled.\n");
-            info.latency_opt = 0;
-        }
-        else {
-            sock_log("Encoding latency optimization enabled.\n");
-            info.latency_opt = 1;
-        }
-
         if (encoder_info->renderfps_enc == 0) {
             sock_log("Encoding by rendering fps disabled\n");
             info.renderfps_enc = 0;
@@ -1390,13 +1381,3 @@ int irr_encoder_get_skipframe(void) {
     return ret;
 }
 
-
-void irr_encoder_set_latency_optflag(bool bLatencyOpt) {
-    irr_stream_set_latency_optflag(bLatencyOpt);
-}
-
-int irr_encoder_get_latency_optflag(void) {
-    int ret = 0;
-    ret = irr_stream_get_latency_optflag();
-    return ret;
-}

--- a/sources/encoder/shared/stream.cpp
+++ b/sources/encoder/shared/stream.cpp
@@ -440,19 +440,3 @@ int irr_stream_get_encode_renderfps_flag(void) {
     return pStreamer->getRenderFpsEncFlag();
 }
 
-void irr_stream_set_latency_optflag(bool bLatencyOpt) {
-    IrrStreamer* pStreamer = IrrStreamer::get();
-    if (!pStreamer)
-        return;
-
-    pStreamer->setLatencyOptFlag(bLatencyOpt);
-}
-
-int irr_stream_get_latency_optflag(void) {
-    IrrStreamer* pStreamer = IrrStreamer::get();
-    if (!pStreamer)
-        return -EINVAL;
-
-    return pStreamer->getLatencyOptFlag();
-}
-


### PR DESCRIPTION
Issue: VSMGWL-62622

* Reorganize encode fps logic to simplified version supporting just 2 cases:
  * Follow Render fps (RenderFpsEnc=1)
  * Deliver fixed target encode fps (RenderFpsEnc=0)

* To accomplish above, SendPacket function always notifies ReadPacket on receiving a frame. 
   ReadPacket function delivers a frame to match a min target fps or just waits for notification by SendPacket.

* Prune redundant control knobs and variables

* Fix race condition where the Encode thread runs without a valid packet.  (The `readPacket` call runs without receiving any frames through `sendPacket` call). This is fixed by moving the blank frame packet logic into within the Demux class and invoking it prior to launching the Encode thread. This is necessary for the the revised FPS control logic to work correctly without run-run timing errors.

