### PR TITLE
docker/jstest: bump node to v18.x series and sync sources

### DIFF
--- a/docker/jstest/ubuntu22.04/Dockerfile
+++ b/docker/jstest/ubuntu22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
 ARG NODESOURCE_KEY_URL="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
 RUN local_key=/usr/share/keyrings/nodesource.gpg && \
   curl -s $NODESOURCE_KEY_URL | gpg --dearmor | tee $local_key >/dev/null && \
-  echo "deb [signed-by=$local_key] https://deb.nodesource.com/node_14.x jammy main" >> /etc/apt/sources.list && \
+  echo "deb [signed-by=$local_key] https://deb.nodesource.com/node_18.x jammy main" >> /etc/apt/sources.list && \
   apt-get update
 
 

--- a/sources/streamer/core/QoSMgt.cpp
+++ b/sources/streamer/core/QoSMgt.cpp
@@ -130,7 +130,7 @@ DWORD __stdcall ProcessQosThreadClient(LPVOID params)
             //std::cout << "Capture latency: " << pQosInfo->capturetime << " ms\n";
             //std::cout << "Encode latency:  " << pQosInfo->encodetime << " ms\n";
             //std::cout << "frame size:  " << pQosInfo->framesize << " ms\n";
-            //    std::cout << "Event: " << (cln_event_time2.tv_sec << "s "<<  cln_event_time2.tv_usec<< " us\n";
+            //    std::cout << "Event: " << (cln_event_time2.tv_sec << "s " <<  cln_event_time2.tv_usec << " us\n";
             //printf("YYYYYYYYYYYYYYYY report mouse event=%lds, %ldus\r\n", pQosInfo->eventime.tv_sec, pQosInfo->eventime.tv_usec);
             QosInfoFull   qosInfoFull;
             if (!qosclientQueue.empty()) {
@@ -287,7 +287,7 @@ restart:
         //std::cout << "Capture latency: " << pQosInfo->capturetime << " ms\n";
         //std::cout << "Encode latency:  " << pQosInfo->encodetime << " ms\n";
         //std::cout << "frame size:  " << pQosInfo->framesize << " ms\n";
-        //    std::cout << "Event: " << (cln_event_time2.tv_sec << "s "<<  cln_event_time2.tv_usec<< " us\n";
+        //    std::cout << "Event: " << (cln_event_time2.tv_sec << "s "<<  cln_event_time2.tv_usec << " us\n";
         //printf("YYYYYYYYYYYYYYYY report mouse event=%lds, %ldus\r\n", pQosInfo->eventime.tv_sec, pQosInfo->eventime.tv_usec);
         QosInfoFull   qosInfoFull;
         memset(&qosInfoFull, 0, sizeof(QosInfoFull));
@@ -495,6 +495,7 @@ restart:
     if (bind(slisten, (struct sockaddr*) &ctrlsin, sizeof(ctrlsin)) < 0) {
         ga_logger(Severity::ERR, "QOS_SRV: controller server-bind: %s\n", strerror(errno));
         free(pMessage);
+        closesocket(slisten);
         return -1;
     }
     ga_logger(Severity::INFO, "QOS_SRV:  start to receive handshake message from client\n");

--- a/sources/streamer/core/cursor.cpp
+++ b/sources/streamer/core/cursor.cpp
@@ -186,6 +186,7 @@ DWORD __stdcall ProcessThreadClient(LPVOID params)
         ctrlsin.sin_addr.S_un.S_addr = name_resolve(pThreadInfo->conf.servername);
         if (ctrlsin.sin_addr.S_un.S_addr == INADDR_NONE) {
             ga_logger(Severity::ERR, "Name resolution failed: %s\n", pThreadInfo->conf.servername);
+            closesocket(m_sclient);
             return -1;
         }
     }
@@ -250,7 +251,7 @@ restart:
         }
 
         CURSOR_INFO *pCursorInfo = (CURSOR_INFO *)((unsigned char *)(buf  + sizeof(MSG_REP_INFO_S)));
-        if (pCursorInfo->lenOfCursor) {
+        if (pCursorInfo->lenOfCursor && (sizeof(MSG_REP_INFO_S) + sizeof(CURSOR_INFO) + pCursorInfo->lenOfCursor) < 8192) {
             memcpy(gCursorData, (unsigned char *)(buf  + sizeof(MSG_REP_INFO_S) + sizeof(CURSOR_INFO)), pCursorInfo->lenOfCursor);
         }
         cursorX = pCursorInfo->pos_x;

--- a/templates/m4docker/components/nodesource.m4
+++ b/templates/m4docker/components/nodesource.m4
@@ -33,7 +33,7 @@ include(begin.m4)
 include(ubuntu.m4)
 
 define(`NODESOURCE_URL',https://deb.nodesource.com)
-DECLARE(`NODE_VER',node_14.x)
+DECLARE(`NODE_VER',node_18.x)
 
 pushdef(`_install_ubuntu',`dnl
 INSTALL_PKGS(PKGS(curl ca-certificates gpg))


### PR DESCRIPTION
We are currently using node v14.x LTS series which EOL 2023-04-30
and which started to have compatibility issues with puppeteer package.
This commit bumps node version to latest supported LTS of v18.x series
with EOL 2025-04-30.

This PR also syncs sources with internal code base to avoid divergence.