### PR TITLE
ics3a/libvhal: Update libvhal-client to 11aaeda

### DIFF
--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
@@ -102,7 +102,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 4ee4307 && \
+  git checkout 11aaeda && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -255,7 +255,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 4ee4307 && \
+  git checkout 11aaeda && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/docker/streamer/ubuntu22.04/Dockerfile
+++ b/docker/streamer/ubuntu22.04/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && \
 ARG LIBVHAL_CLIENT_REPO=https://github.com/projectceladon/libvhal-client.git
 RUN git clone $LIBVHAL_CLIENT_REPO /opt/build/libvhal-client && \
   cd /opt/build/libvhal-client && \
-  git checkout 4ee4307 && \
+  git checkout 11aaeda && \
   mkdir -p build && cd build && \
   cmake -DCMAKE_INSTALL_PREFIX=/opt \
         -DCMAKE_INSTALL_LIBDIR=/opt/lib \

--- a/templates/libvhal-client.m4
+++ b/templates/libvhal-client.m4
@@ -31,7 +31,7 @@ dnl
 include(begin.m4)
 
 DECLARE(`LIBVHAL_SRC_REPO',https://github.com/projectceladon/libvhal-client.git)
-DECLARE(`LIBVHAL_CLIENT_VER',4ee4307)
+DECLARE(`LIBVHAL_CLIENT_VER',11aaeda)
 DECLARE(`LIBVHAL_BUILD_EMU',OFF)
 
 define(`LIBVHAL_CLIENT_BUILD_DEPS',`ca-certificates cmake gcc g++ git dnl


### PR DESCRIPTION
- Add support to use port number provided by client
- Static code analysis fixes