### PR TITLE
win: upstream IDD driver and basic tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.inf text eol=lf

--- a/.github/workflows/EnterDevShell.ps1
+++ b/.github/workflows/EnterDevShell.ps1
@@ -1,0 +1,38 @@
+param(
+    [Parameter()]
+    [String]$architecture
+)
+
+function EnterDevShellEnv  {
+
+    param(
+        [Parameter()]
+        [String]$arch
+    )
+
+    $vsw = Get-Command 'vswhere'
+    $VSFfavors = 'Community','Professional','Enterprise','BuildTools' | %{ "Microsoft.VisualStudio.Product.$_" }
+    $vs = & $vsw.Path -products $VSFfavors -latest -format json | ConvertFrom-Json
+    $tools_dir = Join-Path $vs.installationPath 'Common7' 'Tools'
+    # Try the root tools dir
+    $devshell = Join-Path $tools_dir 'Microsoft.VisualStudio.DevShell.dll'
+    # Try finding it under vsdevshell
+    if (!(Test-Path $devshell -Type Leaf)) {
+        $devshell = Join-Path $tools_dir 'vsdevshell' 'Microsoft.VisualStudio.DevShell.dll'
+    }
+    # Fail if didn't find the DevShell library
+    if (!(Test-Path $devshell -Type Leaf)) {
+        throw "error: cannot find Microsoft.VisualStudio.DevShell.dll"
+    }
+    Import-Module $devshell
+    Enter-VsDevShell -VsInstanceId $vs.instanceId -SkipAutomaticLocation -DevCmdArguments "-arch=$arch -no_logo"
+}
+
+# Enter VsDevShell, capture the environment difference and export it to github env
+$env_before = @{}
+Get-ChildItem env: | %{ $env_before.Add($_.Name, $_.Value) }
+EnterDevShellEnv -arch "$architecture"
+$env_after = @{}
+Get-ChildItem env: | %{ $env_after.Add($_.Name, $_.Value) }
+$env_diff = $env_after.GetEnumerator() | where { -not $env_before.ContainsKey($_.Name) -or $env_before[$_.Name] -ne $_.Value }
+$env_diff | %{ echo "$($_.Name)=$($_.Value)" >> $env:GITHUB_ENV }

--- a/.github/workflows/wincg.yml
+++ b/.github/workflows/wincg.yml
@@ -1,0 +1,50 @@
+name: wincg
+
+on: [push, pull_request]
+
+jobs:
+  idd:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - run: '.github\workflows\EnterDevShell.ps1 amd64'
+      shell: pwsh
+    - name: 'msbuild clean'
+      run: MSBuild.exe "sources\drivers\idd\IddSampleDriver.sln" -t:clean "/p:Configuration=Release;Platform=x64" -v:normal -m
+    - name: 'msbuild rebuild'
+      run: MSBuild.exe "sources\drivers\idd\IddSampleDriver.sln" -t:Rebuild "/p:Configuration=Release;Platform=x64" -v:normal -m
+
+  meson-ninja:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: pip install meson
+    - run: '.github\workflows\EnterDevShell.ps1 amd64'
+      shell: pwsh
+    - name: 'Configure'
+      run: meson setup _build --wrap-mode=forcefallback -Dstreamer=disabled
+    - name: 'Build'
+      run: meson compile -C _build
+    - name: 'Install'
+      run: meson install -C _build
+
+  meson-msbuild:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: pip install meson
+    - run: '.github\workflows\EnterDevShell.ps1 amd64'
+      shell: pwsh
+    - name: 'Configure'
+      run: meson setup _build --backend=vs --wrap-mode=forcefallback -Dstreamer=disabled
+    - name: 'Build'
+      run: meson compile -C _build
+    - name: 'Install'
+      run: meson install -C _build
+

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -40,6 +40,15 @@ Files: sources/streamer/core/asource.cpp
 Copyright: Copyright (C) 2013-2014 Chun-Ying Huang
 License: BSD-3-clause
 
+Files: sources/apps/idd-setup-tool/PairIdd.cpp
+       sources/drivers/idd/Driver.cpp
+       sources/drivers/idd/Driver.h
+       sources/drivers/idd/IddSampleDriver.inf
+       sources/drivers/idd/Trace.h
+Copyright: Copyright (C) Microsoft Corporation
+           Copyright (C) 2022-2023 Intel Corporation
+License: MS-PL
+
 License: Apache-2.0
  Copyright (C) 2022 Intel Corporation
 
@@ -82,3 +91,54 @@ License: BSD-3-clause
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: MS-PL
+ This license governs use of the accompanying software. If you use the
+ software, you accept this license. If you do not accept the license, do not
+ use the software.
+
+ 1. Definitions
+  The terms "reproduce," "reproduction," "derivative works," and "distribution"
+  have the same meaning here as under U.S. copyright law.
+  A "contribution" is the original software, or any additions or changes to the
+  software.
+  A "contributor" is any person that distributes its contribution under this
+  license.
+  "Licensed patents" are a contributor's patent claims that read directly on
+  its contribution.
+
+ 2. Grant of Rights
+  (A) Copyright Grant- Subject to the terms of this license, including the
+  license conditions and limitations in section 3, each contributor grants
+  you a non-exclusive, worldwide, royalty-free copyright license to reproduce
+  its contribution, prepare derivative works of its contribution, and
+  distribute its contribution or any derivative works that you create.
+  (B) Patent Grant- Subject to the terms of this license, including the license
+  conditions and limitations in section 3, each contributor grants you a
+  non-exclusive, worldwide, royalty-free license under its licensed patents to
+  make, have made, use, sell, offer for sale, import, and/or otherwise dispose
+  of its contribution in the software or derivative works of the contribution
+  in the software.
+
+ 3. Conditions and Limitations
+  (A) No Trademark License- This license does not grant you rights to use any
+  contributors' name, logo, or trademarks.
+  (B) If you bring a patent claim against any contributor over patents that you
+  claim are infringed by the software, your patent license from such
+  contributor to the software ends automatically.
+  (C) If you distribute any portion of the software, you must retain all
+  copyright, patent, trademark, and attribution notices that are present in the
+  software.
+  (D) If you distribute any portion of the software in source code form, you
+  may do so only under this license by including a complete copy of this
+  license with your distribution. If you distribute any portion of the software
+  in compiled or object code form, you may only do so under a license that
+  complies with this license.
+  (E) The software is licensed "as-is." You bear the risk of using it. The
+  contributors give no express warranties, guarantees or conditions. You may
+  have additional consumer rights under your local laws which this license
+  cannot change. To the extent permitted under your local laws, the contributors
+  exclude the implied warranties of merchantability, fitness for a particular
+  purpose and non-infringement.
+Comment:
+  That's "The Microsoft Public License (MS-PL)"

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,84 @@
+Format: https: www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Disclaimer:
+  This project is not part of Debian and just reuses copyright file format to
+  state which files are licensed under which license.
+
+Files: *
+Copyright: Copyright (C) 2022-2023 Intel Corporation
+License: Apache-2.0
+
+Files: sources/streamer/core/asource.cpp
+       sources/streamer/core/asource.h
+       sources/streamer/core/controller.cpp
+       sources/streamer/core/controller.h
+       sources/streamer/core/ctrl-msg.cpp
+       sources/streamer/core/ctrl-msg.h
+       sources/streamer/core/dpipe.cpp
+       sources/streamer/core/dpipe.h
+       sources/streamer/core/ga-avcodec.cpp
+       sources/streamer/core/ga-avcodec.h
+       sources/streamer/core/ga-conf.h
+       sources/streamer/core/ga-confvar.cpp
+       sources/streamer/core/ga-confvar.h
+       sources/streamer/core/ga-module.h
+       sources/streamer/core/ga-win32.cpp
+       sources/streamer/core/ga-win32.h
+       sources/streamer/core/libga.cpp
+       sources/streamer/core/rtspconf.cpp
+       sources/streamer/core/rtspconf.h
+       sources/streamer/core/vconverter.cpp
+       sources/streamer/core/vconverter.h
+       sources/streamer/core/vsource.h
+       sources/streamer/core/encoder-common.h
+       sources/streamer/core/ga-common.cpp
+       sources/streamer/core/ga-conf.cpp
+       sources/streamer/core/encoder-common.cpp
+       sources/streamer/core/ga-common.h
+       sources/streamer/core/ga-module.cpp
+       sources/streamer/core/vsource.cpp
+       sources/streamer/server/periodic/ga-server-periodic.cpp
+Copyright: Copyright (C) 2013-2014 Chun-Ying Huang
+License: BSD-3-clause
+
+License: Apache-2.0
+ Copyright (C) 2022 Intel Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http: www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions
+ and limitations under the License.
+
+ SPDX-License-Identifier: Apache-2.0
+
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ * Neither the name of the copyright holder nor the names of its
+ contributors may be used to endorse or promote products derived from
+ this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,9 @@ project('cloud-gaming', 'c', 'cpp',
     'cpp_std=c++17',
     'b_ndebug=if-release',
     'b_pie=true',
+    'b_vscrt=mt',
+    'c_winlibs=',
+    'cpp_winlibs=',
     ],
   )
 
@@ -44,6 +47,7 @@ add_project_link_arguments(c_link_args, language : ['cpp'])
 
 fs = import('fs')
 pkg = import('pkgconfig')
+windows = import('windows')
 
 m4 = find_program('m4', required : get_option('m4'))
 if m4.found()
@@ -76,8 +80,10 @@ if host_machine.system() == 'linux'
 endif
 
 if host_machine.system() == 'windows'
-  owt_dep = null_dep
-  titansdk_dep = null_dep
+  winres_args = []
+  if build_machine.cpu_family() == 'x86_64'
+    winres_args += '-D_WIN64'
+  endif
 endif
 
 nlohmann_json_dep = dependency('nlohmann_json', required : get_option('streamer'))

--- a/sources/apps/enum-adapters/enum-adapters.cpp
+++ b/sources/apps/enum-adapters/enum-adapters.cpp
@@ -1,0 +1,421 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <cassert>
+#include <atlcomcli.h>
+#include <dxgi1_6.h>
+#include "cg-version.h"
+#include "query-adapters.h"
+
+/**
+ * HRESULT code to string
+ *
+ * @param hr   HRESULT code
+ *
+ * @return HRESULT string
+ */
+inline std::string HrToString(HRESULT hr)
+{
+  std::stringstream ss;
+  ss << "HRESULT of 0x" << std::uppercase << std::setfill('0') << std::setw(8) << std::hex << hr;
+  return ss.str();
+}
+
+/**
+ * HRESULT exception class
+ */
+class HrException : public std::runtime_error
+{
+public:
+  HrException(HRESULT hr) : std::runtime_error(HrToString(hr)), hr_(hr) {}
+  HRESULT Error() const { return hr_; }
+private:
+  HRESULT hr_;
+};
+
+/**
+ * Throw if failed HRESULT code
+ *
+ * @param hr   HRESULT code
+ */
+inline void ThrowIfFailed(HRESULT hr)
+{
+  if (FAILED(hr)) {
+    throw HrException(hr);
+  }
+}
+
+/**
+ * DXGI Output Information
+ */
+struct DxgiOutputInfo
+{
+    uint32_t outputIndex;       //!< output index
+    DXGI_OUTPUT_DESC desc;      //!< DXGI output description
+    MONITORINFOEXW monitorInfo; //!< Monitor information
+};
+typedef std::vector<DxgiOutputInfo> DxgiOutputInfoList;
+
+/**
+ * @brief Convert rotation enum to friendly string
+ *
+ * @param rotation  enum DXGI_MODE_ROTATION
+ *
+ * @return Rotation friendly description
+ *
+ */
+static std::string rotation_desc(const DXGI_MODE_ROTATION rotation)
+{
+    switch (rotation) {
+    case DXGI_MODE_ROTATION_UNSPECIFIED:    return "Unspecified";
+    case DXGI_MODE_ROTATION_IDENTITY:       return "Identity";
+    case DXGI_MODE_ROTATION_ROTATE90:       return "Rotate 90";
+    case DXGI_MODE_ROTATION_ROTATE180:      return "Rotate 180";
+    case DXGI_MODE_ROTATION_ROTATE270:      return "Rotate 270";
+    }
+    return "Unknown";
+};
+
+/**
+ * DXGI Adapter Information
+ */
+struct DxgiAdapterInfo
+{
+  uint32_t adapterIndex;            //!< adapter index
+  DXGI_ADAPTER_DESC1 desc;          //!< DXGI adapter description
+  DxgiOutputInfoList outputInfo;    //!< list of output infomation
+};
+typedef std::vector<DxgiAdapterInfo> DxgiAdapterInfoList;
+
+/**
+ * @brief Show mode
+ *
+ */
+enum ShowMode {
+    off = 0,
+    basic = 1,
+    details = 2
+};
+
+/**
+ * @brief Enumeration use API
+ *
+ */
+enum ApiToUse {
+    dxgi = 0,
+    d3dkmt = 1
+};
+
+/**
+ * @brief Display app's usage
+ *
+ * @param app The application name
+ *
+ * @return none.
+ *
+ */
+void usage(const char* app)
+{
+  std::cout << "Build Version: " << CG_VERSION << std::endl << std::endl;
+  std::cout << std::endl;
+  std::cout << "usage: " << app << " [OPTIONS]" << std::endl;
+  std::cout << std::endl;
+  std::cout << "  options:" << std::endl;
+  std::cout << "    --help                          Display this help and exit" << std::endl;
+  std::cout << "    --api   dxgi | d3dkmt           Enumeration API to use (default: dxgi)" << std::endl;
+  std::cout << "    --show  basic | details | off   How much informaiton to show (default: basic)" << std::endl;
+  std::cout << "    --debug                         Show debug message" << std::endl;
+  std::cout << "    --luid  high:low                Specifies adapter LUID \"high:low\" to get adapter index" << std::endl;
+  std::cout << "                                    \"high:low\" in decimal #### or hexadecimal 0xXXXX format" << std::endl;
+}
+
+/**
+ * main function
+ */
+int main(int argc, char** argv)
+{
+    int idx = 1;
+    ShowMode show_mode = ShowMode::basic;
+    ApiToUse use_api = ApiToUse::dxgi;
+    bool debug = false;
+    const char* arg_luid = nullptr;
+
+    // parsing command line argument options
+    if (argc > 1) {
+        for (idx = 1; idx < argc; ++idx) {
+            if (std::string("-h") == argv[idx] || std::string("--help") == argv[idx]) {
+                usage(argv[0]);
+                return 0;
+            }
+            else if (std::string("--api") == argv[idx]) {
+                if (!(++idx >= argc)) {
+                    if (std::string("dxgi") == argv[idx])
+                        use_api = ApiToUse::dxgi;
+                    else if (std::string("d3dkmt") == argv[idx])
+                        use_api = ApiToUse::d3dkmt;
+                    else
+                        std::cout << "WARNING: Unknow '--api' argument - '" << argv[idx] << "'. Use default 'dxgi' list." << std::endl;
+                }
+            }
+            else if (std::string("--luid") == argv[idx]) {
+                if (++idx >= argc) {
+                    std::cerr << "ERROR: Missing LUID argumnet for '--luid'" << std::endl;
+                    std::cout << std::endl;
+                    usage(argv[0]);
+                    return -1;
+                }
+                arg_luid = argv[idx];
+                show_mode = ShowMode::off;
+            }
+            else if (std::string("--show") == argv[idx]) {
+                show_mode = ShowMode::basic;
+                if (!(++idx >= argc)) {
+                    if (std::string("details") == argv[idx])
+                        show_mode = ShowMode::details;
+                    else if (std::string("basic") == argv[idx])
+                        show_mode = ShowMode::basic;
+                    else
+                        std::cout << "WARNING: Unknow '--show' argument - '" << argv[idx] << "'. Use default 'basic' list." << std::endl;
+                }
+            }
+            else if (std::string("--debug") == argv[idx]) {
+                debug = true;
+            }
+            else {
+                std::cerr << "ERROR: Unknown argument optoin: " << argv[idx] << std::endl;
+                std::cout << std::endl;
+                usage(argv[0]);
+                return -1;
+            }
+        }
+    }
+
+    if (use_api == ApiToUse::dxgi) {
+        DxgiAdapterInfoList gpuAdapterDescs;
+
+        CComPtr<IDXGIFactory6> dxgiFactory;
+        HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&dxgiFactory));
+        if (FAILED(hr) || !dxgiFactory) {
+            std::cerr << "Failed to create DXGI factory!!! " << HrToString(hr) << std::endl;
+            return -1;
+        }
+
+        // Enumerating adapters information
+        CComPtr<IDXGIAdapter1> adapter;
+
+        for (UINT adapterIdx = 0; DXGI_ERROR_NOT_FOUND != dxgiFactory->EnumAdapters1(adapterIdx, &adapter); ++adapterIdx) {
+            DxgiAdapterInfo adapterInfo{};
+            ThrowIfFailed(adapter->GetDesc1(&adapterInfo.desc));
+            adapterInfo.adapterIndex = adapterIdx;
+
+            // Enumerating output from the adapter
+            CComPtr<IDXGIOutput> output = nullptr;
+            uint32_t outputIdx = 0;
+            while (SUCCEEDED(adapter->EnumOutputs(outputIdx, &output))) {
+                DxgiOutputInfo outputInfo{};
+                ThrowIfFailed(output->GetDesc(&outputInfo.desc));
+                outputInfo.outputIndex = outputIdx;
+
+                if (outputInfo.desc.AttachedToDesktop) {
+                    RtlZeroMemory(&outputInfo.monitorInfo, sizeof(outputInfo.monitorInfo));
+                    outputInfo.monitorInfo.cbSize = sizeof(outputInfo.monitorInfo);
+                    if (!GetMonitorInfoW(outputInfo.desc.Monitor, &outputInfo.monitorInfo)) {
+                        std::cerr << "Failed to get monitor information! (adapter index = " << adapterInfo.adapterIndex << ", output index = " << outputInfo.outputIndex << std::endl;
+                    }
+                }
+                adapterInfo.outputInfo.push_back(std::move(outputInfo));
+
+                output.Release();
+                ++outputIdx;
+            }
+
+            gpuAdapterDescs.push_back(std::move(adapterInfo));
+
+            adapter.Release();
+        }
+
+        // Show list of GPU adapters
+        if (show_mode != ShowMode::off && !gpuAdapterDescs.empty()) {
+            std::cout << std::endl;
+            std::cout << "[DXGI] Total number of D3D/GPU adapters: = " << gpuAdapterDescs.size() << ":" << std::endl;
+            std::cout << std::endl;
+
+            for (auto& adapterInfo : gpuAdapterDescs) {
+                std::cout << "\tAdapter index #" << adapterInfo.adapterIndex << std::endl;
+                std::cout << "\t----------------" << std::endl;
+                std::wcout << "\t   Description : " << std::wstring(adapterInfo.desc.Description) << std::endl;
+                std::cout << "\t     Vendor ID : " << std::to_string(adapterInfo.desc.VendorId) << " [0x" << std::hex << adapterInfo.desc.VendorId << std::dec << "]" << std::endl;
+                std::cout << "\t     Device ID : " << std::to_string(adapterInfo.desc.DeviceId) << " [0x" << std::hex << adapterInfo.desc.DeviceId << std::dec << "]" << std::endl;
+                std::cout << "\t  Subsystem ID : " << std::to_string(adapterInfo.desc.SubSysId) << " [0x" << std::hex << adapterInfo.desc.SubSysId << std::dec << "]" << std::endl;
+                std::cout << "\t      Revision : " << std::to_string(adapterInfo.desc.Revision) << " [0x" << std::hex << adapterInfo.desc.Revision << std::dec << "]" << std::endl;
+                std::cout << "\t  Adapter LUID : " << std::to_string(adapterInfo.desc.AdapterLuid.HighPart)
+                    << " " << std::to_string(adapterInfo.desc.AdapterLuid.LowPart)
+                    << " [0x" << std::hex << adapterInfo.desc.AdapterLuid.HighPart
+                    << " 0x" << adapterInfo.desc.AdapterLuid.LowPart << std::dec << "]" << std::endl;
+
+                for (auto& outputInfo : adapterInfo.outputInfo) {
+                    std::cout << "\n\t\tOutput index #" << outputInfo.outputIndex << std::endl;
+                    std::cout << "\t\t----------------" << std::endl;
+                    std::wcout << "\t\t           Device Name : " << std::wstring(outputInfo.desc.DeviceName) << std::endl;
+                    std::cout << "\t\t   Attached To Desktop : " << (outputInfo.desc.AttachedToDesktop ? "Yes" : "No") << std::endl;
+                    std::cout << "\t\t   Desktop Coordinates : (" << outputInfo.desc.DesktopCoordinates.left
+                        << ", " << outputInfo.desc.DesktopCoordinates.top
+                        << ", " << outputInfo.desc.DesktopCoordinates.right
+                        << ", " << outputInfo.desc.DesktopCoordinates.bottom << ")" << std::endl;
+                    std::cout << "\t\t              Rotation : " << rotation_desc(outputInfo.desc.Rotation) << std::endl;
+                    std::cout << "\t\t     Handle of Monitor : 0x" << std::hex << outputInfo.desc.Monitor << std::dec << std::endl;
+                    std::wcout << "\t\t   Monitor Device Name : " << std::wstring(outputInfo.monitorInfo.szDevice) << std::endl;
+                }
+                std::cout << std::endl;
+            }
+        }
+
+        if (arg_luid != nullptr) {
+            std::string luidstr = std::string(arg_luid);
+            LUID luid;
+            bool found = false;
+
+            if (!check_luid(luidstr, luid)) {
+                return -1;
+            }
+
+            auto compare_luid = [&luid](DxgiAdapterInfo& info) {
+                return (info.desc.AdapterLuid.HighPart == luid.HighPart && info.desc.AdapterLuid.LowPart == luid.LowPart);
+            };
+
+            if (gpuAdapterDescs.size() > 0) {
+                auto it = std::find_if(gpuAdapterDescs.begin(), gpuAdapterDescs.end(), compare_luid);
+                if (it != gpuAdapterDescs.end()) {
+                    int index = (int)std::distance(gpuAdapterDescs.begin(), it);
+                    std::cout << index << std::endl;    // echo found LUID adapter index for automation script use
+                    found = true;
+                }
+            }
+
+            if (!found) {
+                std::cerr << "LUID [" << luidstr << "] not found!" << std::endl;
+            }
+        }
+    }
+    else if (use_api == ApiToUse::d3dkmt) {
+        AdapterDeviceInfoList physicalDevices;   // List of physical adapter device information
+        AdapterDeviceInfoList softwareDevices;   // List of software adapter device information
+        AdapterDeviceInfoList indirectDevices;   // List of indirect display adapter device information
+
+        query_adapters_list(physicalDevices, indirectDevices, softwareDevices, debug);
+
+        if (show_mode != ShowMode::off) {
+            std::cout << "[D3DKMT] Total number of D3D/GPU adapters = " << (physicalDevices.size() + indirectDevices.size() + softwareDevices.size()) << std::endl;
+            std::cout << std::endl;
+
+            std::cout << "Number of Physical Devices  : " << physicalDevices.size() << std::endl;
+            std::cout << "================================" << std::endl << std::endl;
+            int i = 0;
+            for (auto& info : physicalDevices) {
+                std::wcout << L"Adapter Index in Physical Devices List [" << i++ << L"]" << std::endl;
+                std::wcout << L"-------------------------------------------" << std::endl;
+                show_adapter_device_info(info, show_mode == ShowMode::details);
+            }
+
+            std::cout << "Number of Indirect Devices  : " << indirectDevices.size() << std::endl;
+            std::cout << "================================" << std::endl << std::endl;
+            i = 0;
+            for (auto& info : indirectDevices) {
+                std::wcout << L"Adapter Index in Indirect Devices List [" << i++ << L"]" << std::endl;
+                std::wcout << L"-------------------------------------------" << std::endl;
+                show_adapter_device_info(info, show_mode == ShowMode::details);
+            }
+
+            std::cout << "Number of Software Devices  : " << softwareDevices.size() << std::endl;
+            std::cout << "================================" << std::endl << std::endl;
+            i = 0;
+            for (auto& info : softwareDevices) {
+                std::wcout << L"Adapter Index in Software Devices List [" << i++ << L"]" << std::endl;
+                std::wcout << L"-------------------------------------------" << std::endl;
+                show_adapter_device_info(info, show_mode == ShowMode::details);
+            }
+        }
+
+        if (arg_luid != nullptr) {
+            std::string luidstr = std::string(arg_luid);
+            LUID luid;
+            bool found = false;
+
+            if (!check_luid(luidstr, luid)) {
+                return -1;
+            }
+
+            auto compare_luid = [&luid](AdapterDeviceInfo& info) {
+                return (info.luid.HighPart == luid.HighPart && info.luid.LowPart == luid.LowPart);
+            };
+
+            // Check physical adapters list first
+            if (physicalDevices.size() > 0) {
+                auto it = std::find_if(physicalDevices.begin(), physicalDevices.end(), compare_luid);
+                if (it != physicalDevices.end()) {
+                    int index = (int)std::distance(physicalDevices.begin(), it);
+                    if (debug) {
+                        std::cout << "Found [" << luidstr << "] in the physical devices. index = " << index << std::endl;
+                        show_adapter_device_info(physicalDevices[index], show_mode == ShowMode::details);
+                    }
+                    else {
+                        std::cout << index << std::endl;    // echo found LUID adapter index for automation script use
+                    }
+                    found = true;
+                }
+            }
+            // If not found in physical adapters list check indirect display adapters list
+            if (!found && indirectDevices.size() > 0) {
+                auto it = std::find_if(indirectDevices.begin(), indirectDevices.end(), compare_luid);
+                if (it != indirectDevices.end()) {
+                    int index = (int)std::distance(indirectDevices.begin(), it);
+                    if (debug) {
+                        std::cout << "Found [" << luidstr << "] in the indirect devices. index = " << index << std::endl;
+                        show_adapter_device_info(indirectDevices[index], show_mode == ShowMode::details);
+                    }
+                    else {
+                        std::cout << index << std::endl;    // echo found LUID adapter index for automation script use
+                    }
+                    found = true;
+                }
+            }
+            // If not found in neither physical nor indirect adapters list, check software adapters list
+            if (!found && softwareDevices.size() > 0) {
+                auto it = std::find_if(softwareDevices.begin(), softwareDevices.end(), compare_luid);
+                if (it != softwareDevices.end()) {
+                    int index = (int)std::distance(softwareDevices.begin(), it);
+                    if (debug) {
+                        std::cout << "Found [" << luidstr << "] in the software devices. index = " << index << std::endl;
+                        show_adapter_device_info(softwareDevices[index], show_mode == ShowMode::details);
+                    }
+                    else {
+                        std::cout << index << std::endl;    // echo found LUID adapter index for automation script use
+                    }
+                    found = true;
+                }
+            }
+
+            if (!found) {
+                std::cerr << "LUID [" << luidstr << "] not found!" << std::endl;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/sources/apps/enum-adapters/enum-adapters.rc
+++ b/sources/apps/enum-adapters/enum-adapters.rc
@@ -1,0 +1,106 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+#include "cg-version.h"
+
+#define DESCRIPTION         "Enumerates GPU adapters"
+#define INTERNALNAME        "enum-adapters.exe"
+#define ORIGINALFILENAME    "enum-adapters.exe"
+
+#ifndef _DEBUG
+#define VER_DEBUG   0x00000000L
+#else
+#define VER_DEBUG   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    CG_FILEVERSION
+ PRODUCTVERSION CG_PRODUCTVERSION
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      VER_DEBUG
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_APP
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",        CG_MANUFACTURER
+            VALUE "FileDescription",    DESCRIPTION
+            VALUE "FileVersion",        CG_VERSION_STR
+            VALUE "InternalName",       INTERNALNAME
+            VALUE "LegalCopyright",     CG_LEGALCOPYRIGHT
+            VALUE "OriginalFilename",   ORIGINALFILENAME
+            VALUE "ProductName",        CG_PRODUCTNAME
+            VALUE "ProductVersion",     CG_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/sources/apps/enum-adapters/meson.build
+++ b/sources/apps/enum-adapters/meson.build
@@ -1,0 +1,40 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+srcs = [cgver_file, cgvcs_tgt]
+srcs += files(
+  'enum-adapters.cpp',
+  'query-adapters.cpp',
+  )
+
+srcs += windows.compile_resources(
+  files('enum-adapters.rc'),
+  args : winres_args,
+  depend_files : [ cgver_file, files('resource.h') ],
+  depends : cgvcs_tgt,
+  )
+
+core_deps = [
+  cpp.find_library('dxgi'),
+  cpp.find_library('gdi32'),
+  cpp.find_library('ole32'),
+  cpp.find_library('user32'),
+  ]
+
+executable('enum-adapters', srcs,
+  dependencies : core_deps,
+  install : true,
+  )

--- a/sources/apps/enum-adapters/query-adapters.cpp
+++ b/sources/apps/enum-adapters/query-adapters.cpp
@@ -1,0 +1,393 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file   query-adapters.cpp
+ *
+ * @brief  Functions for query D3D adapter device information using kernel mode thunk interfaces.
+ *
+ */
+
+#include "query-adapters.h"
+#include <sstream>
+#include <algorithm>
+#include <winternl.h>
+#include <d3dkmthk.h>
+
+#if !defined(STATUS_SUCCESS)
+    #define STATUS_SUCCESS                   ((NTSTATUS)0x00000000L)    // ntsubauth
+#endif // !defined(STATUS_SUCCESS)
+
+ /**
+  * @brief GUID to wstring helper function
+  *
+  * @param guid  GUID to convert
+  *
+  * @return none
+  *
+  */
+std::wstring GUID_to_wstring(const GUID& guid)
+{
+    LPOLESTR olestr;
+    if (FAILED(StringFromCLSID(guid, &olestr))) {
+        return L"Unknown";
+    }
+
+    std::wstring w_guid(olestr, olestr + wcslen(olestr));
+    CoTaskMemFree(olestr);
+
+    return w_guid;
+}
+
+/**
+ * @brief Show adapter's device information
+ *
+ * @param info      Adapter's device information
+ * @param details   Show information in details
+ *
+ * @return none
+ *
+ */
+void show_adapter_device_info(const AdapterDeviceInfo& info, bool details /*= false*/)
+{
+    std::wcout << L"            Description : " << info.description << std::endl;
+    std::wcout << L"                   LUID : " << info.luid.HighPart << L":" << info.luid.LowPart
+        << L" [0x" << std::hex << info.luid.HighPart << L":0x" << info.luid.LowPart << L"]" << std::dec << std::endl;
+    std::wcout << L"              Vendor ID : 0x" << std::hex << info.vendorID << std::dec << std::endl;
+    std::wcout << L"              Device ID : 0x" << std::hex << info.deviceID << std::dec << std::endl;
+    std::wcout << L"           Subvendor ID : 0x" << std::hex << info.subVendorID << std::dec << std::endl;
+    std::wcout << L"           Subsystem ID : 0x" << std::hex << info.subSystemID << std::dec << std::endl;
+    std::wcout << L"            Revision ID : 0x" << std::hex << info.revisionID << std::dec << std::endl;
+    std::wcout << L"    Enum. Adapter Index : " << info.adapterIndex << std::endl;
+
+    if (details) {
+        std::wcout << L"         Adapter Handle : 0x" << std::hex << info.handler << std::dec << std::endl;
+        std::wcout << L"      Number of Sources : " << info.numSources << std::endl;
+
+        std::wcout << std::endl;
+        std::wcout << L"       GPU BIOS Version : " << info.gpuBiosVersion << std::endl;
+        std::wcout << L"       GPU Architecture : " << info.gpuArchitecture << std::endl;
+
+        std::wcout << L"                   Name : " << info.name << std::endl;
+        std::wcout << L"                   BIOS : " << info.bios << std::endl;
+        std::wcout << L"               Dac Type : " << info.dacType << std::endl;
+        std::wcout << L"              Chip Type : " << info.chipType << std::endl;
+
+        std::wcout << L"    Phys. Adapter Count : " << info.physicalAdapterCount << std::endl;
+        std::wcout << L"    Phys. Adapter Index : " << info.physicalAdapterIndex << std::endl;
+        std::wcout << L"               Bus Type : " << info.busType << std::endl;
+
+        std::wcout << L"    Bus Device Function : " << info.bus << L" , " << info.device << L" , " << info.function
+            << L" [0x" << std::hex << info.bus << L" , 0x" << info.device << L" , 0x" << info.function << L"]" << std::dec << std::endl;
+
+        std::wcout << L"                   GUID : " << GUID_to_wstring(info.guid) << std::endl;
+
+        std::wcout << L"           Video Memory : " << info.vram << std::endl;
+        std::wcout << L"          System Memory : " << info.sysRam << std::endl;
+        std::wcout << L"     Shared Sys. Memory : " << info.sharedRam << std::endl;
+
+        std::wcout << std::endl;
+        std::wcout << L"           RenderSupported : " << info.renderSupported << std::endl;
+        std::wcout << L"          DisplaySupported : " << info.displaySupported << std::endl;
+        std::wcout << L"            SoftwareDevice : " << info.softwareDevice << std::endl;
+        std::wcout << L"                PostDevice : " << info.postDevice << std::endl;
+        std::wcout << L"            HybridDiscrete : " << info.hybridDiscrete << std::endl;
+        std::wcout << L"          HybridIntegrated : " << info.hybridIntegrated << std::endl;
+        std::wcout << L"     IndirectDisplayDevice : " << info.indirectDisplayDevice << std::endl;
+        std::wcout << L"           Paravirtualized : " << info.paravirtualized << std::endl;
+        std::wcout << L"              ACGSupported : " << info.acgSupported << std::endl;
+        std::wcout << L"SupportSetTimingsFromVidPn : " << info.supportSetTimingsFromVidPn << std::endl;
+        std::wcout << L"                Detachable : " << info.detachable << std::endl;
+        std::wcout << L"               ComputeOnly : " << info.computeOnly << std::endl;
+        std::wcout << L"                 Prototype : " << info.prototype << std::endl;
+        std::wcout << L"    RuntimePowerManagement : " << info.runtimePowerManagement << std::endl;
+    }
+    std::wcout << std::endl;
+}
+
+/**
+ * @brief Check valid LUID from string
+ *
+ * @param luidstr String contained LUID
+ * @param luid    Return LUID if valid
+ *
+ * @return true if success, false otherwise
+ *
+ */
+bool check_luid(std::string luidstr, LUID& luid)
+{
+    std::vector<unsigned long> aluid;
+    std::replace(luidstr.begin(), luidstr.end(), ':', ' ');
+    std::stringstream ss(luidstr);
+    std::string f;
+    while (ss >> f) {
+        try {
+            aluid.push_back(std::stoul(f, nullptr, 0));
+        }
+        catch (std::exception& ex) {
+            std::cerr << ex.what() << ": " << f << std::endl;
+            return false;
+        }
+    }
+
+    if (aluid.size() < 2) {
+        std::cerr << "LUID parsing failed. Incorrect LUID argument: \"" << luidstr << "\". Use '-h' for list correct format." << std::endl;
+        return false;
+    }
+
+    luid.HighPart = aluid[0];
+    luid.LowPart = aluid[1];
+
+    return true;
+}
+
+/**
+ * @brief Query D3D/GPU adapters list
+ *
+ * @param physicalDevices   List of physical adapter devices list
+ * @param indirectDevices   List of indirect adapter devices list
+ * @param softwareDevices   List of software adapter devices list
+ * @param debug             Show debug messages for debugging purpose
+ *
+ * @return true if success, false otherwise
+ *
+ */
+bool query_adapters_list(AdapterDeviceInfoList& physicalDevices, AdapterDeviceInfoList& indirectDevices, AdapterDeviceInfoList& softwareDevices, bool debug /*= false*/)
+{
+    D3DKMT_ENUMADAPTERS enumAdapters{};
+    NTSTATUS status = D3DKMTEnumAdapters(&enumAdapters);
+    if (STATUS_SUCCESS != status) {
+        return false;
+    }
+
+    for (ULONG i = 0; i < enumAdapters.NumAdapters; ++i) {
+        D3DKMT_OPENADAPTERFROMLUID adapterFromLuid{};
+        adapterFromLuid.hAdapter = enumAdapters.Adapters[i].hAdapter;
+        adapterFromLuid.AdapterLuid = enumAdapters.Adapters[i].AdapterLuid;
+        if (D3DKMTOpenAdapterFromLuid(&adapterFromLuid) == STATUS_SUCCESS) {
+            D3DKMT_PHYSICAL_ADAPTER_COUNT adapterCount{};
+            D3DKMT_QUERYADAPTERINFO adapterInfo{};
+            D3DKMT_ADAPTERREGISTRYINFO adapterRegInfo{};
+            D3DKMT_ADAPTERADDRESS adapterAddress{};
+            D3DKMT_SEGMENTSIZEINFO segmentSizeInfo{};
+            D3DKMT_ADAPTERTYPE adapterType{};
+            D3DKMT_QUERY_DEVICE_IDS deviceIds{};
+            D3DKMT_DRIVER_DESCRIPTION driverDescription{};
+            D3DKMT_UMD_DRIVER_VERSION umdDriverVersion{};
+            D3DKMT_KMD_DRIVER_VERSION kmdDriverVersion{};
+            D3DKMT_GPUVERSION gpuVersion{};
+            GUID deviceGuid{};
+
+            if (debug)
+                std::cout << "Enumerated Adapter Index: " << i << std::endl;
+
+            // Query: Registry information about the graphics adapter
+            adapterInfo.Type = KMTQAITYPE_ADAPTERREGISTRYINFO;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &adapterRegInfo;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_ADAPTERREGISTRYINFO);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_ADAPTERREGISTRYINFO      0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: Describes the physical location of the graphics adapter.
+            adapterInfo.Type = KMTQAITYPE_ADAPTERADDRESS;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &adapterAddress;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_ADAPTERADDRESS);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_ADAPTERADDRESS           0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: The GUID for the adapter.
+            adapterInfo.Type = KMTQAITYPE_ADAPTERGUID;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &deviceGuid;
+            adapterInfo.PrivateDriverDataSize = sizeof(GUID);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  Device Adapter GUID             0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: Describes the size, in bytes, of memory and aperture segments.
+            adapterInfo.Type = KMTQAITYPE_GETSEGMENTSIZE;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &segmentSizeInfo;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_SEGMENTSIZEINFO);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_SEGMENTSIZEINFO          0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: Specifies the type of display device that the graphics adapter supports.
+            adapterInfo.Type = KMTQAITYPE_ADAPTERTYPE;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &adapterType;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_ADAPTERTYPE);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_ADAPTERTYPE              0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: Used to get the physical adapter count.
+            adapterInfo.Type = KMTQAITYPE_PHYSICALADAPTERCOUNT;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &adapterCount;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_PHYSICAL_ADAPTER_COUNT);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_PHYSICAL_ADAPTER_COUNT   0x" << std::hex << (status) << std::dec << " count = " << adapterCount.Count << std::endl;
+
+            for (ULONG j = 0; j < enumAdapters.NumAdapters; ++j) {
+                deviceIds.PhysicalAdapterIndex = j;
+                // Query: Used to query for device IDs.
+                adapterInfo.Type = KMTQAITYPE_PHYSICALADAPTERDEVICEIDS;
+                adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+                adapterInfo.pPrivateDriverData = &deviceIds;
+                adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_QUERY_DEVICE_IDS);
+                status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+                if (debug)
+                    std::cout << "  D3DKMT_QUERY_DEVICE_IDS         0x" << (status) << " index: " << j << std::endl;
+                if (STATUS_SUCCESS == status)
+                    break;
+            }
+            if (debug)
+                std::cout << std::endl;
+
+            if (status != STATUS_SUCCESS) {
+                deviceIds.DeviceIds.DeviceID = 0;
+                deviceIds.DeviceIds.VendorID = 0;
+                status = 0;
+            }
+
+            // Query: Used to collect the bios version and GPU architecture name once during GPU initialization.
+            adapterInfo.Type = KMTQUITYPE_GPUVERSION;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &gpuVersion;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_GPUVERSION);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_GPUVERSION               0x" << std::hex << (status) << std::dec << ". GPU Phy. index = " << gpuVersion.PhysicalAdapterIndex << std::endl;
+
+            // Query: Describes the kernel mode display driver.
+            adapterInfo.Type = KMTQAITYPE_DRIVER_DESCRIPTION;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &driverDescription;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_DRIVER_DESCRIPTION);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_DRIVER_DESCRIPTION       0x" << std::hex << (status) << std::dec << std::endl;
+
+            // Query: Indicates the version number of the user-mode driver.
+            adapterInfo.Type = KMTQAITYPE_UMD_DRIVER_VERSION;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &umdDriverVersion;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_UMD_DRIVER_VERSION);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_UMD_DRIVER_VERSION       0x" << std::hex << (status) << " " << umdDriverVersion.DriverVersion.QuadPart << std::dec << std::endl;
+
+            // Query: The kernel mode driver version.
+            adapterInfo.Type = KMTQAITYPE_KMD_DRIVER_VERSION;
+            adapterInfo.hAdapter = adapterFromLuid.hAdapter;
+            adapterInfo.pPrivateDriverData = &kmdDriverVersion;
+            adapterInfo.PrivateDriverDataSize = sizeof(D3DKMT_KMD_DRIVER_VERSION);
+            status = D3DKMTQueryAdapterInfo(&adapterInfo);
+
+            if (debug)
+                std::cout << "  D3DKMT_KMD_DRIVER_VERSION       0x" << std::hex << (status) << " " << kmdDriverVersion.DriverVersion.QuadPart << std::dec << std::endl;
+
+            AdapterDeviceInfo devInfo;
+
+            devInfo.adapterIndex = i;
+
+            devInfo.description = std::wstring(driverDescription.DriverDescription);
+
+            devInfo.gpuBiosVersion = std::wstring(gpuVersion.BiosVersion);
+            devInfo.gpuArchitecture = std::wstring(gpuVersion.GpuArchitecture);
+
+            devInfo.name = std::wstring(adapterRegInfo.AdapterString);
+            devInfo.bios = std::wstring(adapterRegInfo.BiosString);
+            devInfo.dacType = std::wstring(adapterRegInfo.DacType);
+            devInfo.chipType = std::wstring(adapterRegInfo.ChipType);
+
+            devInfo.luid = enumAdapters.Adapters[i].AdapterLuid;
+            devInfo.handler = enumAdapters.Adapters[i].hAdapter;
+            devInfo.numSources = enumAdapters.Adapters[i].NumOfSources;
+
+            devInfo.bus = adapterAddress.BusNumber;
+            devInfo.device = adapterAddress.DeviceNumber;
+            devInfo.function = adapterAddress.FunctionNumber;
+
+            devInfo.guid = deviceGuid;
+
+            devInfo.vram = segmentSizeInfo.DedicatedVideoMemorySize;
+            devInfo.sysRam = segmentSizeInfo.DedicatedSystemMemorySize;
+            devInfo.sharedRam = segmentSizeInfo.SharedSystemMemorySize;
+
+            devInfo.physicalAdapterCount = adapterCount.Count;
+
+            devInfo.physicalAdapterIndex = deviceIds.PhysicalAdapterIndex;
+            devInfo.vendorID = deviceIds.DeviceIds.VendorID;
+            devInfo.deviceID = deviceIds.DeviceIds.DeviceID;
+            devInfo.busType = deviceIds.DeviceIds.BusType;
+            devInfo.revisionID = deviceIds.DeviceIds.RevisionID;
+            devInfo.subSystemID = deviceIds.DeviceIds.SubSystemID;
+            devInfo.subVendorID = deviceIds.DeviceIds.SubVendorID;
+
+            devInfo.renderSupported = adapterType.RenderSupported;
+            devInfo.displaySupported = adapterType.DisplaySupported;
+            devInfo.softwareDevice = adapterType.SoftwareDevice;
+            devInfo.postDevice = adapterType.PostDevice;
+            devInfo.hybridDiscrete = adapterType.HybridDiscrete;
+            devInfo.hybridIntegrated = adapterType.HybridIntegrated;
+            devInfo.indirectDisplayDevice = adapterType.IndirectDisplayDevice;
+            devInfo.paravirtualized = adapterType.Paravirtualized;
+            devInfo.acgSupported = adapterType.ACGSupported;
+            devInfo.supportSetTimingsFromVidPn = adapterType.SupportSetTimingsFromVidPn;
+            devInfo.detachable = adapterType.Detachable;
+            devInfo.computeOnly = adapterType.ComputeOnly;
+            devInfo.prototype = adapterType.Prototype;
+            devInfo.runtimePowerManagement = adapterType.RuntimePowerManagement;
+
+            if (!devInfo.softwareDevice) {
+                if (!devInfo.indirectDisplayDevice) {
+                    physicalDevices.push_back(devInfo);
+                }
+                else {
+                    indirectDevices.push_back(devInfo);
+                }
+            }
+            else {
+                softwareDevices.push_back(devInfo);
+            }
+            {
+                D3DKMT_CLOSEADAPTER closeAdapter;
+                closeAdapter.hAdapter = adapterFromLuid.hAdapter;
+                D3DKMTCloseAdapter(&closeAdapter);
+            }
+        }
+    }
+
+    return true;
+}

--- a/sources/apps/enum-adapters/query-adapters.h
+++ b/sources/apps/enum-adapters/query-adapters.h
@@ -1,0 +1,103 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file   query-adapters.h
+ *
+ * @brief  Functions for query D3D adapter device information.
+ *         Support option to get adapter index by use adapter's LUID.
+ *
+ */
+
+#pragma once
+
+#include <iostream>
+#include <Windows.h>
+#include <vector>
+
+ /**
+  * @brief AdapterDeviceInfo data structure which collect device information from D3DKMT* data structure.
+  */
+struct AdapterDeviceInfo
+{
+    // D3DKMT_DRIVER_DESCRIPTION
+    std::wstring    description;    ///< @brief Describes the kernel mode display driver.
+    // D3DKMT_GPUVERSION
+    std::wstring    gpuBiosVersion; ///< @brief The current bios of the adapter.
+    std::wstring    gpuArchitecture;///< @brief The gpu architecture of the adapter.
+    // D3DKMT_ADAPTERREGISTRYINFO
+    std::wstring    name;           ///< @brief A string that contains the name of the graphics adapter.
+    std::wstring    bios;           ///< @brief A string that contains the name of the BIOS for the graphics adapter.
+    std::wstring    dacType;        ///< @brief A string that contains the DAC type for the graphics adapter.
+    std::wstring    chipType;       ///< @brief A string that contains the chip type for the graphics adapter.
+    // D3DKMT_ENUMADAPTERS
+    uint32_t        adapterIndex;   ///< @brief Adapter index, based on enumerated order.
+    uint32_t        handler;        ///< @brief A handle to the adapter.
+    LUID            luid;           /**< @brief A LUID value that uniquely identifies the adapter, typically until
+                                                the operating system is rebooted. The LUID value changes whenever:
+                                                - the system is rebooted
+                                                - the adapter's driver is updated
+                                                - the adapter is disabled
+                                                - the adapter is disconnected */
+    uint32_t        numSources;     ///< @brief The number of video present sources supported by the adapter.
+    // D3DKMT_ADAPTERADDRESS
+    uint32_t        bus;            ///< @brief The number of the bus that the graphics adapter's physical device is located on.
+    uint32_t        device;         ///< @brief The index of the graphics adapter's physical device on the bus.
+    uint32_t        function;       ///< @brief The function number of the graphics adapter on the physical device.
+    // KMTQAITYPE_ADAPTERGUID
+    GUID            guid;           ///< @brief The adapter GUID
+    // D3DKMT_SEGMENTSIZEINFO
+    uint64_t        vram;           ///< @brief The size, in bytes, of memory that is dedicated from video memory.
+    uint64_t        sysRam;         ///< @brief The size, in bytes, of memory that is dedicated from system memory.
+    uint64_t        sharedRam;      ///< @brief The size, in bytes, of memory from system memory that can be shared by many users.
+    // D3DKMT_PHYSICAL_ADAPTER_COUNT
+    uint32_t        physicalAdapterCount;   ///< @brief The physical adapter count.
+    // D3DKMT_QUERY_DEVICE_IDS
+    uint32_t        physicalAdapterIndex;   ///< @brief The physical adapter index in the LDA (linked display adapter) chain.
+    uint32_t        vendorID;       ///< @brief Vendor ID.
+    uint32_t        deviceID;       ///< @brief Device ID.
+    uint32_t        subVendorID;    ///< @brief Subvendor ID.
+    uint32_t        subSystemID;    ///< @brief Subsystem ID.
+    uint32_t        revisionID;     ///< @brief Revision ID.
+    uint32_t        busType;        ///< @brief Bus type.
+    // D3DKMT_ADAPTERTYPE
+    union {
+        struct {
+            uint32_t    renderSupported : 1;            ///< @brief The adapter supports a render device.
+            uint32_t    displaySupported : 1;           ///< @brief The adapter supports a display device.
+            uint32_t    softwareDevice : 1;             ///< @brief The adapter supports a non-plug and play (PnP) device that is implemented in software.
+            uint32_t    postDevice : 1;                 ///< @brief The adapter supports a power-on self-test (POST) device.
+            uint32_t    hybridDiscrete : 1;             ///< @brief The adapter supports a hybrid discrete device.
+            uint32_t    hybridIntegrated : 1;           ///< @brief The adapter supports a hybrid integrated device.
+            uint32_t    indirectDisplayDevice : 1;      ///< @brief The adapter supports an indirect display device.
+            uint32_t    paravirtualized : 1;            ///< @brief The adapter supports para-virtualization.
+            uint32_t    acgSupported : 1;               ///< @brief The adapter supports Arbitrary Code Guard (ACG).
+            uint32_t    supportSetTimingsFromVidPn : 1; ///< @brief The adapter supports set timeing from vidPn.
+            uint32_t    detachable : 1;                 ///< @brief The adapter supports a detachable device.
+            uint32_t    computeOnly : 1;                ///< @brief The adapter supports a compute-only device.
+            uint32_t    prototype : 1;                  ///< @brief The adapter supports a prototype device.
+            uint32_t    runtimePowerManagement : 1;     ///< @brief The adapter supports a runtime power management device.
+            uint32_t    reserved : 18;                  ///< @brief Reserved for internal use.
+        };
+        uint32_t        flags;                          ///< @brief The flags used to operate over the other members.
+    };
+};
+
+typedef std::vector<AdapterDeviceInfo> AdapterDeviceInfoList;
+
+void show_adapter_device_info(const AdapterDeviceInfo& info, bool details = false);
+bool check_luid(std::string luidstr, LUID& luid);
+bool query_adapters_list(AdapterDeviceInfoList& phyDevices, AdapterDeviceInfoList& indirectDevices, AdapterDeviceInfoList& softwareDevices, bool debug = false);

--- a/sources/apps/enum-adapters/resource.h
+++ b/sources/apps/enum-adapters/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by enum-adapters.rc
+
+// Next default values for new objects
+//
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/sources/apps/idd-setup-tool/ChangeDisplaySettings.cpp
+++ b/sources/apps/idd-setup-tool/ChangeDisplaySettings.cpp
@@ -1,0 +1,224 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ChangeDisplaySettings.h"
+
+#include <sstream>
+#include <algorithm>
+
+using namespace std;
+
+static DPIScalingInfo GetDPIScalingInfo(LUID adapterID, UINT32 sourceID)
+{
+    DISPLAYCONFIG_SOURCE_DPI_SCALE_GET requestPacket = {};
+    requestPacket.header.type = (DISPLAYCONFIG_DEVICE_INFO_TYPE)DISPLAYCONFIG_DEVICE_INFO_TYPE_CUSTOM::DISPLAYCONFIG_DEVICE_INFO_GET_DPI_SCALE;
+    requestPacket.header.size = sizeof(requestPacket);
+    requestPacket.header.adapterId = adapterID;
+    requestPacket.header.id = sourceID;
+
+    auto res = DisplayConfigGetDeviceInfo(&requestPacket.header);
+    if (res != ERROR_SUCCESS)
+    {
+        tstringstream ss;
+        ss << "ERROR: DisplayConfigGetDeviceInfo failed with status " << res << '\n';
+        throw ss.str();
+    }
+
+    requestPacket.curScaleRel = clamp(requestPacket.curScaleRel, requestPacket.minScaleRel, requestPacket.maxScaleRel);
+
+    int32_t min_abs = abs(requestPacket.minScaleRel);
+    if (size(known_dpi) < size_t(min_abs) + requestPacket.maxScaleRel + 1)
+    {
+        tstringstream ss;
+        ss << "ERROR: Invalid index for known DPI array " << (size_t(min_abs) + requestPacket.maxScaleRel)
+            << " while max idx is " << size_t(size(known_dpi) - 1) << '\n';
+        throw ss.str();
+    }
+
+    DPIScalingInfo dpi_info = {};
+
+    dpi_info.current = known_dpi[min_abs + requestPacket.curScaleRel];
+    dpi_info.recommended = known_dpi[min_abs];
+    dpi_info.maximum = known_dpi[min_abs + requestPacket.maxScaleRel];
+
+    return dpi_info;
+}
+
+static void SetDPIScaling(LUID adapterID, UINT32 sourceID, UINT32 dpi_to_set)
+{
+    DPIScalingInfo dPIScalingInfo = GetDPIScalingInfo(adapterID, sourceID);
+
+    dpi_to_set = clamp(dpi_to_set, dPIScalingInfo.minimum, dPIScalingInfo.maximum);
+
+    // Everything is already fine, do nothing
+    if (dpi_to_set == dPIScalingInfo.current)
+        return;
+
+    auto idx_to_set = find(begin(known_dpi), end(known_dpi), dpi_to_set);
+    auto idx_recommended = find(begin(known_dpi), end(known_dpi), dPIScalingInfo.recommended);
+
+    if (idx_to_set == end(known_dpi) || idx_recommended == end(known_dpi))
+    {
+        tstringstream ss;
+        ss << "ERROR: cannot find desired DPI value " << dpi_to_set << '\n';
+        throw ss.str();
+    }
+
+    int64_t dpi_relative = idx_to_set - idx_recommended;
+
+    DISPLAYCONFIG_SOURCE_DPI_SCALE_SET setPacket = {};
+    setPacket.header.adapterId = adapterID;
+    setPacket.header.id = sourceID;
+    setPacket.header.size = sizeof(setPacket);
+    setPacket.header.type = (DISPLAYCONFIG_DEVICE_INFO_TYPE)DISPLAYCONFIG_DEVICE_INFO_TYPE_CUSTOM::DISPLAYCONFIG_DEVICE_INFO_SET_DPI_SCALE;
+    setPacket.scaleRel = (UINT32)dpi_relative;
+
+#if !DRY_RUN
+    auto res = DisplayConfigSetDeviceInfo(&setPacket.header);
+    if (res != ERROR_SUCCESS)
+    {
+        tstringstream ss;
+        ss << "ERROR: DisplayConfigSetDeviceInfo failed with status " << res << '\n';
+        throw ss.str();
+    }
+#endif
+}
+
+void SetDisplayDPI(uint32_t dpi_to_set, bool verbose)
+{
+    vector<DISPLAYCONFIG_PATH_INFO> pathsV;
+    vector<DISPLAYCONFIG_MODE_INFO> modesV;
+
+    LONG status;
+    do
+    {
+        UINT32 flags = QDC_ONLY_ACTIVE_PATHS | QDC_VIRTUAL_MODE_AWARE;
+        UINT32 num_paths = 0, num_modes = 0;
+
+        status = GetDisplayConfigBufferSizes(flags, &num_paths, &num_modes);
+        if (status != ERROR_SUCCESS)
+        {
+            tstringstream ss;
+            ss << "ERROR: GetDisplayConfigBufferSizes failed with code " << status << endl;
+            throw ss.str();
+        }
+
+        if (num_paths == 0 || num_modes == 0)
+        {
+            tstringstream ss;
+            ss << "ERROR: No active display discovered, can't set dpi" << endl;
+            throw ss.str();
+        }
+
+        pathsV.resize(num_paths);
+        modesV.resize(num_modes);
+
+        status = QueryDisplayConfig(flags, &num_paths, pathsV.data(), &num_modes, modesV.data(), nullptr);
+        if (status != ERROR_SUCCESS && status != ERROR_INSUFFICIENT_BUFFER)
+        {
+            tstringstream ss;
+            ss << "ERROR: QueryDisplayConfig failed with code " << status << endl;
+            throw ss.str();
+        }
+        pathsV.resize(num_paths);
+        modesV.resize(num_modes);
+        // It's possible that between the call to GetDisplayConfigBufferSizes and QueryDisplayConfig
+        // that the display state changed, so loop on the case of ERROR_INSUFFICIENT_BUFFER.
+    } while (status == ERROR_INSUFFICIENT_BUFFER);
+
+    for (const auto& path : pathsV)
+    {
+        //get display name
+        auto adapterLUID = path.targetInfo.adapterId;
+        auto sourceID = path.sourceInfo.id;
+
+        DISPLAYCONFIG_TARGET_DEVICE_NAME device_name;
+        if (verbose)
+        {
+            DPIScalingInfo dpi_info = GetDPIScalingInfo(adapterLUID, sourceID);
+
+            device_name.header.size = sizeof(device_name);
+            device_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+            device_name.header.adapterId = adapterLUID;
+            device_name.header.id = path.targetInfo.id;
+
+            if (ERROR_SUCCESS != DisplayConfigGetDeviceInfo(&device_name.header))
+            {
+                tcout << FormatOutput(L"DisplayConfigGetDeviceInfo() failed") << endl;
+            }
+            else
+            {
+                tcout << FormatOutput(L"Device %s:", device_name.monitorFriendlyDeviceName) << endl;
+                tcout << FormatOutputWithOffset(1, L"Current Scaling is %u", dpi_info.current) << endl;
+            }
+            tcout << FormatOutputWithOffset(1, L"Setting Scaling to %u", dpi_to_set) << endl;
+        }
+
+        SetDPIScaling(adapterLUID, sourceID, dpi_to_set);
+
+        if (verbose)
+        {
+            DPIScalingInfo dpi_info = GetDPIScalingInfo(adapterLUID, sourceID);
+            tcout << FormatOutputWithOffset(1, L"Current Scaling for device %s is %u", device_name.monitorFriendlyDeviceName, dpi_info.current) << endl;
+        }
+    }
+}
+
+void SetDisplayResolution(uint32_t width, uint32_t height)
+{
+    DISPLAY_DEVICE displayDevice = {};
+    displayDevice.cb = sizeof(displayDevice);
+
+    for(int sourceID = 0; EnumDisplayDevices(NULL, sourceID, &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME) != 0; sourceID++) {
+        if (EnumDisplayDevices(NULL, sourceID, &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME) == 0) {
+            tstringstream ss;
+            ss << "\t\tERROR: EnumDisplayDevices failed for iDevNum=" << sourceID << endl;
+            throw ss.str();
+        }
+
+        bool targetIsIDDDevice = false;
+        if (wstring(displayDevice.DeviceString).compare(wstring(L"Intel IddSampleDriver Device")) == 0) {
+            targetIsIDDDevice = true;
+        }
+
+        bool targetResolutionIsSupported = false;
+        DEVMODE displaySettingsQuery = { 0 };
+        displaySettingsQuery.dmSize = sizeof(displaySettingsQuery);
+
+        for(int iModeNum = 0; targetResolutionIsSupported == false && EnumDisplaySettings(displayDevice.DeviceName, iModeNum, &displaySettingsQuery) != 0; iModeNum++) {
+            if (displaySettingsQuery.dmPelsWidth == width && displaySettingsQuery.dmPelsHeight == height) {
+                targetResolutionIsSupported = true;
+            }
+        }
+
+        if (targetIsIDDDevice == false) {
+            tcout << FormatOutput(L"Display #%d (SKIP): %s (%s) is not an IDD display", sourceID, displayDevice.DeviceString, displayDevice.DeviceName) << endl;
+        } else if (targetResolutionIsSupported == false) {
+            tcout << FormatOutput(L"Display #%d (SKIP): %s (%s) does not support requested resolution %u by %u", sourceID, displayDevice.DeviceString, displayDevice.DeviceName, width, height) << endl;
+        } else {
+            DEVMODE lpDevMode = {};
+            lpDevMode.dmSize = sizeof(lpDevMode);
+            lpDevMode.dmPelsWidth = (DWORD) width;
+            lpDevMode.dmPelsHeight = (DWORD) height;
+            lpDevMode.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
+            if (ChangeDisplaySettingsEx(displayDevice.DeviceName, &lpDevMode, NULL, 0, NULL) != DISP_CHANGE_SUCCESSFUL) {
+                tcout << FormatOutput(L"Display #%d (FAIL): %s (%s) failed to changed resolution to %u by %u", sourceID, displayDevice.DeviceString, displayDevice.DeviceName, width, height) << endl;
+            } else {
+                tcout << FormatOutput(L"Display #%d (PASS): %s (%s) resolution changed to %u by %u", sourceID, displayDevice.DeviceString, displayDevice.DeviceName, width, height) << endl;
+            }
+        }
+    }
+}

--- a/sources/apps/idd-setup-tool/ChangeDisplaySettings.h
+++ b/sources/apps/idd-setup-tool/ChangeDisplaySettings.h
@@ -1,0 +1,91 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Utility.h"
+
+const UINT32 known_dpi[] = { 100,125,150,175,200,225,250,300,350, 400, 450, 500 };
+
+//our own enum, similar to DISPLAYCONFIG_DEVICE_INFO_TYPE enum in wingdi.h
+enum class DISPLAYCONFIG_DEVICE_INFO_TYPE_CUSTOM : int
+{
+    DISPLAYCONFIG_DEVICE_INFO_GET_DPI_SCALE = -3, //returns min, max, suggested, and currently applied DPI scaling values.
+    DISPLAYCONFIG_DEVICE_INFO_SET_DPI_SCALE = -4, //set current dpi scaling value for a display
+};
+
+/*
+* struct DISPLAYCONFIG_SOURCE_DPI_SCALE_GET
+* @brief used to fetch min, max, suggested, and currently applied DPI scaling values.
+* All values are relative to the recommended DPI scaling value
+* Note that DPI scaling is a property of the source, and not of target.
+*/
+struct DISPLAYCONFIG_SOURCE_DPI_SCALE_GET
+{
+    DISPLAYCONFIG_DEVICE_INFO_HEADER            header;
+    /*
+    * @brief min value of DPI scaling is always 100, minScaleRel gives no. of steps down from recommended scaling
+    * eg. if minScaleRel is -3 => 100 is 3 steps down from recommended scaling => recommended scaling is 175%
+    */
+    int32_t minScaleRel;
+
+    /*
+    * @brief currently applied DPI scaling value wrt the recommended value. eg. if recommended value is 175%,
+    * => if curScaleRel == 0 the current scaling is 175%, if curScaleRel == -1, then current scale is 150%
+    */
+    int32_t curScaleRel;
+
+    /*
+    * @brief maximum supported DPI scaling wrt recommended value
+    */
+    int32_t maxScaleRel;
+};
+
+/*
+* struct DISPLAYCONFIG_SOURCE_DPI_SCALE_SET
+* @brief set DPI scaling value of a source
+* Note that DPI scaling is a property of the source, and not of target.
+*/
+struct DISPLAYCONFIG_SOURCE_DPI_SCALE_SET
+{
+    DISPLAYCONFIG_DEVICE_INFO_HEADER            header;
+    /*
+    * @brief The value we want to set. The value should be relative to the recommended DPI scaling value of source.
+    * eg. if scaleRel == 1, and recommended value is 175% => we are trying to set 200% scaling for the source
+    */
+    int32_t scaleRel;
+};
+
+/*
+* struct DPIScalingInfo
+* @brief DPI info about a source
+* minimum :     minumum DPI scaling in terms of percentage supported by source. Will always be 100%.
+* maximum :     maximum DPI scaling in terms of percentage supported by source. eg. 100%, 150%, etc.
+* current :     currently applied DPI scaling value
+* recommended : DPI scaling value recommended by OS. OS takes resolution, physical size, and expected viewing distance
+*               into account while calculating this, however exact formula is not known, hence must be retrieved from OS
+*               For a system in which user has not explicitly changed DPI, current should equal recommended.
+*/
+struct DPIScalingInfo
+{
+    UINT32 minimum = 100;
+    UINT32 maximum = 100;
+    UINT32 current = 100;
+    UINT32 recommended = 100;
+};
+
+void SetDisplayDPI(uint32_t dpi_to_set = 100, bool verbose = true);
+void SetDisplayResolution(uint32_t width, uint32_t height);

--- a/sources/apps/idd-setup-tool/CommandParserImpl.cpp
+++ b/sources/apps/idd-setup-tool/CommandParserImpl.cpp
@@ -1,0 +1,851 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "CommandParserImpl.h"
+
+CommandParserImpl::CommandParserImpl()
+{
+    this->CurrentCommandNumber = 0;
+}
+
+CommandParserImpl::~CommandParserImpl()
+{
+
+}
+
+CommandStruct& CommandParserImpl::AddCommand(tstring CommandName, tstring CommandAbbreviatedDescription)
+{
+    if (this->MiscCounters.find(TEXT("Commands Offset")) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Commands Offset")] = 0;
+    }
+
+    CommandStruct NewCommand{};
+    NewCommand.CommandName = CommandName;
+    NewCommand.CommandAbbreviatedDescription = CommandAbbreviatedDescription;
+    NewCommand.CommandNumber = this->Commands.size() + 1;
+
+    this->Commands.push_back(NewCommand);
+
+    uint32_t ThisOffset = CommandName.size() + 2;
+
+    if (this->MiscCounters[TEXT("Commands Offset")] < ThisOffset) {
+        this->MiscCounters[TEXT("Commands Offset")] = ThisOffset;
+    }
+
+    this->CommandNumberToNameLookup[NewCommand.CommandNumber] = StringToLowerCase(CommandName);
+    this->CommandNameToNumberLookup[StringToLowerCase(CommandName)] = NewCommand.CommandNumber;
+
+    this->CommandSpecificSwitches[StringToLowerCase(CommandName)] = std::vector<SwitchStruct>();
+    this->CommandSpecificParams[StringToLowerCase(CommandName)] = std::vector<ParamStruct>();
+
+    return this->Commands.back();
+}
+
+void CommandParserImpl::AddGlobalDescription(uint32_t OptionCount, ...)
+{
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        if (i != 0) {
+            GlobalDescription += TEXT("\n");
+        }
+        GlobalDescription += arg;
+    }
+    va_end(args);
+}
+
+void CommandParserImpl::AddCommandSpecificDescription(tstring CommandName, uint32_t OptionCount, ...)
+{
+    uint32_t IndexIntoCommands = this->CommandNameToNumberLookup[StringToLowerCase(CommandName)] - 1;
+
+    CommandStruct *TargetCommand = &this->Commands[IndexIntoCommands];
+
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        if (i != 0) {
+            TargetCommand->CommandDescription += TEXT("\n");
+        }
+        TargetCommand->CommandDescription += arg;
+    }
+    va_end(args);
+}
+
+void CommandParserImpl::AddGlobalBugs(uint32_t OptionCount, ...)
+{
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        if (i != 0) {
+            GlobalBugs += TEXT("\n");
+        }
+        GlobalBugs += arg;
+    }
+    va_end(args);
+}
+
+void CommandParserImpl::AddCommandSpecificBugs(tstring CommandName, uint32_t OptionCount, ...)
+{
+    uint32_t IndexIntoCommands = this->CommandNameToNumberLookup[StringToLowerCase(CommandName)] - 1;
+
+    CommandStruct *TargetCommand = &this->Commands[IndexIntoCommands];
+
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        if (i != 0) {
+            TargetCommand->CommandBugs += TEXT("\n");
+        }
+        TargetCommand->CommandBugs += arg;
+    }
+    va_end(args);
+}
+
+SwitchStruct& CommandParserImpl::AddGlobalSwitch(bool& Switch, tstring HelpMessage, uint32_t OptionCount, ...)
+{
+    if (OptionCount > MAX_ARGUMENT_VARIATIONS) {
+        tcout
+            << FormatOutput(
+                TEXT("Command Parser Error: Attempted to add global switch with %u variations. Exceeds limit of %s variations"),
+                OptionCount,
+                MAX_ARGUMENT_VARIATIONS)
+            << std::endl;
+        exit(1);
+    }
+
+    if (this->MiscCounters.find(TEXT("Global Options Offset")) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Global Options Offset")] = 0;
+    }
+
+    SwitchStruct NewSwitch{};
+    NewSwitch.Target = &Switch;
+    NewSwitch.HelpMessage = HelpMessage;
+    NewSwitch.VariationsCount = OptionCount;
+
+    uint32_t ThisOffset = OptionCount * 2;
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        NewSwitch.OptionsList[i] = tstring(arg);
+        ThisOffset += NewSwitch.OptionsList[i].size();
+    }
+    va_end(args);
+
+    this->GlobalSwitches.push_back(NewSwitch);
+
+    if (this->MiscCounters[TEXT("Global Options Offset")] < ThisOffset) {
+        this->MiscCounters[TEXT("Global Options Offset")] = ThisOffset;
+    }
+
+    return this->GlobalSwitches.back();
+}
+
+ParamStruct& CommandParserImpl::AddGlobalParam(void* Param, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...)
+{
+    if (OptionCount > MAX_ARGUMENT_VARIATIONS) {
+        tcout
+            << FormatOutput(
+                TEXT("Command Parser Error: Attempted to add global param with %u variations. Exceeds limit of %s variations"),
+                OptionCount,
+                MAX_ARGUMENT_VARIATIONS)
+            << std::endl;
+        exit(1);
+    }
+
+    if (this->MiscCounters.find(TEXT("Global Options Offset")) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Global Options Offset")] = 0;
+    }
+
+    ParamStruct NewParam{};
+    NewParam.Target = Param;
+    NewParam.Type = Type;
+    NewParam.Delimiter = Delimiter;
+    NewParam.ArgumentCount = ArgumentCount;
+    NewParam.IgnoreCase = IgnoreCase;
+    NewParam.HelpMessage = HelpMessage;
+    NewParam.VariationsCount = OptionCount;
+
+    TCHAR ExpressionTempString[4096];
+    swprintf(ExpressionTempString, 4096, TEXT(""));
+    if (Type == ArgumentTypes::INTEGER_VECTOR || Type == ArgumentTypes::STRING_VECTOR) {
+        swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), Delimiter.c_str(), Delimiter.c_str());
+    } else {
+        for (int i = 0; i < ArgumentCount; i++) {
+            if (i == 0) {
+                swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+            } else {
+                swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, Delimiter.c_str());
+            }
+        }
+    }
+    tstring ExpressionString = tstring(ExpressionTempString);
+
+    uint32_t ThisOffset = ExpressionString.size() + 3;
+    uint32_t MaxOptionLength = 0;
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        NewParam.OptionsList[i] = tstring(arg);
+        if (NewParam.OptionsList[i].size() > MaxOptionLength) {
+            MaxOptionLength = NewParam.OptionsList[i].size();
+        }
+    }
+    va_end(args);
+    ThisOffset += MaxOptionLength;
+
+    this->GlobalParams.push_back(NewParam);
+
+    if (this->MiscCounters[TEXT("Global Options Offset")] < ThisOffset) {
+        this->MiscCounters[TEXT("Global Options Offset")] = ThisOffset;
+    }
+
+    return this->GlobalParams.back();
+}
+
+ParamStruct& CommandParserImpl::AddCommandSpecificSetting(tstring Command, void* Setting, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...)
+{
+    if (OptionCount > MAX_ARGUMENT_VARIATIONS) {
+        tcout
+            << FormatOutput(
+                TEXT("Command Parser Error: Attempted to add command specific (%s) setting with %u variations. Exceeds limit of %s variations"),
+                Command.c_str(),
+                OptionCount,
+                MAX_ARGUMENT_VARIATIONS)
+            << std::endl;
+        exit(1);
+    }
+
+    if (this->MiscCounters.find(TEXT("Command Specific Settings Offset: ") + StringToLowerCase(Command)) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Command Specific Settings Offset: ") + StringToLowerCase(Command)] = 0;
+    }
+
+    ParamStruct NewSetting{};
+    NewSetting.Target = Setting;
+    NewSetting.Type = Type;
+    NewSetting.Delimiter = Delimiter;
+    NewSetting.ArgumentCount = ArgumentCount;
+    NewSetting.IgnoreCase = IgnoreCase;
+    NewSetting.HelpMessage = HelpMessage;
+    NewSetting.VariationsCount = OptionCount;
+
+    TCHAR ExpressionTempString[4096];
+    swprintf(ExpressionTempString, 4096, TEXT(""));
+    if (Type == ArgumentTypes::INTEGER_VECTOR || Type == ArgumentTypes::STRING_VECTOR) {
+        swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), Delimiter.c_str(), Delimiter.c_str());
+    } else {
+        for (int i = 0; i < ArgumentCount; i++) {
+            if (i == 0) {
+                swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+            } else {
+                swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, Delimiter.c_str());
+            }
+        }
+    }
+    tstring ExpressionString = tstring(ExpressionTempString);
+
+    uint32_t ThisOffset = ExpressionString.size() + 3;
+    uint32_t MaxOptionLength = 0;
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        NewSetting.OptionsList[i] = tstring(arg);
+        if (NewSetting.OptionsList[i].size() > MaxOptionLength) {
+            MaxOptionLength = NewSetting.OptionsList[i].size();
+        }
+    }
+    va_end(args);
+    ThisOffset += MaxOptionLength;
+
+    this->CommandSpecificSettings[StringToLowerCase(Command)].push_back(NewSetting);
+
+    if (this->MiscCounters[TEXT("Command Specific Settings Offset: ") + StringToLowerCase(Command)] < ThisOffset) {
+        this->MiscCounters[TEXT("Command Specific Settings Offset: ") + StringToLowerCase(Command)] = ThisOffset;
+    }
+
+    return this->CommandSpecificSettings[StringToLowerCase(Command)].back();
+}
+
+SwitchStruct& CommandParserImpl::AddCommandSpecificSwitch(tstring Command, bool& Switch, tstring HelpMessage, uint32_t OptionCount, ...)
+{
+    if (OptionCount > MAX_ARGUMENT_VARIATIONS) {
+        tcout
+            << FormatOutput(
+                TEXT("Command Parser Error: Attempted to add command specific (%s) switch with %u variations. Exceeds limit of %s variations"),
+                Command.c_str(),
+                OptionCount,
+                MAX_ARGUMENT_VARIATIONS)
+            << std::endl;
+        exit(1);
+    }
+
+    if (this->MiscCounters.find(TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] = 0;
+    }
+
+    SwitchStruct NewSwitch{};
+    NewSwitch.Target = &Switch;
+    NewSwitch.HelpMessage = HelpMessage;
+    NewSwitch.VariationsCount = OptionCount;
+
+    uint32_t ThisOffset = OptionCount * 2;
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        NewSwitch.OptionsList[i] = tstring(arg);
+        ThisOffset += NewSwitch.OptionsList[i].size();
+    }
+    va_end(args);
+
+    this->CommandSpecificSwitches[StringToLowerCase(Command)].push_back(NewSwitch);
+
+    if (this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] < ThisOffset) {
+        this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] = ThisOffset;
+    }
+
+    return this->CommandSpecificSwitches[StringToLowerCase(Command)].back();
+}
+
+ParamStruct& CommandParserImpl::AddCommandSpecificParam(tstring Command, void* Param, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...)
+{
+    if (OptionCount > MAX_ARGUMENT_VARIATIONS) {
+        tcout
+            << FormatOutput(
+                TEXT("Command Parser Error: Attempted to add command specific (%s) param with %u variations. Exceeds limit of %s variations"),
+                Command.c_str(),
+                OptionCount,
+                MAX_ARGUMENT_VARIATIONS)
+            << std::endl;
+        exit(1);
+    }
+
+    if (this->MiscCounters.find(TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)) == this->MiscCounters.end()) {
+        this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] = 0;
+    }
+
+    ParamStruct NewParam{};
+    NewParam.Target = Param;
+    NewParam.Type = Type;
+    NewParam.Delimiter = Delimiter;
+    NewParam.ArgumentCount = ArgumentCount;
+    NewParam.IgnoreCase = IgnoreCase;
+    NewParam.HelpMessage = HelpMessage;
+    NewParam.VariationsCount = OptionCount;
+
+    TCHAR ExpressionTempString[4096];
+    swprintf(ExpressionTempString, 4096, TEXT(""));
+    if (Type == ArgumentTypes::INTEGER_VECTOR || Type == ArgumentTypes::STRING_VECTOR) {
+        swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), Delimiter.c_str(), Delimiter.c_str());
+    } else {
+        for (int i = 0; i < ArgumentCount; i++) {
+            if (i == 0) {
+                swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+            } else {
+                swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, Delimiter.c_str());
+            }
+        }
+    }
+    tstring ExpressionString = tstring(ExpressionTempString);
+
+    uint32_t ThisOffset = ExpressionString.size() + 3;
+    uint32_t MaxOptionLength = 0;
+    va_list args;
+    va_start(args, OptionCount);
+    for (int i = 0; i < OptionCount; i++) {
+        TCHAR *arg = va_arg(args, TCHAR*);
+        NewParam.OptionsList[i] = tstring(arg);
+        if (NewParam.OptionsList[i].size() > MaxOptionLength) {
+            MaxOptionLength = NewParam.OptionsList[i].size();
+        }
+    }
+    va_end(args);
+    ThisOffset += MaxOptionLength;
+
+    this->CommandSpecificParams[StringToLowerCase(Command)].push_back(NewParam);
+
+    if (this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] < ThisOffset) {
+        this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(Command)] = ThisOffset;
+    }
+
+    return this->CommandSpecificParams[StringToLowerCase(Command)].back();
+}
+
+CommandStruct& CommandParserImpl::SetHidden(CommandStruct& Target)
+{
+    Target.IsHidden = true;
+    return Target;
+}
+
+SwitchStruct& CommandParserImpl::SetHidden(SwitchStruct& Target)
+{
+    Target.IsHidden = true;
+    return Target;
+}
+
+ParamStruct& CommandParserImpl::SetHidden(ParamStruct& Target)
+{
+    Target.IsHidden = true;
+    return Target;
+}
+
+CommandStruct* CommandParserImpl::GetCurrentCommand(void)
+{
+    if (this->CurrentCommandNumber == 0) {
+        return NULL;
+    }
+
+    int32_t IndexIntoCommands = this->CurrentCommandNumber - 1;
+    return &this->Commands[IndexIntoCommands];
+}
+
+bool CommandParserImpl::ParseCommands(int ArgumentCount, char** Arguments)
+{
+    int32_t ProcessedCount = 1;
+    while (ProcessedCount < ArgumentCount) {
+        this->RawArguments.push_back(get_tstring_from_chars(Arguments[ProcessedCount]));
+        if (this->ProcessSingleCommand(get_tstring_from_chars(Arguments[ProcessedCount])) == false) {
+            tcout << TEXT("Invalid Argument Detected: ") << get_tstring_from_chars(Arguments[ProcessedCount]) << std::endl;
+            return false;
+        }
+        ProcessedCount++;
+    }
+
+    // Call child classes constraint function and return result.
+    return this->ConstraintFunction();
+}
+
+tstring CommandParserImpl::FormatHelpMessage(uint32_t Whitespace, tstring Header, tstring Content)
+{
+    // Prepare indentation to insert
+    tstring IndentationString = TEXT("");
+    for (int Indent = 0; Indent < Whitespace; Indent++)
+    {
+        IndentationString += TEXT(" ");
+    }
+    // Prepare the header to insert on first line only
+    while (Header.length() < Whitespace) {
+        Header += TEXT(" ");
+    }
+
+    // Iterate over lines in Content and break them into lines of the max allowed length.
+    int32_t StartLocation = 0;
+    size_t EndLocation = Content.find(TEXT('\n'), StartLocation);
+    tstring IntermediateContent = TEXT("");
+    uint32_t MaxLineLength = HELP_MESSAGE_MAX_LENGTH - Whitespace;
+    while (EndLocation != tstring::npos)
+    {
+        tstring Substring = Content.substr(StartLocation, EndLocation - StartLocation);
+        Substring.erase(remove(begin(Substring), end(Substring), TEXT('\n')), cend(Substring));
+        Substring.erase(remove(begin(Substring), end(Substring), TEXT('\r')), cend(Substring));
+        while (Substring.length() > MaxLineLength) {
+            uint32_t SplitSize = MaxLineLength;
+
+            while (Substring.at(SplitSize + 1) != TEXT(' ')) {
+                SplitSize -= 1;
+            }
+            while (Substring.at(SplitSize) == TEXT(' ')) {
+                SplitSize -= 1;
+            }
+            SplitSize++;
+            tstring SplitSubstring = Substring.substr(0, SplitSize + 1);
+            Substring = Substring.substr(SplitSize + 1);
+            IntermediateContent += SplitSubstring + TEXT("\n");
+        }
+        IntermediateContent += Substring + TEXT("\n");
+        StartLocation = EndLocation + 1;
+        EndLocation = Content.find(TEXT('\n'), StartLocation);
+    }
+    tstring Substring = Content.substr(StartLocation, Content.length() - StartLocation);
+    Substring.erase(remove(begin(Substring), end(Substring), TEXT('\n')), cend(Substring));
+    Substring.erase(remove(begin(Substring), end(Substring), TEXT('\r')), cend(Substring));
+    while (Substring.length() > MaxLineLength + 1) {
+        uint32_t SplitSize = MaxLineLength;
+
+        while (Substring.at(SplitSize + 1) != TEXT(' ')) {
+            SplitSize -= 1;
+        }
+        while (Substring.at(SplitSize) == TEXT(' ')) {
+            SplitSize -= 1;
+        }
+        SplitSize++;
+        tstring SplitSubstring = Substring.substr(0, SplitSize + 1);
+        Substring = Substring.substr(SplitSize + 1);
+        IntermediateContent += SplitSubstring + TEXT("\n");
+    }
+    IntermediateContent += Substring;
+
+    tstring StringToInsert = Header;
+
+    // Iterate over lines in IntermediateContent and insert indentation or the header.
+    StartLocation = 0;
+    EndLocation = IntermediateContent.find(TEXT('\n'), StartLocation);
+    tstring Destination = TEXT("");
+    while (EndLocation != tstring::npos)
+    {
+        tstring Substring = IntermediateContent.substr(StartLocation, EndLocation - StartLocation);
+        Substring.erase(remove(begin(Substring), end(Substring), TEXT('\n')), cend(Substring));
+        Substring.erase(remove(begin(Substring), end(Substring), TEXT('\r')), cend(Substring));
+        Destination += StringToInsert + Substring + TEXT("\n");
+        StartLocation = EndLocation + 1;
+        EndLocation = IntermediateContent.find(TEXT('\n'), StartLocation);
+        StringToInsert = IndentationString;
+    }
+    Substring = IntermediateContent.substr(StartLocation, IntermediateContent.length() - StartLocation);
+    Substring.erase(remove(begin(Substring), end(Substring), TEXT('\n')), cend(Substring));
+    Substring.erase(remove(begin(Substring), end(Substring), TEXT('\r')), cend(Substring));
+    Destination += StringToInsert + Substring;
+
+    return Destination;
+}
+
+void CommandParserImpl::ShowHelpMessage(void)
+{
+    size_t GlobalOptionCount = this->GlobalSwitches.size() + this->GlobalParams.size();
+
+    if (this->CurrentCommandNumber == 0) {
+        tcout << FormatOutput(TEXT("1) %s [<global-options>]"), this->ToolName.c_str()) << std::endl;
+        tcout << FormatOutput(TEXT("2) %s <command> [<options>] [<global-options>]"), this->ToolName.c_str()) << std::endl;
+        tcout << std::endl;
+        tcout << FormatOutput(TEXT("Supported Commands:")) << std::endl;
+        tcout << std::endl;
+
+        for (auto Command : this->Commands) {
+            if (Command.IsHidden) continue;
+            tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(this->MiscCounters[TEXT("Commands Offset")], Command.CommandName, Command.CommandAbbreviatedDescription).c_str()) << std::endl;
+        }
+    } else {
+        int32_t IndexIntoCommands = this->CurrentCommandNumber - 1;
+
+        tstring CurrentCommandName = this->Commands[IndexIntoCommands].CommandName;
+
+        size_t CommandSpecificOptionCount = this->CommandSpecificSwitches[StringToLowerCase(CurrentCommandName)].size() + this->CommandSpecificParams[StringToLowerCase(CurrentCommandName)].size();
+
+        tstring UsageString = FormatString(TEXT("%s %s"), this->ToolName.c_str(), CurrentCommandName.c_str());
+        if (this->CommandSpecificSettings[StringToLowerCase(CurrentCommandName)].size() > 0) {
+            UsageString += FormatString(TEXT(" <settings> ..."));
+        }
+        if (CommandSpecificOptionCount > 0) {
+            UsageString += FormatString(TEXT(" [<options>]"));
+        }
+        if (GlobalOptionCount > 0) {
+            UsageString += FormatString(TEXT(" [<global-options>]"));
+        }
+
+        tcout << FormatOutput(UsageString.c_str()) << std::endl;
+
+        if (this->CommandSpecificSettings[StringToLowerCase(CurrentCommandName)].size() > 0) {
+            tcout << std::endl;
+            tcout << FormatOutput(TEXT("Settings:")) << std::endl;
+            tcout << std::endl;
+
+            uint32_t CommandSpecificSettingsOffset = this->MiscCounters[TEXT("Command Specific Settings Offset: ") + StringToLowerCase(CurrentCommandName)];
+            for (auto CommandSpecificSetting : this->CommandSpecificSettings[StringToLowerCase(CurrentCommandName)]) {
+                if (CommandSpecificSetting.IsHidden) continue;
+                TCHAR ExpressionTempString[4096];
+                swprintf(ExpressionTempString, 4096, TEXT(""));
+                if (CommandSpecificSetting.Type == ArgumentTypes::INTEGER_VECTOR || CommandSpecificSetting.Type == ArgumentTypes::STRING_VECTOR) {
+                    swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), CommandSpecificSetting.Delimiter.c_str(), CommandSpecificSetting.Delimiter.c_str());
+                } else {
+                    for (int i = 0; i < CommandSpecificSetting.ArgumentCount; i++) {
+                        if (i == 0) {
+                            swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+                        } else {
+                            swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, CommandSpecificSetting.Delimiter.c_str());
+                        }
+                    }
+                }
+                tstring ExpressionString = tstring(ExpressionTempString);
+
+                tstring Commands = TEXT("");
+                for (uint32_t Iteration = 0; Iteration < CommandSpecificSetting.VariationsCount; Iteration++) {
+                    tstring SettingCommand = CommandSpecificSetting.OptionsList[Iteration] + TEXT("=") + ExpressionString;
+                    tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(CommandSpecificSettingsOffset, SettingCommand, CommandSpecificSetting.HelpMessage).c_str()) << std::endl;
+                }
+            }
+        }
+
+        if (CommandSpecificOptionCount > 0) {
+            tcout << std::endl;
+            tcout << FormatOutput(TEXT("Options:")) << std::endl;
+            tcout << std::endl;
+
+            uint32_t CommandSpecificOptionsOffset = this->MiscCounters[TEXT("Command Specific Options Offset: ") + StringToLowerCase(CurrentCommandName)];
+            for (auto CommandSpecificSwitch : this->CommandSpecificSwitches[StringToLowerCase(CurrentCommandName)]) {
+                if (CommandSpecificSwitch.IsHidden) continue;
+                tstring Commands = TEXT("");
+                for (uint32_t Iteration = 0; Iteration < CommandSpecificSwitch.VariationsCount; Iteration++) {
+                    tstring SwitchCommand = CommandSpecificSwitch.OptionsList[Iteration];
+                    if (Iteration != 0) {
+                        Commands += tstring(TEXT(", "));
+                    }
+                    Commands += SwitchCommand;
+                }
+                tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(CommandSpecificOptionsOffset, Commands, CommandSpecificSwitch.HelpMessage).c_str()) << std::endl;
+            }
+
+            for (auto CommandSpecificParam : this->CommandSpecificParams[StringToLowerCase(CurrentCommandName)]) {
+                if (CommandSpecificParam.IsHidden) continue;
+                TCHAR ExpressionTempString[4096];
+                swprintf(ExpressionTempString, 4096, TEXT(""));
+                if (CommandSpecificParam.Type == ArgumentTypes::INTEGER_VECTOR || CommandSpecificParam.Type == ArgumentTypes::STRING_VECTOR) {
+                    swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), CommandSpecificParam.Delimiter.c_str(), CommandSpecificParam.Delimiter.c_str());
+                } else {
+                    for (int i = 0; i < CommandSpecificParam.ArgumentCount; i++) {
+                        if (i == 0) {
+                            swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+                        } else {
+                            swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, CommandSpecificParam.Delimiter.c_str());
+                        }
+                    }
+                }
+                tstring ExpressionString = tstring(ExpressionTempString);
+
+                tstring Commands = TEXT("");
+                for (uint32_t Iteration = 0; Iteration < CommandSpecificParam.VariationsCount; Iteration++) {
+                    tstring ParamCommand = CommandSpecificParam.OptionsList[Iteration] + TEXT("=") + ExpressionString;
+                    tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(CommandSpecificOptionsOffset, ParamCommand, CommandSpecificParam.HelpMessage).c_str()) << std::endl;
+                }
+            }
+        }
+    }
+
+    tcout << std::endl;
+    tcout << FormatOutput(TEXT("Globally Available Options:")) << std::endl;
+    tcout << std::endl;
+
+    uint32_t GlobalOptionsOffset = this->MiscCounters[TEXT("Global Options Offset")];
+    for (auto GlobalSwitch : this->GlobalSwitches) {
+        if (GlobalSwitch.IsHidden) continue;
+        tstring Commands = TEXT("");
+        for (uint32_t Iteration = 0; Iteration < GlobalSwitch.VariationsCount; Iteration++) {
+            tstring SwitchCommand = GlobalSwitch.OptionsList[Iteration];
+            if (Iteration != 0) {
+                Commands += tstring(TEXT(", "));
+            }
+            Commands += SwitchCommand;
+        }
+        tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(GlobalOptionsOffset, Commands, GlobalSwitch.HelpMessage).c_str()) << std::endl;
+    }
+
+    for (auto GlobalParam : this->GlobalParams) {
+        if (GlobalParam.IsHidden) continue;
+        TCHAR ExpressionTempString[4096];
+        swprintf(ExpressionTempString, 4096, TEXT(""));
+        if (GlobalParam.Type == ArgumentTypes::INTEGER_VECTOR || GlobalParam.Type == ArgumentTypes::STRING_VECTOR) {
+            swprintf(ExpressionTempString, 4096, TEXT("<VALUE>%s<VALUE>%s..."), GlobalParam.Delimiter.c_str(), GlobalParam.Delimiter.c_str());
+        } else {
+            for (int i = 0; i < GlobalParam.ArgumentCount; i++) {
+                if (i == 0) {
+                    swprintf(ExpressionTempString, 4096, TEXT("%s<VALUE>"), ExpressionTempString);
+                } else {
+                    swprintf(ExpressionTempString, 4096, TEXT("%s%s<VALUE>"), ExpressionTempString, GlobalParam.Delimiter.c_str());
+                }
+            }
+        }
+        tstring ExpressionString = tstring(ExpressionTempString);
+
+        tstring Commands = TEXT("");
+        for (uint32_t Iteration = 0; Iteration < GlobalParam.VariationsCount; Iteration++) {
+            tstring ParamCommand = GlobalParam.OptionsList[Iteration] + TEXT("=") + ExpressionString;
+            tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(GlobalOptionsOffset, ParamCommand, GlobalParam.HelpMessage).c_str()) << std::endl;
+        }
+    }
+
+    tstring DescriptionString = TEXT("");
+
+    if (this->CurrentCommandNumber != 0) {
+        int32_t IndexIntoCommands = this->CurrentCommandNumber - 1;
+        DescriptionString += this->Commands[IndexIntoCommands].CommandDescription;
+    } else {
+        DescriptionString += this->GlobalDescription;
+    }
+
+    if (DescriptionString.length() != 0) {
+        tcout << std::endl;
+        tcout << FormatOutput(TEXT("Description:")) << std::endl;
+        tcout << std::endl;
+        tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(0, TEXT(""), DescriptionString).c_str()) << std::endl;
+    }
+
+    tstring BugsString = TEXT("");
+
+    if (this->CurrentCommandNumber != 0) {
+        int32_t IndexIntoCommands = this->CurrentCommandNumber - 1;
+        BugsString += this->Commands[IndexIntoCommands].CommandBugs;
+    } else {
+        BugsString += this->GlobalBugs;
+    }
+
+    if (BugsString.length() != 0) {
+        tcout << std::endl;
+        tcout << FormatOutput(TEXT("Bugs:")) << std::endl;
+        tcout << std::endl;
+        tcout << FormatOutputWithOffset(1, TEXT("%s"), this->FormatHelpMessage(0, TEXT(""), BugsString).c_str()) << std::endl;
+    }
+
+}
+
+bool CommandParserImpl::ExtractAndStoreParamInfo(ParamStruct& Param, tstring Arguments)
+{
+    int32_t DelimiterCount = 0;
+    size_t DelimiterLocation = 0;
+    while (Arguments.size() > 0) {
+        size_t NextDelimiterLocation = Arguments.find(Param.Delimiter, DelimiterLocation);
+        tstring ArgumentsSegment;
+
+        if (NextDelimiterLocation != tstring::npos && Param.Delimiter.size() > 0) {
+            ArgumentsSegment = Arguments.substr(DelimiterLocation, NextDelimiterLocation);
+            Arguments = tstring(Arguments.begin() + NextDelimiterLocation + Param.Delimiter.size(), Arguments.end());
+        } else {
+            ArgumentsSegment = Arguments;
+            Arguments = TEXT("");
+        }
+
+        if (Param.IgnoreCase) {
+            ArgumentsSegment = StringToLowerCase(ArgumentsSegment);
+        }
+
+        if (Param.Type == ArgumentTypes::STRING) {
+            tstring *Target = (tstring *) Param.Target;
+            Target[DelimiterCount] = ArgumentsSegment;
+        } else if (Param.Type == ArgumentTypes::INTEGER) {
+            int32_t *Target = (int *) Param.Target;
+            Target[DelimiterCount] = get_int_from_tstring(ArgumentsSegment);
+        } else if (Param.Type == ArgumentTypes::STRING_VECTOR) {
+            std::vector<tstring> *Target = (std::vector<tstring> *) Param.Target;
+            Target->push_back(ArgumentsSegment);
+        } else if (Param.Type == ArgumentTypes::INTEGER_VECTOR) {
+            std::vector<int32_t> *Target = (std::vector<int> *) Param.Target;
+            Target->push_back(get_int_from_tstring(ArgumentsSegment));
+        } else if (Param.Type == ArgumentTypes::PATH) {
+            std::filesystem::path* Target = (std::filesystem::path*)Param.Target;
+            Target[DelimiterCount] = ArgumentsSegment;
+        }
+        DelimiterCount++;
+    }
+
+    if (Param.ArgumentCount != 0 && DelimiterCount != Param.ArgumentCount) {
+        return false;
+    } else if (Param.ArgumentCount == 0 && DelimiterCount == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+bool CommandParserImpl::ProcessSingleCommand(tstring CommandLineArgument)
+{
+    if (this->CheckForGlobalOptions(CommandLineArgument)) {
+        return true;
+    }
+
+    if (this->CurrentCommandNumber == 0) {
+        if (this->CheckForCommandChange(CommandLineArgument)) {
+            return true;
+        }
+    }
+
+    return this->CheckForCommandSpecificOptions(CommandLineArgument);
+}
+
+bool CommandParserImpl::CheckForGlobalOptions(tstring CommandLineArgument)
+{
+    for (auto GlobalParam : this->GlobalParams) {
+        for (uint32_t Iteration = 0; Iteration < GlobalParam.VariationsCount; Iteration++) {
+            tstring ParamCommand = StringToLowerCase(GlobalParam.OptionsList[Iteration]) + TEXT("=");
+            if (StringToLowerCase(CommandLineArgument).find(ParamCommand) != tstring::npos) {
+                if (ExtractAndStoreParamInfo(GlobalParam, CommandLineArgument.substr(ParamCommand.size())) == false) {
+                    tcout << FormatOutput(TEXT("ERROR: Command line global parameter \"%s\" violated constraints. See --help option."), CommandLineArgument.c_str());
+                }
+                // No need to reprocess variants of this param.
+                Iteration = GlobalParam.VariationsCount;
+                return true;
+            }
+        }
+    }
+
+    for (auto GlobalSwitch : this->GlobalSwitches) {
+        for (uint32_t Iteration = 0; Iteration < GlobalSwitch.VariationsCount; Iteration++) {
+            tstring SwitchCommand = GlobalSwitch.OptionsList[Iteration];
+            if (StringToLowerCase(CommandLineArgument) == StringToLowerCase(SwitchCommand)) {
+                *GlobalSwitch.Target = true;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool CommandParserImpl::CheckForCommandSpecificOptions(tstring CommandLineArgument)
+{
+    int32_t IndexIntoCommands = this->CurrentCommandNumber - 1;
+    tstring CurrentCommandName = StringToLowerCase(this->Commands[IndexIntoCommands].CommandName);
+    for (auto CommandSpecificSetting : this->CommandSpecificSettings[CurrentCommandName]) {
+        for (uint32_t Iteration = 0; Iteration < CommandSpecificSetting.VariationsCount; Iteration++) {
+            tstring SettingCommand = StringToLowerCase(CommandSpecificSetting.OptionsList[Iteration]) + TEXT("=");
+            if (StringToLowerCase(CommandLineArgument).find(SettingCommand) != tstring::npos) {
+                if (ExtractAndStoreParamInfo(CommandSpecificSetting, CommandLineArgument.substr(SettingCommand.size())) == false) {
+                    tcout << FormatOutput(TEXT("ERROR: Command line command specific setting \"%s\" violated constraints. See --help option for the current command."), CommandLineArgument.c_str());
+                }
+                // No need to reprocess variants of this setting.
+                Iteration = CommandSpecificSetting.VariationsCount;
+                return true;
+            }
+        }
+    }
+
+    for (auto CommandSpecificParam : this->CommandSpecificParams[CurrentCommandName]) {
+        for (uint32_t Iteration = 0; Iteration < CommandSpecificParam.VariationsCount; Iteration++) {
+            tstring ParamCommand = StringToLowerCase(CommandSpecificParam.OptionsList[Iteration]) + TEXT("=");
+            if (StringToLowerCase(CommandLineArgument).find(ParamCommand) != tstring::npos) {
+                if (ExtractAndStoreParamInfo(CommandSpecificParam, CommandLineArgument.substr(ParamCommand.size())) == false) {
+                    tcout << FormatOutput(TEXT("ERROR: Command line command specific parameter \"%s\" violated constraints. See --help option for the current command."), CommandLineArgument.c_str());
+                }
+                // No need to reprocess variants of this param.
+                Iteration = CommandSpecificParam.VariationsCount;
+                return true;
+            }
+        }
+    }
+
+    for (auto CommandSpecificSwitch : this->CommandSpecificSwitches[CurrentCommandName]) {
+        for (uint32_t Iteration = 0; Iteration < CommandSpecificSwitch.VariationsCount; Iteration++) {
+            tstring SwitchCommand = CommandSpecificSwitch.OptionsList[Iteration];
+            if (StringToLowerCase(CommandLineArgument) == StringToLowerCase(SwitchCommand)) {
+                *CommandSpecificSwitch.Target = true;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool CommandParserImpl::CheckForCommandChange(tstring CommandLineArgument)
+{
+    if (this->CommandNameToNumberLookup.find(StringToLowerCase(CommandLineArgument)) != this->CommandNameToNumberLookup.end()) {
+        this->CurrentCommandNumber = this->CommandNameToNumberLookup[StringToLowerCase(CommandLineArgument)];
+        return true;
+    }
+    return false;
+}

--- a/sources/apps/idd-setup-tool/CommandParserImpl.h
+++ b/sources/apps/idd-setup-tool/CommandParserImpl.h
@@ -1,0 +1,130 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef _COMMAND_PARSER_IMPL_H_
+#define _COMMAND_PARSER_IMPL_H_
+
+#include <unordered_map>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <list>
+#include <algorithm>
+#include <tuple>
+#include <sstream>
+
+#include <windows.h>
+#include <Wingdi.h>
+#include <Winuser.h>
+#include <SetupAPI.h>
+#include <stringapiset.h>
+#include "Utility.h"
+
+#define MAX_OPTIONS_PER_COMMAND 10
+typedef struct COMMAND_STRUCT {
+    uint32_t CommandNumber;
+    tstring CommandName;
+    tstring CommandAbbreviatedDescription;
+    tstring CommandDescription;
+    tstring CommandBugs;
+    bool IsHidden = false;
+} CommandStruct;
+
+#define MAX_ARGUMENT_VARIATIONS 3
+typedef struct SWITCH_STRUCT {
+    bool *Target;
+    tstring OptionsList[MAX_ARGUMENT_VARIATIONS];
+    uint32_t VariationsCount;
+    tstring HelpMessage;
+    bool IsHidden = false;
+} SwitchStruct;
+
+enum ArgumentTypes {
+    NONE           = 0x0,
+    STRING         = 0x1,
+    INTEGER        = 0x2,
+    STRING_VECTOR  = 0x3,
+    INTEGER_VECTOR = 0x4,
+    PATH           = 0x5,
+};
+
+typedef struct PARAM_STRUCT {
+    void *Target;
+    ArgumentTypes Type = ArgumentTypes::NONE;
+    tstring OptionsList[MAX_ARGUMENT_VARIATIONS];
+    tstring Delimiter;
+    uint32_t ArgumentCount;
+    bool IgnoreCase = false;
+    uint32_t VariationsCount;
+    tstring HelpMessage;
+    bool IsHidden = false;
+} ParamStruct;
+
+#define HELP_MESSAGE_MAX_LENGTH 110
+
+class CommandParserImpl {
+private:
+    uint32_t CurrentCommandNumber;
+    tstring GlobalDescription;
+    tstring GlobalBugs;
+
+    std::unordered_map<tstring, uint32_t> MiscCounters;
+
+    std::vector<CommandStruct> Commands;
+    std::unordered_map<uint32_t, tstring> CommandNumberToNameLookup;
+    std::unordered_map<tstring, uint32_t> CommandNameToNumberLookup;
+    std::vector<SwitchStruct> GlobalSwitches;
+    std::vector<ParamStruct> GlobalParams;
+    std::unordered_map<tstring, std::vector<ParamStruct>> CommandSpecificSettings;
+    std::unordered_map<tstring, std::vector<SwitchStruct>> CommandSpecificSwitches;
+    std::unordered_map<tstring, std::vector<ParamStruct>> CommandSpecificParams;
+
+    bool    ExtractAndStoreParamInfo(ParamStruct& Param, tstring Arguments);
+    bool    ProcessSingleCommand(tstring CommandLineArgument);
+    bool    CheckForGlobalOptions(tstring CommandLineArgument);
+    bool    CheckForCommandSpecificOptions(tstring CommandLineArgument);
+    bool    CheckForCommandChange(tstring CommandLineArgument);
+    tstring FormatHelpMessage(uint32_t Whitespace, tstring Header, tstring Content);
+protected:
+    tstring ToolName = TEXT("");
+    std::vector<tstring> RawArguments;
+
+    CommandStruct& AddCommand(tstring CommandName, tstring CommandAbbreviatedDescription);
+    void           AddGlobalDescription(uint32_t OptionCount, ...);
+    void           AddCommandSpecificDescription(tstring CommandName, uint32_t OptionCount, ...);
+    void           AddGlobalBugs(uint32_t OptionCount, ...);
+    void           AddCommandSpecificBugs(tstring CommandName, uint32_t OptionCount, ...);
+    SwitchStruct&  AddGlobalSwitch(bool& Switch, tstring HelpMessage, uint32_t OptionCount, ...);
+    ParamStruct&   AddGlobalParam(void* Param, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...);
+    ParamStruct& AddCommandSpecificSetting(tstring Command, void* Setting, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...);
+    SwitchStruct&  AddCommandSpecificSwitch(tstring Command, bool& Switch, tstring HelpMessage, uint32_t OptionCount, ...);
+    ParamStruct&   AddCommandSpecificParam(tstring Command, void* Param, ArgumentTypes Type, bool IgnoreCase, tstring Delimiter, uint32_t ArgumentCount, tstring HelpMessage, uint32_t OptionCount, ...);
+    CommandStruct& SetHidden(CommandStruct& Target);
+    SwitchStruct&  SetHidden(SwitchStruct& Target);
+    ParamStruct&   SetHidden(ParamStruct& Target);
+    CommandStruct* GetCurrentCommand(void);
+
+    // This must be defined by inheriting classes.
+    // Handle any fixed constraints like if mode=X this setting must be set, or running A must also run B.
+    virtual bool ConstraintFunction(void) = 0;
+public:
+    CommandParserImpl(void);
+    ~CommandParserImpl(void);
+    bool ParseCommands(int ArgumentCount, char** Arguments);
+    void ShowHelpMessage(void);
+};
+
+#endif // _COMMAND_PARSER_IMPL_H_

--- a/sources/apps/idd-setup-tool/EnableDisableAdapters.cpp
+++ b/sources/apps/idd-setup-tool/EnableDisableAdapters.cpp
@@ -1,0 +1,584 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "EnableDisableAdapters.h"
+
+#include <windows.h>
+#include <tchar.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <setupapi.h>
+#include <regstr.h>
+#include <infstr.h>
+#include <cfgmgr32.h>
+#include <string.h>
+#include <malloc.h>
+#include <newdev.h>
+#include <objbase.h>
+#include <strsafe.h>
+#include <io.h>
+#include <fcntl.h>
+
+#include <memory>
+#include <sstream>
+using namespace std;
+
+#pragma comment (lib , "Setupapi.lib")
+
+//////////////////////////////////////////////////////////////////////////
+//
+//////////////////////////////////////////////////////////////////////////
+
+static void MSG_LISTCLASS_NOCLASS_LOCAL(const tstring& class_name)
+{
+    tcout << FormatOutputWithOffset(1, L"ERROR: There is no %s setup class on the local machine", class_name.c_str()) << endl;
+}
+
+static void MSG_LISTCLASS_HEADER_NONE_LOCAL(const tstring& class_name, const tstring& class_descr)
+{
+    tcout << FormatOutputWithOffset(1, L"ERROR: There are no devices in setup class %s (%s)", class_name.c_str(), class_descr.c_str()) << endl;
+}
+
+static void MSG_LISTCLASS_HEADER_LOCAL(DWORD dev_count, const tstring& class_name, const tstring& class_descr)
+{
+    tcout << FormatOutputWithOffset(1, L"Listing %lu devices in setup class %s (%s)", dev_count, class_name.c_str(), class_descr.c_str()) << endl;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// All taken from devcon.cpp from github
+//////////////////////////////////////////////////////////////////////////
+
+static string data_type_to_string(DWORD data_type)
+{
+    switch (data_type)
+    {
+    case REG_NONE:
+        return "REG_NONE";
+    case REG_SZ:
+        return "REG_SZ";
+    case REG_EXPAND_SZ:
+        return "REG_EXPAND_SZ";
+    case REG_BINARY:
+        return "REG_BINARY";
+    case REG_DWORD:
+        return "REG_DWORD / REG_DWORD_LITTLE_ENDIAN";
+    case REG_DWORD_BIG_ENDIAN:
+        return "REG_DWORD_BIG_ENDIAN";
+    case REG_LINK:
+        return "REG_LINK";
+    case REG_MULTI_SZ:
+        return "REG_MULTI_SZ";
+    case REG_RESOURCE_LIST:
+        return "REG_RESOURCE_LIST";
+    case REG_FULL_RESOURCE_DESCRIPTOR:
+        return "REG_FULL_RESOURCE_DESCRIPTOR";
+    case REG_RESOURCE_REQUIREMENTS_LIST:
+        return "REG_RESOURCE_REQUIREMENTS_LIST";
+    case REG_QWORD:
+        return "REG_QWORD / REG_QWORD_LITTLE_ENDIAN";
+    default:
+        return "Unknown";
+    }
+}
+
+static tstring GetDeviceStringProperty(_In_ HDEVINFO Devs, _In_ PSP_DEVINFO_DATA DevInfo, _In_ DWORD Prop)
+{
+    vector<TCHAR> buffer((1024 / sizeof(TCHAR)) + 1);
+
+    DWORD reqSize, dataType;
+    while (!SetupDiGetDeviceRegistryProperty(Devs, DevInfo, Prop, &dataType, (LPBYTE)buffer.data(), (DWORD)buffer.size() * sizeof(TCHAR), &reqSize))
+    {
+        auto err = GetLastError();
+        if (err != ERROR_INSUFFICIENT_BUFFER)
+        {
+            GetLastErrorAndThrow(TEXT("SetupDiGetDeviceRegistryProperty"));
+        }
+        if (dataType == REG_SZ) {
+            // Do nothing
+        } else if (dataType == REG_MULTI_SZ) {
+            // Do nothing
+        } else {
+            tstringstream ss;
+            ss << "ERROR: SetupDiGetDeviceRegistryProperty returned data type " << dataType << " (" << data_type_to_string(REG_SZ).c_str() << ") "
+                << "but expected type " << REG_SZ << " (REG_SZ) or " << REG_MULTI_SZ << " (REG_MULTI_SZ)\n";
+            throw ss.str();
+        }
+        buffer.resize((reqSize / sizeof(TCHAR)) + 1);
+    }
+    buffer.back() = TEXT('\0');
+
+    return tstring(begin(buffer), end(buffer));
+}
+
+static tstring GetDeviceDescription(_In_ HDEVINFO Devs, _In_ PSP_DEVINFO_DATA DevInfo)
+{
+    tstring desc;
+
+    try
+    {
+        desc = GetDeviceStringProperty(Devs, DevInfo, SPDRP_FRIENDLYNAME);
+    }
+    catch (...)
+    {
+        desc = GetDeviceStringProperty(Devs, DevInfo, SPDRP_DEVICEDESC);
+    }
+    return desc;
+}
+
+static tstring GetDeviceHardwareID(_In_ HDEVINFO Devs, _In_ PSP_DEVINFO_DATA DevInfo)
+{
+    return GetDeviceStringProperty(Devs, DevInfo, SPDRP_HARDWAREID);
+}
+
+static tstring GetDeviceID(_In_ HDEVINFO Devs, _In_ PSP_DEVINFO_DATA DevInfo)
+{
+    tstring device_id;
+    TCHAR devID[MAX_DEVICE_ID_LEN] = {};
+
+    SP_DEVINFO_LIST_DETAIL_DATA devInfoListDetail;
+    devInfoListDetail.cbSize = sizeof(devInfoListDetail);
+
+    if ((!SetupDiGetDeviceInfoListDetail(Devs, &devInfoListDetail)) ||
+        (CM_Get_Device_ID_Ex(DevInfo->DevInst, devID, MAX_DEVICE_ID_LEN, 0, devInfoListDetail.RemoteMachineHandle) != CR_SUCCESS))
+    {
+        StringCchCopy(devID, ARRAYSIZE(devID), TEXT("?"));
+    }
+
+    return tstring(devID);
+}
+
+static VOID DumpDevice(_In_ HDEVINFO Devs, _In_ PSP_DEVINFO_DATA DevInfo, _In_ Adapter &adapter)
+{
+    tcout << FormatOutputWithOffset(1, L"Device Name: %s", adapter.devName.c_str()) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device ID         : %s", adapter.devID.c_str()) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device Hardware ID: %s", adapter.devHardwareID.c_str()) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device GUID       : {%08lX-%04hX-%04hX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX}",
+        adapter.devGuid.Data1, adapter.devGuid.Data2, adapter.devGuid.Data3,
+        adapter.devGuid.Data4[0], adapter.devGuid.Data4[1], adapter.devGuid.Data4[2], adapter.devGuid.Data4[3],
+        adapter.devGuid.Data4[4], adapter.devGuid.Data4[5], adapter.devGuid.Data4[6], adapter.devGuid.Data4[7]) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device Index      : %d", adapter.devIndex) << endl;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+//////////////////////////////////////////////////////////////////////////
+
+static std::unordered_map<tstring, uint32_t> PatternMatchCounts {};
+static std::unordered_map<tstring, std::vector<tstring>> DeviceIDsForIndexedPatterns {};
+
+static void CheckEnableDisablePatternMatches(tstring device_name, tstring device_id, bool verbose)
+{
+    if (verbose) {
+        tcout << FormatOutputWithOffset(2, L"Adapter can be enabled and disabled with patterns:") << endl;
+    }
+    for (EnableDisablePatternStruct& pattern : SupportedEnableDisablePatterns) {
+        for (tstring sub_pattern : pattern.AdaptersToMatch) {
+            bool matches_this_pattern = false;
+            if (pattern.PatternType == ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION &&
+                CheckIfStringContainsPattern(device_name, sub_pattern, true) != pattern.IsAnInvertedTarget) {
+                matches_this_pattern = true;
+            } else if (pattern.PatternType == ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID &&
+                CheckIfStringContainsPattern(device_id, sub_pattern, true) != pattern.IsAnInvertedTarget) {
+                matches_this_pattern = true;
+            }
+            if (matches_this_pattern) {
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(3, L"%s", pattern.Abbreviation.c_str()) << endl;
+                }
+                if (PatternMatchCounts.find(pattern.Abbreviation) == PatternMatchCounts.end()) {
+                    PatternMatchCounts[pattern.Abbreviation] = 1;
+                    DeviceIDsForIndexedPatterns[pattern.Abbreviation] = std::vector<tstring>();
+                } else {
+                    PatternMatchCounts[pattern.Abbreviation]++;
+                }
+                DeviceIDsForIndexedPatterns[pattern.Abbreviation].push_back(device_id);
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(3, L"%s%u", pattern.Abbreviation.c_str(), PatternMatchCounts[pattern.Abbreviation]) << endl;
+                }
+                break;
+            }
+        }
+    }
+}
+
+std::vector<Adapter> GetAdapterList(bool verbose)
+{
+    vector<Adapter> out_list;
+
+    PatternMatchCounts.clear();
+    DeviceIDsForIndexedPatterns.clear();
+
+    vector<tstring> k_ARGS = { TEXT("Display") };
+
+    for (auto& arg : k_ARGS)
+    {
+        if (arg.empty())
+            continue;
+
+        //
+        // there could be one to many name to GUID mapping
+        //
+        vector<GUID> guids(16);
+        DWORD num_guids = 0;
+        while (!SetupDiClassGuidsFromNameEx(arg.data(), guids.data(), (DWORD)guids.size(), &num_guids, NULL, NULL))
+        {
+            auto err = GetLastError();
+            if (err != ERROR_INSUFFICIENT_BUFFER)
+            {
+                GetLastErrorAndThrow(TEXT("SetupDiClassGuidsFromNameEx"));
+            }
+            guids.resize(num_guids);
+        }
+        guids.resize(num_guids);
+
+        if (guids.empty())
+        {
+            if (verbose)
+                MSG_LISTCLASS_NOCLASS_LOCAL(arg);
+
+            continue;
+        }
+
+        for (auto& guid : guids)
+        {
+            SP_DEVINFO_DATA devInfo;
+
+            HDEVINFO devs = SetupDiGetClassDevsEx(&guid, NULL, NULL, DIGCF_PRESENT, NULL, NULL, NULL);
+
+            if (devs == INVALID_HANDLE_VALUE)
+            {
+                GetLastErrorAndThrow(TEXT("SetupDiGetClassDevsEx"));
+            }
+
+            ClassDevsScopedStorage scoped_devs(devs);
+
+            //
+            // count number of devices
+            //
+            devInfo.cbSize = sizeof(devInfo);
+            DWORD devCount = 0;
+            for (; SetupDiEnumDeviceInfo(devs, devCount, &devInfo); ++devCount)
+            {
+            }
+
+            TCHAR className[MAX_CLASS_NAME_LEN] = {};
+            if (!SetupDiClassNameFromGuidEx(&guid, className, MAX_CLASS_NAME_LEN, NULL, NULL, NULL))
+            {
+                if (FAILED(StringCchCopy(className, MAX_CLASS_NAME_LEN, TEXT("?"))))
+                {
+                    GetLastErrorAndThrow(TEXT("SetupDiClassNameFromGuidEx"));
+                }
+            }
+
+            TCHAR classDesc[LINE_LEN] = {};
+            if (!SetupDiGetClassDescriptionEx(&guid, classDesc, LINE_LEN, NULL, NULL, NULL))
+            {
+                if (FAILED(StringCchCopy(classDesc, LINE_LEN, className)))
+                {
+                    GetLastErrorAndThrow(TEXT("SetupDiGetClassDescriptionEx"));
+                }
+            }
+
+            //
+            // how many devices?
+            //
+            if (!devCount)
+            {
+                MSG_LISTCLASS_HEADER_NONE_LOCAL(className, classDesc);
+                continue;
+            }
+
+            // only if we want info output
+            if (verbose)
+                MSG_LISTCLASS_HEADER_LOCAL(devCount, className, classDesc);
+
+            for (int devIndex = 0; SetupDiEnumDeviceInfo(devs, devIndex, &devInfo); devIndex++)
+            {
+                Adapter a;
+                a.devID = GetDeviceID(devs, &devInfo);
+                a.devName = GetDeviceDescription(devs, &devInfo);
+                a.devHardwareID = GetDeviceHardwareID(devs, &devInfo);
+                a.devGuid = guid;
+                a.devIndex = devIndex;
+
+                out_list.push_back(a);
+
+                if (verbose) {
+                    DumpDevice(devs, &devInfo, out_list.back());
+                }
+                CheckEnableDisablePatternMatches(out_list.back().devName, out_list.back().devID, verbose);
+            }
+        }
+    }
+
+    return out_list;
+}
+
+size_t GetNumIddCompatibleAdapters(std::vector<Adapter> &adapter_list)
+{
+    size_t num_idd_compatible_adapters = 0;
+    for (auto& adapter : adapter_list) {
+        tstring hardware_id = StringToLowerCase(adapter.devHardwareID);
+        if (
+            hardware_id.find(tstring(TEXT("ven_8086"))) != tstring::npos &&
+            hardware_id.find(tstring(TEXT("dev_56c1"))) != tstring::npos
+        ) {
+            num_idd_compatible_adapters++;
+        } else if (
+            hardware_id.find(tstring(TEXT("ven_8086"))) != tstring::npos &&
+            hardware_id.find(tstring(TEXT("dev_56c0"))) != tstring::npos
+        ) {
+            num_idd_compatible_adapters++;
+        }
+    }
+    return num_idd_compatible_adapters;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//
+//////////////////////////////////////////////////////////////////////////
+
+static void ChangeAdapterState(const Adapter& dev, bool bEnable, bool verbose = true)
+{
+    HDEVINFO devs = SetupDiGetClassDevsEx(&dev.devGuid, NULL, NULL, DIGCF_PRESENT, NULL, NULL, NULL);
+
+    if (devs == INVALID_HANDLE_VALUE)
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiGetClassDevsEx"));
+    }
+
+    ClassDevsScopedStorage scoped_devs(devs);
+
+    SP_DEVINFO_DATA DevInfo;
+    DevInfo.cbSize = sizeof(DevInfo);
+
+    bool bFound = false;
+    for (int devIndex = 0; SetupDiEnumDeviceInfo(devs, devIndex, &DevInfo); devIndex++)
+    {
+        tstring thisId = GetDeviceID(devs, &DevInfo);
+        if (dev.devID.compare(thisId) == 0)
+        {
+            bFound = true;
+            break;
+        }
+    }
+
+    if (!bFound)
+    {
+        tstringstream ss;
+        ss << "ERROR: couldn't find device " << dev.devName << " [ID: " << dev.devID << ", idx: " << dev.devIndex << "]\n";
+
+        throw ss.str();
+    }
+
+    SP_PROPCHANGE_PARAMS pcp;
+    SP_DEVINSTALL_PARAMS devParams;
+    if (bEnable)
+    {
+        //
+        // enable both on global and config-specific profile
+        // do global first and see if that succeeded in enabling the device
+        // (global enable doesn't mark reboot required if device is still
+        // disabled on current config whereas vice-versa isn't true)
+        //
+        pcp.ClassInstallHeader.cbSize = sizeof(SP_CLASSINSTALL_HEADER);
+        pcp.ClassInstallHeader.InstallFunction = DIF_PROPERTYCHANGE;
+        pcp.StateChange = DICS_ENABLE;
+        pcp.Scope = DICS_FLAG_GLOBAL;
+        pcp.HwProfile = 0;
+        //
+        // don't worry if this fails, we'll get an error when we try config-
+        // specific.
+#if !DRY_RUN
+        if (SetupDiSetClassInstallParams(devs, &DevInfo, &pcp.ClassInstallHeader, sizeof(pcp)))
+        {
+            SetupDiCallClassInstaller(DIF_PROPERTYCHANGE, devs, &DevInfo);
+        }
+#endif
+    }
+
+    // operate on config-specific profile
+    pcp.ClassInstallHeader.cbSize = sizeof(SP_CLASSINSTALL_HEADER);
+    pcp.ClassInstallHeader.InstallFunction = DIF_PROPERTYCHANGE;
+    pcp.StateChange = bEnable ? DICS_ENABLE : DICS_DISABLE;
+    pcp.Scope = DICS_FLAG_CONFIGSPECIFIC;
+    pcp.HwProfile = 0;
+
+#if !DRY_RUN
+    if (SetupDiSetClassInstallParams(devs, &DevInfo, &pcp.ClassInstallHeader, sizeof(pcp)))
+    {
+        if (!SetupDiCallClassInstaller(DIF_PROPERTYCHANGE, devs, &DevInfo))
+        {
+            GetLastErrorAndThrow(TEXT("SetupDiCallClassInstaller"));
+        }
+    }
+    else
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiSetClassInstallParams"));
+    }
+#endif
+
+    // see if device needs reboot
+    devParams.cbSize = sizeof(devParams);
+
+#if !DRY_RUN
+    if (verbose)
+    {
+        if (SetupDiGetDeviceInstallParams(devs, &DevInfo, &devParams))
+        {
+            tcout << FormatOutputWithOffset(3, L"State change successful. Reboot is %s", ((devParams.Flags & (DI_NEEDRESTART | DI_NEEDREBOOT)) ? L"REQUIRED" : L"NOT REQUIRED")) << endl;
+        }
+        else
+        {
+            GetLastErrorAndThrow(TEXT("SetupDiGetDeviceInstallParams"));
+        }
+    }
+#endif
+}
+
+void EnableDisableAdapter(vector<Adapter>& adapter_list, adapter_target_info_t& target_info, bool enable, bool verbose)
+{
+    tstring enable_keyword = tstring((enable ? TEXT("enable") : TEXT("disable")));
+    tstring invert_target_keyword = tstring((target_info.is_an_inverted_target ? TEXT("dont match") : TEXT("match")));
+
+    if (verbose) {
+        tcout << FormatOutputWithOffset(1, L"Target Name: %s", target_info.pattern.c_str()) << endl;
+        tcout << FormatOutputWithOffset(1, L"Invert: %s", invert_target_keyword.c_str()) << endl;
+        tcout << FormatOutputWithOffset(1, L"Enable: %s", enable_keyword.c_str()) << endl;
+        tcout << FormatOutputWithOffset(1, L"Specific Device: %s", target_info.target_device_id.c_str()) << endl;
+        tcout << FormatOutputWithOffset(1, L"Devices:") << endl;
+    }
+
+    for (auto& adapter : adapter_list)
+    {
+        if (verbose) {
+            tcout << FormatOutputWithOffset(2, L"Device Name: %s", adapter.devName.c_str()) << endl;
+            tcout << FormatOutputWithOffset(3, L"Device ID         : %s", adapter.devID.c_str()) << endl;
+            tcout << FormatOutputWithOffset(3, L"Device Hardware ID: %s", adapter.devHardwareID.c_str()) << endl;
+            tcout << FormatOutputWithOffset(3, L"Device GUID       : {%08lX-%04hX-%04hX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX}",
+                adapter.devGuid.Data1, adapter.devGuid.Data2, adapter.devGuid.Data3,
+                adapter.devGuid.Data4[0], adapter.devGuid.Data4[1], adapter.devGuid.Data4[2], adapter.devGuid.Data4[3],
+                adapter.devGuid.Data4[4], adapter.devGuid.Data4[5], adapter.devGuid.Data4[6], adapter.devGuid.Data4[7]) << endl;
+            tcout << FormatOutputWithOffset(3, L"Device Index      : %d", adapter.devIndex) << endl;
+        }
+
+        bool is_match = false;
+        if (target_info.pattern_type == ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION && 
+            CheckIfStringContainsPattern(adapter.devName, target_info.pattern, true) != target_info.is_an_inverted_target) {
+            is_match = true;
+        } else if (target_info.pattern_type == ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID && 
+            CheckIfStringContainsPattern(adapter.devID, target_info.pattern, true) != target_info.is_an_inverted_target) {
+            is_match = true;
+        }
+        
+        if (is_match) {
+            if (target_info.target_device_id.length() > 0 && target_info.target_device_id.find(adapter.devID) != 0) {
+                // We aren't the specific display adapter requested. Skip this display adapter.
+                continue;
+            }
+
+            if (verbose) {
+                tcout << FormatOutputWithOffset(3, L"Attempting to %s %s", enable_keyword.c_str(), adapter.devName.c_str()) << endl;
+            } else {
+                tcout << FormatOutput(L"Attempting to %s %s [ID: %s, idx: %d]", enable_keyword.c_str(), adapter.devName.c_str(), adapter.devID.c_str(), adapter.devIndex) << endl;
+            }
+
+            ChangeAdapterState(adapter, enable, verbose);
+        }
+    }
+}
+
+void EnableDisableDisplayAdapterManager(tstring Pattern, bool verbose, bool enable)
+{
+    Pattern = StringToLowerCase(Pattern);
+
+    tstring temp_string = TEXT("disable");
+    if (enable) {
+        temp_string = TEXT("enable");
+    }
+
+    vector<Adapter> adapter_list = GetAdapterList(verbose);
+
+    for (EnableDisablePatternStruct& possible_pattern_match : SupportedEnableDisablePatterns) {
+        bool is_a_full_match = false;
+        if (Pattern.find(possible_pattern_match.Abbreviation) == 0) {
+            is_a_full_match = true;
+            tstring target_device_id = TEXT("");
+            int32_t target_index = 0;
+            // We match this abbreviated pattern. Lets check if it has an index on it.
+            if (Pattern.length() > possible_pattern_match.Abbreviation.length()) {
+                // We might have an index. Lets verify.
+                bool has_index_string = true;
+                tstring index_string = tstring(Pattern.begin() + possible_pattern_match.Abbreviation.size(), Pattern.end());
+                for (auto character : index_string) {
+                    if (tstring(TEXT("0123456789")).find(character) == tstring::npos) {
+                        // Oops what we though was an index has non-numeric contents. Guess we didnt match...
+                        has_index_string = false;
+                    }
+                }
+                if (has_index_string) {
+                    // We have an index. Lets extract it.
+                    target_index = get_int_from_tstring(index_string);
+                    // Check if the index we got is valid. If not we will alert user and continue.
+                    if (target_index < 1 || target_index > PatternMatchCounts[possible_pattern_match.Abbreviation]) {
+                        tcout << FormatOutputWithOffset(1, 
+                        L"The specified display adapter to %s '%s' matches a valid display adapter pattern '%s' but index '%d' is out of range (max of '%d', min of '1').",
+                        temp_string.c_str(),
+                        Pattern.c_str(),
+                        possible_pattern_match.Abbreviation.c_str(),
+                        target_index,
+                        PatternMatchCounts[possible_pattern_match.Abbreviation]) << endl;
+                        is_a_full_match = false;
+                    } else {
+                        target_device_id = DeviceIDsForIndexedPatterns[possible_pattern_match.Abbreviation][target_index - 1];
+                    }
+                } else {
+                    is_a_full_match = false;
+                }
+            }
+
+            if (is_a_full_match) {
+                for (tstring sub_pattern : possible_pattern_match.AdaptersToMatch) {
+                    adapter_target_info_t target_info;
+                    target_info.pattern = sub_pattern;
+                    target_info.is_an_inverted_target = possible_pattern_match.IsAnInvertedTarget;
+                    target_info.target_device_id = target_device_id;
+                    target_info.pattern_type = possible_pattern_match.PatternType;
+
+                    if (enable) {
+                        EnableDisableAdapter(adapter_list, target_info, true, verbose);
+                    } else {
+                        EnableDisableAdapter(adapter_list, target_info, false, verbose);
+                    }
+                }
+                return;
+            }
+        }
+    }
+
+    tcout << FormatOutputWithOffset(1, 
+        L"The specified display adapter to %s '%s' matched no display adapter patterns supported by this tool.", temp_string.c_str(), Pattern.c_str()) << endl;
+}
+
+void DisableDisplayAdapter(tstring Pattern, bool verbose)
+{
+    EnableDisableDisplayAdapterManager(Pattern, verbose, false);
+}
+
+void EnableDisplayAdapter(tstring Pattern, bool verbose)
+{
+    EnableDisableDisplayAdapterManager(Pattern, verbose, true);
+}

--- a/sources/apps/idd-setup-tool/EnableDisableAdapters.h
+++ b/sources/apps/idd-setup-tool/EnableDisableAdapters.h
@@ -1,0 +1,47 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <windows.h>
+#include <vector>
+#include <iostream>
+#include <string>
+#include <cassert>
+
+#include "Utility.h"
+
+struct Adapter
+{
+    tstring devID;
+    tstring devName;
+    tstring devHardwareID;
+    GUID    devGuid = {};
+    int     devIndex = -1;
+};
+
+struct adapter_target_info_t
+{
+    tstring                      pattern;
+    bool                         is_an_inverted_target;
+    tstring                      target_device_id;
+    ENABLE_DISABLE_PATTERN_TYPES pattern_type;
+};
+
+std::vector<Adapter> GetAdapterList(bool verbose);
+size_t GetNumIddCompatibleAdapters(std::vector<Adapter> &adapter_list);
+void DisableDisplayAdapter(tstring Pattern, bool verbose = true);
+void EnableDisplayAdapter(tstring Pattern, bool verbose = true);

--- a/sources/apps/idd-setup-tool/Guids.h
+++ b/sources/apps/idd-setup-tool/Guids.h
@@ -1,0 +1,25 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is dedicated to list GUIDs which requires initialization. Keep
+// _only_ GUIDs here so you can add this header as a last item in your
+// headers list and initialize it with initguid.h as needed.
+
+#include <guiddef.h>
+
+// {4d36e968-e325-11ce-bfc1-08002be10318}
+DEFINE_GUID(DISPLAY_GUID,
+    0x4d36e968, 0xe325, 0x11ce, 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18);

--- a/sources/apps/idd-setup-tool/IddSetupToolCommandParser.cpp
+++ b/sources/apps/idd-setup-tool/IddSetupToolCommandParser.cpp
@@ -1,0 +1,402 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "IddSetupToolCommandParser.h"
+#include <filesystem>
+#include <fstream>
+
+extern std::unique_ptr<IddSetupToolCommandParser> g_params;
+
+IddSetupToolCommandParser::IddSetupToolCommandParser()
+{
+    this->ToolName = TEXT("idd-setup-tool.exe");
+
+    this->AddGlobalSwitch(this->Options.Verbose                                                            , TEXT("Turn on additional logging (default: off)")                                                                             , 2, TEXT("-v"), TEXT("--verbose"));
+    this->AddGlobalSwitch(this->Options.Help                                                               , TEXT("Print help")                                                                                                            , 2, TEXT("-h"), TEXT("--help")   );
+    this->AddGlobalSwitch(this->Options.Yes                                                                , TEXT("Assume \"yes\" on all prompts (default: off)")                                                                          , 2, TEXT("-y"), TEXT("--yes")    );
+    this->AddGlobalParam ((void*) &this->Options.PostActionDelay, ArgumentTypes::INTEGER, true, TEXT(""), 1, TEXT("Applies the specified delay (in milliseconds) after every action that changes display or adapter states (default: 2000ms)"), 1, TEXT("--delay"));
+
+    this->SetHidden(this->AddGlobalParam(
+        (void*) &this->Options.IndentationLevel,
+        ArgumentTypes::INTEGER,
+        true, TEXT(""),
+        1,
+        TEXT("Offset all output from this tool by this amount"),
+        1,
+        TEXT("--indentation")
+    ));
+
+    this->SetHidden(this->AddGlobalSwitch(
+        this->Options.DumpConfigurationValues,
+        TEXT("Causes tool to append values of all configuration options interpreted by this command parser to the file idd_setup_tool_dumped_configuration_values.csv."),
+        1,
+        TEXT("--dump-configuration-values")
+    ));
+
+    this->AddGlobalBugs(
+        6,
+        TEXT("Some functions of this tool do not work in non-interactive shells. A list of known commands that require interactive shells is below; but overall this tool is not validated in non-interactive shell."),
+        FormatString(TEXT(" - \"%s set\" scaling change functionality."), this->ToolName.c_str()).c_str(),
+        FormatString(TEXT(" - \"%s install\" scaling change functionality."), this->ToolName.c_str()).c_str(),
+        TEXT(""),
+        TEXT("Some functions of this tool have a known instability when running operations immediately after enabling or disabling adapters."),
+        TEXT("In our testing this is resolved by including a small delay between sensitive actions which is applied by default (2000ms) if an adapter has been disabled or enabled. However this can be set to zero or increased if required by using the \"--delay=<VALUE>\" parameter.")
+    );
+
+    this->AddCommand(TEXT("install")    , TEXT("Installs IDD")                         );
+    this->AddCommand(TEXT("uninstall")  , TEXT("Uninstalls IDD")                       );
+    this->AddCommand(TEXT("set")        , TEXT("Configure adapter(s) settings")        );
+    this->AddCommand(TEXT("enable")     , TEXT("Enable adapters or displays")          );
+    this->AddCommand(TEXT("disable")    , TEXT("Disable adapters or displays")         );
+    this->AddCommand(TEXT("pair")       , TEXT("Pair adapters to IDD displays")        );
+    this->AddCommand(TEXT("rearrange")  , TEXT("Rearrange available displays")        );
+    this->AddCommand(TEXT("show")       , TEXT("Show information related to IDD setup"));
+
+    this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.InfPath          , ArgumentTypes::PATH         , false, TEXT("") , 1, TEXT("Location of IDD driver (IddSampleDriver.inf) to install (default: $bindir\\idd\\)"), 1, TEXT("--location"));
+    this->AddCommandSpecificSwitch (TEXT("install")  , this->Options.TrustInf                                                               , TEXT("Extract certificate and add it to the trusted store (default: no)")                                                                  , 1, TEXT("--trust"));
+    //TODO: Implement "--display-number" option for "install" command
+    //this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.IddInstallNumber , ArgumentTypes::INTEGER      , true , TEXT("") , 1, TEXT("Specify number of IDD displays to install, maximum of 1 per IDD compatible adapter (default: 1 per adapter)")                        , 1, TEXT("--display-number"));
+    this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.Scale            , ArgumentTypes::INTEGER      , true , TEXT("") , 1, TEXT("Configure specified scaling for the display (default: use system default)")                                                          , 1, TEXT("--scale"));
+    this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.Resolutions[0]   , ArgumentTypes::INTEGER      , true , TEXT("x"), 2, TEXT("Configure specified resolution for the display (default: use system default)")                                                       , 1, TEXT("--resolution"));
+    this->AddCommandSpecificSwitch (TEXT("install")  , this->Options.RearrangeDisplays                                                            , TEXT("Rearrange displays horizontally, set leftmost as primary")                                                                           , 1, TEXT("--rearrange"));
+    this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.AdaptersToDisable, ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Disable specified adapter (options: msft, idd, flex)")                                                                               , 1, TEXT("--disable-adapter"));
+    this->AddCommandSpecificParam  (TEXT("install")  , (void*) &this->Options.DisplaysToDisable, ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Disable specified display (options: non-flex, msft, idd, virtio, non-idd)")                                                          , 1, TEXT("--disable-display"));
+    this->SetHidden(
+        this->AddCommandSpecificSwitch(TEXT("install"), this->Options.ForceNoUninstall                                                            , TEXT("Perform installation with no uninstall step")                                                                                        , 1, TEXT("--force-no-uninstall"))
+    );
+    this->SetHidden(
+        this->AddCommandSpecificSwitch(TEXT("install"), this->Options.ForceNoPair                                                                 , TEXT("Perform installation with no pair step")                                                                                            , 1, TEXT("--force-no-pair"))
+    );
+
+    this->AddCommandSpecificParam  (TEXT("uninstall"), (void*) &this->Options.AdaptersToEnable , ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Enable specified adapter after IDD uninstallation (options: msft, idd, flex)")                                                       , 1, TEXT("--enable-adapter"));
+    this->AddCommandSpecificParam  (TEXT("uninstall"), (void*) &this->Options.DisplaysToEnable , ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Enable specified display after IDD uninstallation (options: non-flex, msft, idd, virtio, non-idd)")                                  , 1, TEXT("--enable-display"));
+
+    //TODO: Implement "--display" option for "set" command
+    //this->AddCommandSpecificParam  (TEXT("set")      , (void*) &this->Options.TargetDisplay    , ArgumentTypes::STRING       , false, TEXT("") , 1, TEXT("Apply settings for specific display (default: Intel IddSampleDriver Device)")                                                        , 1, TEXT("--display"));
+    this->AddCommandSpecificSetting(TEXT("set")      , (void*) &this->Options.Scale            , ArgumentTypes::INTEGER      , true , TEXT("") , 1, TEXT("Configure specified scaling for the display")                                                                                        , 1, TEXT("scale"));
+    this->AddCommandSpecificSetting(TEXT("set")      , (void*) &this->Options.Resolutions[0]   , ArgumentTypes::INTEGER      , true , TEXT("x"), 2, TEXT("Configure specified resolution for the display")                                                                                     , 1, TEXT("resolution"));
+
+    this->AddCommandSpecificSetting(TEXT("enable")   , (void*) &this->Options.AdaptersToEnable , ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Enable specified adapter (options: msft, idd, flex)")                                                                               , 1, TEXT("adapter"));
+    this->AddCommandSpecificSetting(TEXT("enable")   , (void*) &this->Options.DisplaysToEnable , ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Enable specified display (options: non-flex, msft, idd, virtio, non-idd)")                                                          , 1, TEXT("display"));
+
+    this->AddCommandSpecificSetting(TEXT("disable")  , (void*) &this->Options.AdaptersToDisable, ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Disable specified adapter (options: msft, idd, flex)")                                                                               , 1, TEXT("adapter"));
+    this->AddCommandSpecificSetting(TEXT("disable")  , (void*) &this->Options.DisplaysToDisable, ArgumentTypes::STRING_VECTOR, true , TEXT(","), 0, TEXT("Disable specified display (options: non-flex, msft, idd, virtio, non-idd)")                                                          , 1, TEXT("display"));
+
+    this->AddCommandSpecificParam  (TEXT("show")     , (void*) &this->Options.ShowIddCount     , ArgumentTypes::STRING       , true , TEXT("") , 1, TEXT("If this option is \"yes\" then print number of IDD-compatible adapters on the system (default: yes)")                                , 1, TEXT("--count"));
+    this->AddCommandSpecificParam  (TEXT("show")     , (void*) &this->Options.ShowAdaptersInfo , ArgumentTypes::STRING       , true , TEXT("") , 1, TEXT("If this option is \"yes\" then print some information on adapters (default: yes)")                                                   , 1, TEXT("--adapters"));
+    this->AddCommandSpecificParam  (TEXT("show")     , (void*) &this->Options.ShowDisplaysInfo , ArgumentTypes::STRING       , true , TEXT("") , 1, TEXT("If this option is \"yes\" then print some information on displays (default: yes)")                                                   , 1, TEXT("--displays"));
+
+    this->AddGlobalDescription(
+        3,
+        TEXT("The order in which arguments are supplied to this tool is not important, with the exception of the <command> argument which must come before any arguments specific to that command."),
+        TEXT(""),
+        TEXT("All options and modes in this tool are case insensitive; though the values provided to these options (e.g. a path to an INF file) may still be case sensitive.")
+    );
+
+    this->AddCommandSpecificDescription(
+        TEXT("install"),
+        12,
+        TEXT("Installs IDD display for each IDD compatible adapter."),
+        TEXT("This will uninstall any previously installed IDD displays prior to installation of new IDD displays."),
+        TEXT(""),
+        TEXT("Pairing is done automatically following installation."),
+        TEXT("See \"idd-setup-tool.exe pair --help\" for more details on pairing."),
+        TEXT(""),
+        TEXT("Using \"--resolution\" or \"--scale\" you can configure any installed IDD displays resolution."),
+        TEXT("This behaves identical to \"idd-setup-tool.exe set\" in terms of behavior."),
+        TEXT("See \"idd-setup-tool.exe set --help\" for more details on setting IDD resolution and scaling."),
+        TEXT(""),
+        TEXT("Using \"--disable-adapter\" or \"--disable-display\" you can disable specific adapters or displays specified by the pattern."),
+        TEXT("See \"idd-setup-tool.exe disable --help\" for more details on adapter and display disabling, as well as the detailed list of supported patterns.")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("uninstall"),
+        4,
+        TEXT("Uninstalls any detected IDD display.")
+        TEXT(""),
+        TEXT("Using \"--enable-adapter\" or \"--enable-display\" you can enable specific adapters or displays specified by the pattern."),
+        TEXT("See \"idd-setup-tool.exe enable --help\" for more details on adapter and display enabling, as well as the detailed list of supported patterns.")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("set"),
+        6,
+        TEXT("Configures given setting for available IDD displays."),
+        TEXT(""),
+        TEXT("Mind that if the order in which these settings are set is important, this should be done by execution of \"idd-setup-tool.exe set\" a few times consecutively"),
+        TEXT("Default ordering of this tool is:"),
+        TEXT(" - Resolution"),
+        TEXT(" - Scaling")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("enable"),
+        15,
+        TEXT("Enables specified adapters/displays."),
+        TEXT(""),
+        TEXT("Using \"adapter\" or \"display\" you can enable adapters or displays specified by a pattern:"),
+        TEXT(" - non-flex = All except Intel Data Center GPU Flex"),
+        TEXT(" - msft     = Microsoft Basic Adapter"),
+        TEXT(" - virtio   = Red Hat VirtIO GPU DOD controller and Red Hat QXL controller"),
+        TEXT(" - idd      = Intel IddSampleDriver Device"),
+        TEXT(" - flex     = Intel Data Center GPU Flex Series"),
+        TEXT(" - non-idd  = All except Intel IddSampleDriver Device"),
+        TEXT("Specific displays and adapters can be targeted by supplying one of the above patterns with an index (e.g. idd1 disable only the first idd display or adapter)."),
+        TEXT("'show' command can be used to enumerate the full list of patterns that will affect each adapter or display."),
+        TEXT("Default ordering of this tool is:"),
+        TEXT(" - Enable adapters"),
+        TEXT(" - Enable displays"),
+        TEXT("Note: Some of these patterns are display or adapter only.")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("disable"),
+        15,
+        TEXT("Disables specified adapters/displays."),
+        TEXT(""),
+        TEXT("Using \"adapter\" or \"display\" you can disable adapters or displays specified by a pattern:"),
+        TEXT(" - non-flex = All except Intel Data Center GPU Flex"),
+        TEXT(" - msft     = Microsoft Basic Adapter"),
+        TEXT(" - virtio   = Red Hat VirtIO GPU DOD controller and Red Hat QXL controller"),
+        TEXT(" - idd      = Intel IddSampleDriver Device"),
+        TEXT(" - flex     = Intel Data Center GPU Flex Series"),
+        TEXT(" - non-idd  = All except Intel IddSampleDriver Device"),
+        TEXT("Specific displays and adapters can be targeted by supplying one of the above patterns with an index (e.g. idd1 disable only the first idd display or adapter)."),
+        TEXT("'show' command can be used to enumerate the full list of patterns that will affect each adapter or display."),
+        TEXT("Default ordering of this tool is:"),
+        TEXT(" - Disable adapters"),
+        TEXT(" - Disable displays"),
+        TEXT("Note: Some of these patterns are display or adapter only.")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("pair"),
+        2,
+        TEXT("Loops through IDD displays and adapters and pairs each IDD display with next IDD compatible adapter."),
+        TEXT("If there are more displays than adapters, adapters loop starts anew so some adapters will be assigned with few displays.")
+    );
+    this->AddCommandSpecificBugs(
+        TEXT("pair"),
+        9,
+        TEXT("This command will likely re-enable MSFT basic display (and perhaps any other disabled displays)."),
+        TEXT("It is recommended to disable any unwanted displays after running this command - or any other commands that run"),
+        TEXT("IDD paring such as install."),
+        TEXT(""),
+        TEXT("Pairing should preserve over reboot. Its our bug that it's not. As a workaround \"pair\" command must be re-run"),
+        TEXT("anytime the following occurs:"),
+        TEXT(" - IDD Driver is disabled/enabled"),
+        TEXT(" - GFX Driver is disabled/enabled"),
+        TEXT(" - System is rebooted")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("rearrange"),
+        1,
+        TEXT("Rearranges displays horizontally, and sets the leftmost display as the primary.")
+    );
+    this->AddCommandSpecificDescription(
+        TEXT("show"),
+        2,
+        TEXT("Prints information on adapters or displays."),
+        TEXT("Along with information about each display and adapter the list of adapter and display enabling and disabling patterns that will affect each device is also displayed.")
+    );
+}
+
+IddSetupToolCommandParser::~IddSetupToolCommandParser()
+{
+
+}
+
+bool IddSetupToolCommandParser::ConstraintFunction(void)
+{
+    CommandStruct *CurrentCommand = this->GetCurrentCommand();
+
+    // If just asking for help call help function and exit with return code 0.
+    // Also show help message is no [COMMAND] was specified.
+    if (this->Options.Help || CurrentCommand == NULL) {
+        this->ShowHelpMessage();
+        exit(0);
+    }
+
+    // Set default modes enabled depending on the mode its running in.
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("install")) {
+        if (this->Options.ForceNoUninstall == false) {
+            this->Options.UninstallIdd = true;
+        }
+        this->Options.InstallIdd = true;
+        if (this->Options.ForceNoPair == false) {
+            this->Options.PairIdd = true;
+        }
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("uninstall")) {
+        this->Options.UninstallIdd = true;
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("set")) {
+        if (this->Options.Resolutions[0] == 0 && this->Options.Scale == 0) {
+            tcout << FormatOutput(TEXT("Error: At least one setting must be provided to \"set\" command.")) << std::endl;
+            tcout << FormatOutput(TEXT("       See \"idd-setup-tool.exe set --help\" for a list of available settings.")) << std::endl;
+            exit(-1);
+        }
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("enable")) {
+        if (this->Options.AdaptersToEnable.size() == 0 && this->Options.DisplaysToEnable.size() == 0) {
+            tcout << FormatOutput(TEXT("Error: At least one setting must be provided to \"enable\" command.")) << std::endl;
+            tcout << FormatOutput(TEXT("       See \"idd-setup-tool.exe enable --help\" for a list of available settings.")) << std::endl;
+            exit(-1);
+        }
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("disable")) {
+        if (this->Options.AdaptersToDisable.size() == 0 && this->Options.DisplaysToDisable.size() == 0) {
+            tcout << FormatOutput(TEXT("Error: At least one setting must be provided to \"disable\" command.")) << std::endl;
+            tcout << FormatOutput(TEXT("       See \"idd-setup-tool.exe disable --help\" for a list of available settings.")) << std::endl;
+            exit(-1);
+        }
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("pair")) {
+        this->Options.PairIdd = true;
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("rearrange")) {
+        this->Options.RearrangeDisplays = true;
+    }
+    if (StringToLowerCase(CurrentCommand->CommandName) == TEXT("show")) {
+        if (this->Options.ShowAdaptersInfo == TEXT("")) {
+            this->Options.ShowAdaptersInfo = TEXT("yes");
+        }
+        if (this->Options.ShowDisplaysInfo == TEXT("")) {
+            this->Options.ShowDisplaysInfo = TEXT("yes");
+        }
+        if (this->Options.ShowIddCount == TEXT("")) {
+            this->Options.ShowIddCount = TEXT("yes");
+        }
+    }
+
+    // Current usage limitations: if certain switches are enabled others must be as well.
+    if (this->Options.InstallIdd   ||
+        this->Options.TrustInf) {
+        std::filesystem::path& idd = this->Options.InfPath;
+
+        if (idd.empty()) {
+            idd = GetDefaultIddPath();
+        }
+        if (!isIddOk(idd)) {
+            tcout << FormatOutput(TEXT("Error: No IDD files (.inf, .dll, .cat) found in %s"), idd.c_str()) << std::endl;
+            exit(-1);
+        }
+        tcout << FormatOutput(TEXT("Found IDD files (.inf, .dll, .cat) to install: %s"), idd.c_str()) << std::endl;
+    }
+
+    if (this->Options.DumpConfigurationValues) {
+        this->DumpConfigurationValues();
+    }
+
+    return true;
+}
+
+void IddSetupToolCommandParser::DumpConfigurationValues(void)
+{
+    std::ofstream MyFile;
+    if (std::filesystem::exists(TEXT("idd_setup_tool_dumped_configuration_values.csv")) == false) {
+        MyFile.open(TEXT("idd_setup_tool_dumped_configuration_values.csv"), std::ios::out);
+        MyFile << "CL";
+        MyFile << "," << "Verbose";
+        MyFile << "," << "Yes";
+        MyFile << "," << "Help";
+        MyFile << "," << "InstallIdd";
+        MyFile << "," << "UninstallIdd";
+        MyFile << "," << "TrustInf";
+        MyFile << "," << "PairIdd";
+        MyFile << "," << "ForceNoUninstall";
+        MyFile << "," << "ForceNoPair";
+        //TODO: Implement "--display-number" option for "install" command
+        //MyFile << "," << "IddInstallNumber";
+        MyFile << "," << "InfPath";
+        MyFile << "," << "Resolutions.Width";
+        MyFile << "," << "Resolutions.Height";
+        MyFile << "," << "Scale";
+        MyFile << "," << "RearrangeDisplays";
+        MyFile << "," << "AdaptersToDisable";
+        MyFile << "," << "DisplaysToDisable";
+        MyFile << "," << "AdaptersToEnable";
+        MyFile << "," << "DisplaysToEnable";
+        //TODO: Implement "--display" option for "set" command
+        //MyFile << "," << "TargetDisplay";
+        MyFile << "," << "ShowIddCount";
+        MyFile << "," << "ShowAdaptersInfo";
+        MyFile << "," << "ShowDisplaysInfo";
+        MyFile << "," << "IndentationLevel";
+        MyFile << "," << "PostActionDelay";
+        MyFile << std::endl;
+    } else {
+        MyFile.open(TEXT("idd_setup_tool_dumped_configuration_values.csv"), std::ios::out | std::ios::app);
+    }
+
+    for (int i = 0; i < this->RawArguments.size(); i++) {
+        if (i != 0) {
+            MyFile << " ";
+        }
+        MyFile << ws2s(this->RawArguments[i]);
+    }
+
+    MyFile << "," << this->Options.Verbose;
+    MyFile << "," << this->Options.Yes;
+    MyFile << "," << this->Options.Help;
+    MyFile << "," << this->Options.InstallIdd;
+    MyFile << "," << this->Options.UninstallIdd;
+    MyFile << "," << this->Options.TrustInf;
+    MyFile << "," << this->Options.PairIdd;
+    MyFile << "," << this->Options.ForceNoUninstall;
+    MyFile << "," << this->Options.ForceNoPair;
+    //TODO: Implement "--display-number" option for "install" command
+    //MyFile << "," << this->Options.IddInstallNumber;
+    MyFile << "," << this->Options.InfPath.c_str();
+    MyFile << "," << this->Options.Resolutions[0];
+    MyFile << "," << this->Options.Resolutions[1];
+    MyFile << "," << this->Options.Scale;
+    MyFile << "," << this->Options.RearrangeDisplays;
+    MyFile << ",";
+    for (int Index = 0; Index < this->Options.AdaptersToDisable.size(); Index++) {
+        if (Index != 0) {
+            MyFile << "|";
+        }
+         MyFile << ws2s(this->Options.AdaptersToDisable[Index]);
+    }
+    MyFile << ",";
+    for (int Index = 0; Index < this->Options.DisplaysToDisable.size(); Index++) {
+        if (Index != 0) {
+            MyFile << "|";
+        }
+         MyFile << ws2s(this->Options.DisplaysToDisable[Index]);
+    }
+    MyFile << ",";
+    for (int Index = 0; Index < this->Options.AdaptersToEnable.size(); Index++) {
+        if (Index != 0) {
+            MyFile << "|";
+        }
+         MyFile << ws2s(this->Options.AdaptersToEnable[Index]);
+    }
+    MyFile << ",";
+    for (int Index = 0; Index < this->Options.DisplaysToEnable.size(); Index++) {
+        if (Index != 0) {
+            MyFile << "|";
+        }
+         MyFile << ws2s(this->Options.DisplaysToEnable[Index]);
+    }
+    //TODO: Implement "--display" option for "set" command
+    //MyFile << "," << ws2s(this->Options.TargetDisplay);
+    MyFile << "," << ws2s(this->Options.ShowIddCount);
+    MyFile << "," << ws2s(this->Options.ShowAdaptersInfo);
+    MyFile << "," << ws2s(this->Options.ShowDisplaysInfo);
+    MyFile << "," << this->Options.IndentationLevel;
+    MyFile << "," << this->Options.PostActionDelay;
+    MyFile << std::endl;
+
+    MyFile.close();
+}

--- a/sources/apps/idd-setup-tool/IddSetupToolCommandParser.h
+++ b/sources/apps/idd-setup-tool/IddSetupToolCommandParser.h
@@ -1,0 +1,63 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+#include "Utility.h"
+#include <vector>
+#include "CommandParserImpl.h"
+
+typedef struct IDD_SETUP_TOOL_OPTIONS_STRUCT {
+    bool Verbose = false;
+    bool Yes = false;
+    bool Help = false;
+    bool InstallIdd = false;
+    bool UninstallIdd = false;
+    bool TrustInf = false;
+    bool PairIdd = false;
+    bool ForceNoUninstall = false;
+    bool ForceNoPair = false;
+    //TODO: Implement "--display-number" option for "install" command
+    //int  IddInstallNumber = -1;
+    std::filesystem::path InfPath;
+    int32_t Resolutions[2] = { 0 };
+    int32_t Scale = 0;
+    bool RearrangeDisplays = false;
+    std::vector<tstring> AdaptersToDisable { };
+    std::vector<tstring> DisplaysToDisable { };
+    std::vector<tstring> AdaptersToEnable  { };
+    std::vector<tstring> DisplaysToEnable  { };
+    //TODO: Implement "--display" option for "set" command
+    //tstring TargetDisplay = TEXT("Intel IddSampleDriver Device");
+    tstring ShowIddCount = TEXT("");
+    tstring ShowAdaptersInfo = TEXT("");
+    tstring ShowDisplaysInfo = TEXT("");
+    uint32_t IndentationLevel = 0;
+    uint32_t PostActionDelay = 2000;
+    bool DumpConfigurationValues = false;
+} IddSetupToolOptionsStruct;
+
+class IddSetupToolCommandParser : public CommandParserImpl {
+protected:
+    bool ConstraintFunction(void) override;
+    void DumpConfigurationValues(void);
+public:
+    IddSetupToolCommandParser(void);
+    ~IddSetupToolCommandParser(void);
+
+    IddSetupToolOptionsStruct Options;
+};

--- a/sources/apps/idd-setup-tool/InstallIDD.cpp
+++ b/sources/apps/idd-setup-tool/InstallIDD.cpp
@@ -1,0 +1,364 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "InstallIDD.h"
+#include "Guids.h"
+
+#include <windows.h>
+#include <setupapi.h>
+#include <cfgmgr32.h>
+#include <strsafe.h>
+#include <tchar.h>
+#include <newdev.h>
+#include <stdlib.h>
+#include <sstream>
+#include <filesystem>
+
+using namespace std;
+
+// function pointer - definition from newdev.h, implemented in newdev.dll
+typedef BOOL(WINAPI* updateDriverFN)(
+    _In_opt_  HWND hwndParent,
+    _In_      LPCWSTR HardwareId,
+    _In_      LPCWSTR FullInfPath,
+    _In_      DWORD InstallFlags,
+    _Out_opt_ PBOOL bRebootRequired
+    );
+
+bool TrustIDD(const std::filesystem::path& inf_path)
+{
+    // We will be looking for install_certificate.ps1 script next to the current executable
+    std::filesystem::path ps1 = getExePath().replace_filename("install_certificate.ps1");
+    std::filesystem::path cat = inf_path / "iddsampledriver.cat";
+
+    auto patharg = [](const std::filesystem::path& path) -> tstring {
+        return tstring(L"'") + path.c_str() + tstring(L"'");
+    };
+
+    const tstring command = L"powershell -NoProfile -ExecutionPolicy Unrestricted -Command \"& " +
+        patharg(ps1) + L" -driverFile " + patharg(cat) + L"\"";
+
+    tstring results;
+    bool SystemCallStatus = RunSystemCommand(command, results);
+
+    if (!SystemCallStatus) {
+        tcout << FormatOutput(L"Error: %s", command.c_str()) << endl;
+        return false;
+    }
+
+    tcout << FormatOutput(L"%s", results.c_str()) << endl;
+    return true;
+}
+
+std::vector<tstring> GetMultiSzDevProperty(HDEVINFO hDevInfo, SP_DEVINFO_DATA& devInfoData, DWORD propId)
+{
+    std::vector<tstring> prop;
+    DWORD propType = 0;
+    DWORD propSize = 0;
+    if (!SetupDiGetDeviceRegistryProperty(hDevInfo, &devInfoData, propId, &propType, nullptr, 0, &propSize)) {
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER || propType != REG_MULTI_SZ || !propSize) {
+            return prop;
+        }
+    }
+
+    tstring buf(propSize, TEXT('\0'));
+    if (!SetupDiGetDeviceRegistryProperty(hDevInfo, &devInfoData, propId, nullptr, (PBYTE)buf.data(), buf.size(), nullptr))
+        return prop;
+
+    // See: https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types
+    // Example: String1\0String2\0String3\0LastString\0\0
+    for (auto it = buf.data(); *it != TEXT('\0');) {
+        tstring tmp(it);
+        it += tmp.size() + 1;
+        prop.push_back(tmp);
+    }
+    return prop;
+}
+
+bool UninstallIDD()
+{
+    HDEVINFO hDevInfo = SetupDiGetClassDevsEx(&DISPLAY_GUID, nullptr, nullptr, DIGCF_PRESENT, nullptr, nullptr, nullptr);
+    if (hDevInfo == INVALID_HANDLE_VALUE) {
+        tcout << FormatOutput(L"Error: SetupDiGetClassDevsEx() failed") << endl;
+        return false;
+    }
+
+    bool result = true;
+    DWORD count = 0;
+    SP_DEVINFO_DATA devInfoData;
+    devInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+
+    for (DWORD idx = 0; SetupDiEnumDeviceInfo(hDevInfo, idx, &devInfoData); ++idx) {
+        std::vector<tstring> hwIds = GetMultiSzDevProperty(hDevInfo, devInfoData, SPDRP_HARDWAREID);
+
+        if (std::find(std::begin(hwIds), std::end(hwIds), TEXT("root\\iddsampledriver")) == std::end(hwIds))
+            continue;
+
+        tstring devId(MAX_DEVICE_ID_LEN + 1, TEXT('\0'));
+        // We need this id for the better print out of operation results.
+        CM_Get_Device_ID(devInfoData.DevInst, devId.data(), devId.size(), 0);
+
+        SP_REMOVEDEVICE_PARAMS rmDevParams{};
+        rmDevParams.ClassInstallHeader.cbSize = sizeof(SP_CLASSINSTALL_HEADER);
+        rmDevParams.ClassInstallHeader.InstallFunction = DIF_REMOVE;
+        rmDevParams.Scope = DI_REMOVEDEVICE_GLOBAL;
+        rmDevParams.HwProfile = 0;
+
+        if (!SetupDiSetClassInstallParams(hDevInfo, &devInfoData, &rmDevParams.ClassInstallHeader, sizeof(SP_REMOVEDEVICE_PARAMS)) ||
+            !SetupDiCallClassInstaller(DIF_REMOVE, hDevInfo, &devInfoData)) {
+            tcout << FormatOutput(L"    ") << devId << ": Remove failed"<< endl;
+            result = false;
+        } else {
+            SP_DEVINSTALL_PARAMS devParams{};
+            devParams.cbSize = sizeof(SP_DEVINSTALL_PARAMS);
+            if (SetupDiGetDeviceInstallParams(hDevInfo, &devInfoData, &devParams) &&
+                (devParams.Flags & (DI_NEEDRESTART | DI_NEEDREBOOT))) {
+                tcout << FormatOutput(L"    ") << devId.c_str() << ": Removed on reboot" << endl;
+
+            } else {
+                tcout << FormatOutput(L"    ") << devId.c_str() << ": Removed" << endl;
+            }
+            ++count;
+        }
+    }
+    tcout << FormatOutput(L"    ") << count << L" device(s) were removed." << endl;
+
+    SetupDiDestroyDeviceInfoList(hDevInfo);
+    return result;
+}
+
+bool InstallIDD(const std::filesystem::path& inf_path, const tstring& HWID, bool& rebootRequired, bool verbose)
+{
+    std::filesystem::path inf = inf_path / "IddSampleDriver.inf";
+
+    if (HWID.empty())
+    {
+        tstringstream ss;
+        ss << "ERROR: Empty .inf path\n";
+        throw ss.str();
+    }
+
+    // retrieve class name and GUID from inf file
+    GUID classGUID;
+    vector<TCHAR> className(MAX_CLASS_NAME_LEN);
+    if (!SetupDiGetINFClass(inf.c_str(), &classGUID, className.data(), (DWORD)size(className), 0))
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiGetINFClass"));
+    }
+
+    // create empty device information set for the class GUID
+    HDEVINFO devInfoSet = SetupDiCreateDeviceInfoList(&classGUID, 0);
+    if (devInfoSet == INVALID_HANDLE_VALUE)
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiCreateDeviceInfoList"));
+    }
+
+    ClassDevsScopedStorage scoped_devs(devInfoSet);
+
+    // create device info element and add to devInfoSet
+    SP_DEVINFO_DATA devInfoData;
+    devInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
+    if (!SetupDiCreateDeviceInfo(devInfoSet, className.data(), &classGUID, NULL, 0, DICD_GENERATE_ID, &devInfoData))
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiCreateDeviceInfo"));
+    }
+
+    // copy HWID to string terminated with 00
+    tstring HWID_tmp(HWID);
+    HWID_tmp += TEXT("\0\0");
+
+    // set PNP device property "SPDRP_HARDWAREID"
+    if (!SetupDiSetDeviceRegistryProperty(devInfoSet, &devInfoData, SPDRP_HARDWAREID, (const LPBYTE)HWID_tmp.data(), (DWORD)HWID_tmp.size() * sizeof(TCHAR)))
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiSetDeviceRegistryProperty"));
+    }
+
+    // call the class installer
+    if (!SetupDiCallClassInstaller(DIF_REGISTERDEVICE, devInfoSet, &devInfoData))
+    {
+        GetLastErrorAndThrow(TEXT("SetupDiCallClassInstaller"));
+    }
+
+    class LibraryHolder
+    {
+    public:
+        LibraryHolder(HMODULE library)
+            : m_library(library)
+        {}
+
+        ~LibraryHolder()
+        {
+            ignore = FreeLibrary(m_library);
+        }
+    private:
+        HMODULE m_library = nullptr;
+    };
+
+    HMODULE hLibNewdev = LoadLibrary(TEXT("newdev.dll"));
+    if (!hLibNewdev)
+    {
+        GetLastErrorAndThrow(TEXT("LoadLibrary for \"newdev.dll\""));
+    }
+    LibraryHolder scoped_hLibNewdev(hLibNewdev);
+
+    BOOL bReboot = false;
+    updateDriverFN pFunc = (updateDriverFN)GetProcAddress(hLibNewdev, PROPER_FUNCTION("UpdateDriverForPlugAndPlayDevices"));
+    if (!pFunc)
+    {
+        GetLastErrorAndThrow(TEXT("GetProcAddress for " PROPER_FUNCTION("UpdateDriverForPlugAndPlayDevices")));
+    }
+
+#if !DRY_RUN
+    if (!pFunc(NULL, HWID.data(), inf.c_str(), INSTALLFLAG_FORCE, &bReboot))
+    {
+        GetLastErrorAndThrow(TEXT(PROPER_FUNCTION("UpdateDriverForPlugAndPlayDevices")));
+    }
+#endif
+
+    rebootRequired = bReboot;
+    return true;
+}
+
+bool SetIDDRegisterKeys(void)
+{
+    DWORD sub_key_count=0;   // number of subkeys
+
+    HKEY key_handle;
+    LONG ret_status = OpenKeyAndEnumerateInfo(
+        HKEY_LOCAL_MACHINE,
+        tstring(INDIRECT_DISPLAY_SUPPORT_KEY_PATH),
+        &key_handle,
+        &sub_key_count,
+        NULL
+    );
+
+    if (ret_status != ERROR_SUCCESS) {
+        return false;
+    }
+
+    // Enumerate the subkeys, until RegEnumKeyEx() fails.
+    if(!sub_key_count) {
+        tcout << FormatOutput(L"WARNING: RegQueryInfoKey(%s) reported no sub-keys.", INDIRECT_DISPLAY_SUPPORT_KEY_PATH) << endl;
+        RegCloseKey(key_handle);
+        return false;
+    }
+
+    TCHAR sub_key_name[MAX_KEY_LENGTH]; // buffer for subkey name
+    DWORD sub_key_name_len;             // size of name string
+
+    for(int sub_key_index = 0; sub_key_index < sub_key_count; sub_key_index++) {
+        sub_key_name_len = MAX_KEY_LENGTH;
+        ret_status = RegEnumKeyExW(
+            key_handle,           // Handle to an open/predefined key
+            sub_key_index,        // Index of the subkey to retrieve.
+            (LPWSTR)sub_key_name, // buffer that receives the name of the subkey
+            &sub_key_name_len,    // size of the buffer specified by the sub_key_name
+            NULL,                 // Reserved; must be NULL
+            NULL,                 // buffer that receives the class string
+                                  // of the enumerated subkey
+            NULL,                 // size of the buffer specified by the previous parameter
+            NULL                  // variable that receives the time at which
+                                  // the enumerated subkey was last written
+        );
+
+        if(ret_status != ERROR_SUCCESS) {
+            continue;
+        }
+
+        DWORD value_count=0;
+
+        HKEY idd_key_handle;
+        ret_status = OpenKeyAndEnumerateInfo(
+            key_handle,
+            tstring(sub_key_name),
+            &idd_key_handle,
+            NULL,
+            &value_count
+        );
+
+        if (ret_status != ERROR_SUCCESS) {
+            continue;
+        }
+
+        bool is_idd_display = false;
+        bool is_flex_adapter = false;
+
+        for(int value_number = 0; value_number < value_count; value_number++) {
+            TCHAR value[MAX_VALUE_NAME];
+            DWORD value_len = MAX_VALUE_NAME;
+            TCHAR value_data[255];
+            DWORD value_data_len = sizeof(value_data);
+            DWORD value_data_type;
+            ret_status = RegEnumValue(
+                idd_key_handle,     // Handle to an open key
+                value_number,       // Index of value
+                (LPWSTR)value,      // Value name
+                &value_len,         // Buffer for value name
+                NULL,               // Reserved
+                &value_data_type,   // Value type
+                (LPBYTE)value_data, // Value data
+                &value_data_len     // Buffer for value data
+            );
+
+            if(ret_status == ERROR_SUCCESS) {
+                if (StringToLowerCase(tstring(value)).compare(tstring(L"driverdesc")) == 0) {
+                    if (StringToLowerCase(tstring(value_data)).compare(tstring(L"intel iddsampledriver device")) == 0) {
+                        tcout << FormatOutput(L"IDD Display found: %s", sub_key_name) << endl;
+                        is_idd_display = true;
+                    }
+                }
+                if (StringToLowerCase(tstring(value)).compare(tstring(L"matchingdeviceid")) == 0) {
+                    if (StringToLowerCase(tstring(value_data)).find(tstring(L"ven_8086&dev_56c1")) != std::string::npos) {
+                        tcout << FormatOutput(L"Flex GPU Adapter found: %s", sub_key_name) << endl;
+                        is_flex_adapter = true;
+                    } else if (StringToLowerCase(tstring(value_data)).find(tstring(L"ven_8086&dev_56c0")) != std::string::npos) {
+                        tcout << FormatOutput(L"Flex GPU Adapter found: %s", sub_key_name) << endl;
+                        is_flex_adapter = true;
+                    }
+                }
+            }
+        }
+
+        if (is_idd_display) {
+            // Nothing to set for IDD displays currently.
+        }
+
+        if (is_flex_adapter) {
+            DWORD value_data_type = REG_DWORD;
+            DWORD value_data = 0x1;
+            DWORD value_data_len = sizeof(value_data);
+            ret_status = RegSetKeyValueW(
+                idd_key_handle,            // Key
+                NULL,                      // Subkey
+                L"IndirectDisplaySupport", // Name of the value to set
+                value_data_type,           // Value type
+                (LPBYTE)&value_data,       // Value to set
+                value_data_len             // Length of the value
+            );
+
+            if(ret_status != ERROR_SUCCESS) {
+                tcout << FormatOutputWithOffset(1, L"Failed to set IndirectDisplaySupport for GPU adapter: %s", sub_key_name) << endl;
+            } else {
+                tcout << FormatOutputWithOffset(1, L"Successfully set IndirectDisplaySupport for GPU adapter: %s", sub_key_name) << endl;
+            }
+        }
+
+        RegCloseKey(idd_key_handle);
+    }
+
+    RegCloseKey(key_handle);
+    return true;
+}

--- a/sources/apps/idd-setup-tool/InstallIDD.h
+++ b/sources/apps/idd-setup-tool/InstallIDD.h
@@ -1,0 +1,24 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Utility.h"
+
+bool TrustIDD(const std::filesystem::path& inf_path);
+bool InstallIDD(const std::filesystem::path& inf_path, const tstring& HWID, bool& rebootRequired, bool verbose = true);
+bool UninstallIDD();
+bool SetIDDRegisterKeys(void);

--- a/sources/apps/idd-setup-tool/PairIdd.cpp
+++ b/sources/apps/idd-setup-tool/PairIdd.cpp
@@ -1,0 +1,338 @@
+// Copyright (C) Microsoft Corporation
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// This file contains modifications made to the original Microsoft sample code from
+// https://github.com/microsoft/Windows-driver-samples/tree/main/video/IndirectDisplay/IddSampleApp
+//
+// List of modifications:
+// 1. Add multi-adapter support
+
+#include "PairIdd.h"
+#include <iostream>
+#include <vector>
+#include <map>
+#include <string>
+#include <windows.h>
+#include <swdevice.h>
+#include <conio.h>
+#include <wrl.h>
+#include <setupapi.h>
+#include <strsafe.h>
+#include <dxgi1_6.h>
+#include <atlcomcli.h>
+#include "idd_io.h"
+
+using namespace std;
+
+const GUID GUID_DEVINTERFACE_IDD_DEVICE = {
+    0x881EF630,
+    0x82B2,
+    0x81d2,
+    {
+        0x88,
+        0x82,
+        0x80,
+        0x80,
+        0x8E,
+        0x8F,
+        0x82,
+        0x82
+    } 
+ };
+
+#define INTERFACE_DETAIL_SIZE        1024
+#define MSFT_BASIC_DISPLAY_ADAPTER 0x1414
+
+static std::vector<LUID> IddLUIDs;
+static std::vector<LUID> GpuLUIDs;
+
+/**
+ * DXGI Adapter Information
+ */
+struct DxgiAdapterInfo
+{
+    uint32_t adapterIndex;    //!< adapter index
+    DXGI_ADAPTER_DESC1 desc;  //!< DXGI adapter description
+};
+
+std::vector<tstring> GetDevicePath()
+{
+    std::vector<tstring> pszDevicePath;
+    HDEVINFO                         hDevInfoSet;
+    SP_DEVICE_INTERFACE_DATA         ifdata;
+    PSP_DEVICE_INTERFACE_DETAIL_DATA pDetail;
+    UINT32 ifIndex = 0;
+    BOOL   bStatus = TRUE;
+    GUID  virtDispGuid = GUID_DEVINTERFACE_IDD_DEVICE;
+    IDD_STATUS Status =IDD_STATUS_SUCCESS;
+
+    // Get a Device Info handle that relates to provided class GUID
+    hDevInfoSet = SetupDiGetClassDevs(
+        &virtDispGuid,                        // Class GUID
+        NULL,                                 // No Enumerator
+        NULL,                                 // No Parent Window
+        DIGCF_PRESENT | DIGCF_DEVICEINTERFACE // Enumerate all present interfaces
+    );
+
+    if (hDevInfoSet == INVALID_HANDLE_VALUE) {
+        printf("IDD: not present any interface relates to Intel IDD\n");
+        return pszDevicePath;
+    }
+
+    pDetail = (PSP_DEVICE_INTERFACE_DETAIL_DATA)GlobalAlloc(LMEM_ZEROINIT, INTERFACE_DETAIL_SIZE);
+    pDetail->cbSize = (DWORD)sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
+
+    // Enumerates all the interfaces
+    while (bStatus) {
+        ifdata.cbSize = sizeof(ifdata);
+        //Enumerates interface specified by the interface order, start from 0
+        bStatus = SetupDiEnumDeviceInterfaces(
+            hDevInfoSet,
+            NULL,
+            &virtDispGuid,
+            (ULONG)ifIndex,
+            &ifdata
+        );
+
+        if (bStatus) {
+            bStatus = SetupDiGetInterfaceDeviceDetail(
+                hDevInfoSet,
+                &ifdata,
+                pDetail,
+                INTERFACE_DETAIL_SIZE,
+                NULL,
+                NULL
+            );
+
+            if (bStatus) {
+                tstring tempString = pDetail->DevicePath;
+                pszDevicePath.push_back(std::move(tempString));
+                ifIndex++;
+            }
+        }
+    }
+
+    GlobalFree(pDetail);
+    SetupDiDestroyDeviceInfoList(hDevInfoSet);
+
+    return pszDevicePath;
+}
+
+/**
+ * Open a handle to the Idd Driver.
+ *
+ */
+IDD_STATUS OpenVirtualDisplay(IN tstring pszDevicePath, OUT HANDLE* handle)
+{
+    // wait till new interface is ready
+    IDD_STATUS Status = IDD_STATUS_SUCCESS;
+    if (NULL == handle || pszDevicePath.size() == 0) {
+        return IDD_INVALID_HANDLE;
+    }
+
+    do {
+        *handle = CreateFile(
+            pszDevicePath.c_str(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            NULL,                               // no SECURITY_ATTRIBUTES structure
+            OPEN_EXISTING,
+            0,                                  // No special attributes
+            NULL
+        );
+
+        if (*handle == INVALID_HANDLE_VALUE || *handle == NULL) {
+            Status = IDD_STATUS_ACCESS_DENIED;
+            printf("OpenVirtualDisplay: Failed to createFile error=0x%x\n", GetLastError());
+        }
+    } while (0);
+
+    return Status;
+}
+
+/**
+ * Find out if an Adapter is Idd adapter.
+ * Using Query Display Config, all of the adapters including Idd should have been enumerated.
+ * If the adapter LUID matches and Idd LUID, mark it as idd adapter.
+ */
+bool IsIddAdapter(LUID luid)
+{
+    if (!IddLUIDs.empty()) {
+        for (auto& IddLUID : IddLUIDs) {
+            if (luid.HighPart == IddLUID.HighPart && luid.LowPart == IddLUID.LowPart) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Find out if a given path has Idd monitor.
+ * Using Query Display Config, all of the adapters including Idd should have been enumerated.
+ * If the Video Output Technology type matches, Indirect Wired/virtual or other mark it as an idd path/adapter.
+ */
+bool IsIddPath(DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY VotType)
+{
+    if  (//(VotType == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_OTHER) ||
+        (VotType == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_WIRED) ||
+        (VotType == DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_VIRTUAL))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Get Adapter LUIDs.
+ * Using Query Display Config, find out all the idd adapters and store them in IddLUIDs.
+ * Using Enumerate adapters find out all the adapters in the system (both idd and non idd)
+ * Filter out the Idd adapters using the IddLUIDs list. All the other adapters must be physical adapters
+ * This can be further enhanced to have vendor id/device id checks for further restrictions. .
+ */
+void GetAdapterLUIDs()
+{
+    LUID IddLUID = { 0 };
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+    // UINT32 flags = QDC_ONLY_ACTIVE_PATHS | QDC_VIRTUAL_MODE_AWARE;
+    UINT32 flags = QDC_ALL_PATHS | QDC_VIRTUAL_MODE_AWARE;
+    LONG result = ERROR_SUCCESS;
+
+    tcout << FormatOutput(TEXT("Querying Display Adapter LUIDs")) << std::endl;
+
+    do {
+        // Determine how many path and mode structures to allocate
+        UINT32 pathCount, modeCount;
+        result = GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount);
+
+        if (result != ERROR_SUCCESS) {
+            tcout << FormatOutputWithOffset(1, TEXT("GetAdapterLUIDs: Query Display Config Failure")) << std::endl;
+            return;
+        }
+
+        // Allocate the path and mode arrays
+        paths.resize(pathCount);
+        modes.resize(modeCount);
+
+        // Get all active paths and their modes
+        result = QueryDisplayConfig(flags, &pathCount, paths.data(), &modeCount, modes.data(), nullptr);
+
+        // The function may have returned fewer paths/modes than estimated
+        paths.resize(pathCount);
+        modes.resize(modeCount);
+
+        // It's possible that between the call to GetDisplayConfigBufferSizes and QueryDisplayConfig
+        // that the display state changed, so loop on the case of ERROR_INSUFFICIENT_BUFFER.
+    } while (result == ERROR_INSUFFICIENT_BUFFER);
+
+    // For each active path
+    for (auto& path : paths) {
+        // If its an idd display add to the IddLUIDs.
+        if (IsIddPath(path.targetInfo.outputTechnology)) {
+            IddLUIDs.push_back(path.targetInfo.adapterId);// Store the Idd LUID
+        }
+    }
+
+    std::vector<DxgiAdapterInfo> gpuAdapterDescs;
+
+    CComPtr<IDXGIFactory6> dxgiFactory;
+    HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&dxgiFactory));
+    if (FAILED(hr) || !dxgiFactory) {
+        return;
+    }
+
+    // Enumerating adapters information
+    CComPtr<IDXGIAdapter1> adapter;
+
+    for (UINT adapterIdx = 0; DXGI_ERROR_NOT_FOUND != dxgiFactory->EnumAdapters1(adapterIdx, &adapter); ++adapterIdx) {
+        DxgiAdapterInfo adapterInfo{};
+        adapterInfo.adapterIndex = adapterIdx;
+        adapter->GetDesc1(&adapterInfo.desc);
+
+        // Ignore software adapter/basic render adapter.
+        if ((adapterInfo.desc.VendorId != MSFT_BASIC_DISPLAY_ADAPTER)) {
+            gpuAdapterDescs.push_back(std::move(adapterInfo));
+        }
+        adapter.Release();
+    }
+
+    if (!gpuAdapterDescs.empty()) {
+        for (auto& adapterInfo : gpuAdapterDescs) {
+            if (IsIddAdapter(adapterInfo.desc.AdapterLuid)) {
+                tcout << FormatOutputWithOffset(1, TEXT("Idd Adapter LUID: High Part = 0x%x, Low Part = 0x%x"), adapterInfo.desc.AdapterLuid.HighPart, adapterInfo.desc.AdapterLuid.LowPart) << std::endl;
+            } else {
+                // Store the non-idd LUIDs in a list.
+                GpuLUIDs.push_back(adapterInfo.desc.AdapterLuid);
+                tcout << FormatOutputWithOffset(1, TEXT("Physical Adapter LUID: High Part = 0x%x, Low Part = 0x%x"), adapterInfo.desc.AdapterLuid.HighPart, adapterInfo.desc.AdapterLuid.LowPart) << std::endl;
+            }
+        }
+    }
+}
+
+/**
+ * Call the Idd IOCTL to update LUID.
+ */
+IDD_STATUS  UpdateAdapterLUID(IN HANDLE hDevice, IN LUID luid)
+{
+    IDD_STATUS Status = IDD_STATUS_SUCCESS;
+    IDD_UPDATE_LUID UpdateLUID = { 0 };
+    DWORD bytesReturn = 0;
+
+    tcout << FormatOutputWithOffset(1, TEXT("IDD LUID Update: Pairing with LUID high part = 0x%x, LUID low part = 0x%x"), luid.HighPart, luid.LowPart) << std::endl;
+
+    if (hDevice == NULL) {
+        tcout << FormatOutputWithOffset(2, TEXT("IDD LUID Update: Pairing failed. Null Handle passed")) << std::endl;
+        return IDD_STATUS_ACCESS_DENIED;
+    }
+
+    UpdateLUID.luid = luid;
+    if (TRUE == DeviceIoControl(
+        hDevice,
+        IOCTL_IDD_UPDATE_LUID,
+        &UpdateLUID,                 // Ptr to InBuffer
+        sizeof(UpdateLUID),          // Length of InBuffer
+        NULL,                        // Ptr to OutBuffer
+        0,                           // Length of OutBuffer
+        &bytesReturn,                // BytesReturned
+        0))                          // Ptr to Overlapped structure
+    {
+        Status = IDD_STATUS_SUCCESS;
+        tcout << FormatOutputWithOffset(2, TEXT("IDD LUID Update: Pairing succeeded")) << std::endl;
+    } else {
+        Status = IDD_INVALID_PARAM;
+        DWORD error = GetLastError();
+        tcout << FormatOutputWithOffset(2, TEXT("IDD LUID Update: Pairing failed with error %x"), error) << std::endl;
+    }
+
+    return Status;
+}
+
+/**
+ * Enumerate all the adapters in the systems.
+ * Using Query Display Config, find out all the idd adapters and store them in IddLUIDs.
+ * Using Enumerate adapters find out all the adapters in the system (both idd and non idd)
+ * Filter out the Idd adapters using the IddLUIDs list. All the other adapters must be physical adapters
+ * This can be further enhanced to have vendor id/device id checks for further restrictions. .
+ */
+void PairIddLUIDsToGpuLUIDs(void)
+{
+    IDD_STATUS Status = IDD_STATUS_SUCCESS;
+    GetAdapterLUIDs();
+
+    std::vector<tstring> path = GetDevicePath();
+    tcout << FormatOutput(TEXT("Found %llu IddAdapters"), path.size()) << std::endl;
+    for (int i = 0; i < path.size(); i++) {
+        tcout << FormatOutput(TEXT("Opening IDD device: %s"), path[i].c_str()) << std::endl;
+        HANDLE handle;
+        Status = OpenVirtualDisplay(path[i], &handle);
+        if (Status == IDD_STATUS_SUCCESS) {
+            LUID luid;
+            auto noOfPhysicalAdapter = GpuLUIDs.size();
+            luid = GpuLUIDs.at(i % noOfPhysicalAdapter);
+            UpdateAdapterLUID(handle, luid);
+            CloseHandle(handle);
+        }
+    }
+}

--- a/sources/apps/idd-setup-tool/PairIdd.h
+++ b/sources/apps/idd-setup-tool/PairIdd.h
@@ -1,0 +1,25 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include "Utility.h"
+#include "shellapi.h"
+#include <stdio.h>
+#include <filesystem>
+#include <system_error>
+
+namespace fs = std::filesystem;
+
+void PairIddLUIDsToGpuLUIDs(void);

--- a/sources/apps/idd-setup-tool/RearrangeDisplays.cpp
+++ b/sources/apps/idd-setup-tool/RearrangeDisplays.cpp
@@ -1,0 +1,535 @@
+// Copyright (C) 2022-2023 Intel Corporationation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "RearrangeDisplays.h"
+#include <unordered_map>
+
+using namespace std;
+
+#define DEBUG_PRINT 0
+
+static std::unordered_map<tstring, uint32_t> PatternMatchCounts {};
+static std::unordered_map<tstring, std::vector<tstring>> DeviceNamesForIndexedPatterns {};
+
+static bool CheckAndPrintDisplayChangeStatus(LONG sts)
+{
+    switch (sts)
+    {
+    case DISP_CHANGE_SUCCESSFUL:
+        tcout << FormatOutput(L"Display Change Status (PASS): DISP_CHANGE_SUCCESSFUL (%d)", DISP_CHANGE_SUCCESSFUL) << endl;
+        return true;
+
+    case DISP_CHANGE_RESTART:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_RESTART (%d)", DISP_CHANGE_RESTART) << endl;
+        break;
+
+    case DISP_CHANGE_FAILED:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_FAILED (%d)", DISP_CHANGE_FAILED) << endl;
+        break;
+
+    case DISP_CHANGE_BADMODE:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_BADMODE (%d)", DISP_CHANGE_BADMODE) << endl;
+        break;
+
+    case DISP_CHANGE_NOTUPDATED:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_NOTUPDATED (%d)", DISP_CHANGE_NOTUPDATED) << endl;
+        break;
+
+    case DISP_CHANGE_BADFLAGS:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_BADFLAGS (%d)", DISP_CHANGE_BADFLAGS) << endl;
+        break;
+
+    case DISP_CHANGE_BADPARAM:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_BADPARAM (%d)", DISP_CHANGE_BADPARAM) << endl;
+        break;
+
+    case DISP_CHANGE_BADDUALVIEW:
+        tcout << FormatOutput(L"Display Change Status (FAIL): DISP_CHANGE_BADDUALVIEW (%d)", DISP_CHANGE_BADDUALVIEW) << endl;
+        break;
+    }
+
+    return false;
+}
+
+static void PrintStateFlags(DWORD flags)
+{
+    if (flags)
+    {
+        tcout << FormatOutputWithOffset(1, L"StateFlags are:") << endl;
+
+        if (flags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_ATTACHED_TO_DESKTOP") << endl;
+
+        if (flags & DISPLAY_DEVICE_MULTI_DRIVER)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_MULTI_DRIVER") << endl;
+
+        if (flags & DISPLAY_DEVICE_PRIMARY_DEVICE)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_PRIMARY_DEVICE") << endl;
+
+        if (flags & DISPLAY_DEVICE_MIRRORING_DRIVER)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_MIRRORING_DRIVER") << endl;
+
+        if (flags & DISPLAY_DEVICE_VGA_COMPATIBLE)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_VGA_COMPATIBLE") << endl;
+
+        if (flags & DISPLAY_DEVICE_REMOVABLE)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_REMOVABLE") << endl;
+
+        if (flags & DISPLAY_DEVICE_ACC_DRIVER)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_ACC_DRIVER") << endl;
+
+        if (flags & DISPLAY_DEVICE_MODESPRUNED)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_MODESPRUNED") << endl;
+
+        if (flags & DISPLAY_DEVICE_RDPUDD)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_RDPUDD") << endl;
+
+        if (flags & DISPLAY_DEVICE_REMOTE)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_REMOTE") << endl;
+
+        if (flags & DISPLAY_DEVICE_DISCONNECT)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_DISCONNECT") << endl;
+
+        if (flags & DISPLAY_DEVICE_TS_COMPATIBLE)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_TS_COMPATIBLE") << endl;
+
+        if (flags & DISPLAY_DEVICE_UNSAFE_MODES_ON)
+            tcout << FormatOutputWithOffset(2, L"DISPLAY_DEVICE_UNSAFE_MODES_ON") << endl;
+    }
+}
+
+static tstring EraseFromStartOfString(tstring main_str, const tstring to_erase)
+{
+    // Search for the substring in string
+    size_t pos = StringToLowerCase(main_str).find(StringToLowerCase(to_erase));
+
+    if (pos != 0) {
+        // If not at start then dont erase.
+        return main_str;
+    }
+
+    if (pos != tstring::npos) {
+        // If found then erase it from string
+        main_str.erase(pos, to_erase.length());
+    }
+
+
+    return main_str;
+}
+
+static tstring LookupDeviceIDForDisplay(tstring device_key)
+{
+    DWORD sub_key_count=0;   // number of subkeys
+    DWORD sub_val_count=0;   // number of subvalue
+
+    // String we are searching for is always in HKEY_LOCAL_MACHINE. Likewise the format of the passed in device_key must be adjusted.
+    device_key = EraseFromStartOfString(device_key, tstring(TEXT("\\REGISTRY\\MACHINE\\")));
+
+    HKEY key_handle;
+    LONG ret_status = OpenKeyAndEnumerateInfo(
+        HKEY_LOCAL_MACHINE,
+        device_key,
+        &key_handle,
+        &sub_key_count,
+        &sub_val_count
+    );
+
+    if (ret_status != ERROR_SUCCESS) {
+        return tstring(TEXT(""));
+    }
+
+    tstring device_id;
+
+    for(int value_number = 0; value_number < sub_val_count; value_number++) {
+        TCHAR value[MAX_VALUE_NAME];
+        DWORD value_len = MAX_VALUE_NAME;
+        TCHAR value_data[255];
+        DWORD value_data_len = sizeof(value_data);
+        DWORD value_data_type;
+        ret_status = RegEnumValue(
+            key_handle,         // Handle to an open key
+            value_number,       // Index of value
+            (LPWSTR)value,      // Value name
+            &value_len,         // Buffer for value name
+            NULL,               // Reserved
+            &value_data_type,   // Value type
+            (LPBYTE)value_data, // Value data
+            &value_data_len     // Buffer for value data
+        );
+
+        if(ret_status == ERROR_SUCCESS) {
+            if (StringToLowerCase(tstring(value)).compare(tstring(L"matchingdeviceid")) == 0) {
+                device_id = tstring(value_data);
+            }
+        }
+    }
+
+    RegCloseKey(key_handle);
+
+    return device_id;
+}
+
+static void CheckEnableDisablePatternMatches(tstring device_string, tstring device_id, tstring device_name, bool verbose)
+{
+    if (verbose) {
+        tcout << FormatOutputWithOffset(1, L"Display can be enabled and disabled with patterns:") << endl;
+    }
+    for (EnableDisablePatternStruct& pattern : SupportedEnableDisablePatterns) {
+        for (tstring sub_pattern : pattern.DisplaysToMatch) {
+            bool matches_this_pattern = false;
+            if (CheckIfStringContainsPattern(device_string, sub_pattern, true) != pattern.IsAnInvertedTarget) {
+                matches_this_pattern = true;
+            }
+            if (pattern.PatternType == ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION &&
+                CheckIfStringContainsPattern(device_string, sub_pattern, true) != pattern.IsAnInvertedTarget) {
+                matches_this_pattern = true;
+            } else if (pattern.PatternType == ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID &&
+                CheckIfStringContainsPattern(device_id, sub_pattern, true) != pattern.IsAnInvertedTarget) {
+                matches_this_pattern = true;
+            }
+            if (matches_this_pattern) {
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(2, L"%s", pattern.Abbreviation.c_str()) << endl;
+                }
+                if (PatternMatchCounts.find(pattern.Abbreviation) == PatternMatchCounts.end()) {
+                    PatternMatchCounts[pattern.Abbreviation] = 1;
+                    DeviceNamesForIndexedPatterns[pattern.Abbreviation] = std::vector<tstring>();
+                } else {
+                    PatternMatchCounts[pattern.Abbreviation]++;
+                }
+                DeviceNamesForIndexedPatterns[pattern.Abbreviation].push_back(device_name);
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(2, L"%s%u", pattern.Abbreviation.c_str(), PatternMatchCounts[pattern.Abbreviation]) << endl;
+                }
+                break;
+            }
+        }
+    }
+}
+
+static void PrintDisplayDevice(DISPLAY_DEVICE display_device, tstring device_id, DWORD idev_num)
+{
+    tcout << FormatOutputWithOffset(1, L"Device number: %lu", idev_num);
+    if (display_device.StateFlags & DISPLAY_DEVICE_PRIMARY_DEVICE)
+        tcout << L" <------ Primary Device";
+    tcout << endl;
+
+    tcout << FormatOutputWithOffset(2, L"Device Name       : %s", display_device.DeviceName) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device String     : %s", display_device.DeviceString) << endl;
+    tcout << FormatOutputWithOffset(2, L"State Flags       : %lu", display_device.StateFlags) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device ID         : %s", display_device.DeviceID) << endl;
+    tcout << FormatOutputWithOffset(2, L"Device Key        : %s", display_device.DeviceKey) << endl;
+    tcout << FormatOutputWithOffset(2, L"Matching Device ID: %s", device_id.c_str()) << endl;
+    IncIndentation();
+    PrintStateFlags(display_device.StateFlags);
+    DecIndentation();
+    IncIndentation();
+    CheckEnableDisablePatternMatches(display_device.DeviceString, device_id, display_device.DeviceName, true);
+    DecIndentation();
+}
+
+static void PrintPosition(DEVMODE dev_mode)
+{
+    tcout << FormatOutputWithOffset(1, L"Position:") << endl;
+    tcout << FormatOutputWithOffset(2, L"x     : %ld", dev_mode.dmPosition.x) << endl;
+    tcout << FormatOutputWithOffset(2, L"y     : %ld", dev_mode.dmPosition.y) << endl;
+    tcout << FormatOutputWithOffset(2, L"width : %lu", dev_mode.dmPelsWidth) << endl;
+    tcout << FormatOutputWithOffset(2, L"height: %lu", dev_mode.dmPelsHeight) << endl;
+}
+
+// This function actually queries topology of screen and returns it back. No changes to displays arrangement happen here
+list_of_settings QueryActiveSettings(bool verbose, bool extract_only_attached)
+{
+    list_of_settings active_settings;
+
+    PatternMatchCounts.clear();
+    DeviceNamesForIndexedPatterns.clear();
+
+    if (verbose)
+        tcout << FormatOutput(L"Starting enumeration...") << endl;
+
+    // MSFT way to run through all displays on system is to query until it fails on some index
+    for (DWORD idev_num = 0;; ++idev_num)
+    {
+        DISPLAY_DEVICE display_device = {};
+        display_device.cb = sizeof(DISPLAY_DEVICE);
+
+        // Get info for display indexed as idev_num, this usually matches to digits on screen during "Detect display"
+        // Here we obtain some basic info like Name of the adapter, State (attached/detached, main display), reg. key location
+        if (!EnumDisplayDevices(nullptr, idev_num, &display_device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+            tcout << FormatOutputWithOffset(1, L"Enumerated %lu displays", idev_num) << endl;
+            break;
+        }
+
+        tstring device_id = LookupDeviceIDForDisplay(tstring(display_device.DeviceKey));
+
+        if (verbose) {
+            PrintDisplayDevice(display_device, device_id, idev_num);
+        } else {
+            CheckEnableDisablePatternMatches(display_device.DeviceString, device_id, display_device.DeviceName, false);
+        }
+
+        DEVMODE current_settings = {};
+        current_settings.dmSize = sizeof(DEVMODE);
+
+        // This will error out if display is not attached.
+        if (display_device.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) {
+            if (verbose) {
+                tcout << FormatOutput(L"Getting current display settings...") << endl;
+            }
+            // Now retrieving settings for selected display
+            // Gives more info about display as physical device: offset from main display, width/height in pxls, bpp, etc.
+            auto ret = EnumDisplaySettings(display_device.DeviceName, ENUM_CURRENT_SETTINGS, &current_settings);
+
+            if (!ret) {
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(1, L"ERROR: EnumDisplaySettings (Current Settings) failed with status %lu: %s", GetLastError(), GetLastErrorString().c_str()) << endl;
+                }
+                continue;
+            }
+
+            if (verbose) {
+                PrintPosition(current_settings);
+            }
+        } else if (extract_only_attached == false) {
+            auto ret = EnumDisplaySettings(display_device.DeviceName, ENUM_REGISTRY_SETTINGS, &current_settings);
+            if (!ret) {
+                if (verbose) {
+                    tcout << FormatOutputWithOffset(1, L"ERROR: EnumDisplaySettings (Registry Settings) failed with status %lu: %s", GetLastError(), GetLastErrorString().c_str()) << endl;
+                }
+                continue;
+            }
+        }
+
+        // Some of the displays are not corresponding to physically present displays.
+        if (extract_only_attached == false || display_device.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) {
+            active_settings.emplace_back(make_pair(display_device, current_settings));
+        }
+    }
+
+    if (verbose)
+        tcout << FormatOutput(L"End of enumeration...") << endl;
+
+    return active_settings;
+}
+
+// Here the magic happens. Displays are sorted in correct order in terms of their ids.
+// First display in a row made primary
+int RearrangeDisplays(list_of_settings active_settings)
+{
+    if (active_settings.empty())
+        return -1;
+
+    // Here we starting iteration over adapters to put them in correct order as screens
+    // (we store them in order as got from QueryActiveSettings, so they are already sorted by ids,
+    // but may not be sorted in same way in terms of display coordinates, we fixing it).
+
+    auto it_prev = begin(active_settings);
+
+    // Making first adapter to be our primary display
+    DEVMODE* p_dev_mode = &it_prev->second;
+    // Primary adapter has coordinates 0,0 always
+    p_dev_mode->dmPosition.x = 0;
+    // Changing y is not necessary, we consider only horizontal layout, so y is 0 for all displays
+    p_dev_mode->dmPosition.y = 0;
+
+#if DEBUG_PRINT
+    int32_t tmp_idx = 0;
+    PrintDisplayDevice(it_prev->first, tmp_idx++);
+    PrintPosition(*p_dev_mode);
+#endif
+
+    // This API operates as state machine, first we push new config for each display to Registry. At the end apply them all
+#if !DRY_RUN
+    auto ret = ChangeDisplaySettingsEx(it_prev->first.DeviceName, p_dev_mode, NULL, CDS_SET_PRIMARY | CDS_UPDATEREGISTRY | CDS_NORESET, NULL);
+    if (!CheckAndPrintDisplayChangeStatus(ret))
+        return -1;
+#endif
+
+    // Here we iterate over all adapters setting their offset carefully to have them all stacked horizontally.
+    //
+    // So briefly: Display[i].x_coord = Display[i-1].x_coord + Display[i-1].width
+
+    for (auto it_curr = next(it_prev); it_curr != end(active_settings); ++it_curr, ++it_prev)
+    {
+        p_dev_mode = &it_curr->second;
+
+        p_dev_mode->dmPosition.x = it_prev->second.dmPosition.x + it_prev->second.dmPelsWidth;
+        //NOTE: assumed pure horizontal layout, so dev_mode.dmPosition.y not touched
+
+#if DEBUG_PRINT
+        PrintDisplayDevice(it_curr->first, tmp_idx++);
+        PrintPosition(*p_dev_mode);
+#endif
+
+        // Pushing new state for current display
+#if !DRY_RUN
+        auto ret = ChangeDisplaySettingsEx(it_curr->first.DeviceName, p_dev_mode, NULL, CDS_UPDATEREGISTRY | CDS_NORESET, NULL);
+        if (!CheckAndPrintDisplayChangeStatus(ret))
+            return -1;
+#endif
+    }
+
+    // This function just applies all pushed changes, making screen blink for ~1s
+    //
+    // As result you should see stacked displays in correct order and MSFT Basic will be last one
+#if !DRY_RUN
+    ret = ChangeDisplaySettingsEx(NULL, NULL, NULL, 0, NULL);
+    if (!CheckAndPrintDisplayChangeStatus(ret))
+        return -1;
+#endif
+
+    return 0;
+}
+
+int EnableDisableDisplay(list_of_settings active_settings, display_target_info_t &target_info)
+{
+    if (active_settings.empty()) {
+        return -1;
+    }
+
+    for (auto it_adapter = begin(active_settings); it_adapter != end(active_settings); it_adapter++) {
+        tstring device_id = LookupDeviceIDForDisplay(tstring(it_adapter->first.DeviceKey));
+        bool is_match = false;
+        if (target_info.pattern_type == ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION &&
+            CheckIfStringContainsPattern(it_adapter->first.DeviceString, target_info.pattern, true) != target_info.is_an_inverted_target) {
+            is_match = true;
+        } else if (target_info.pattern_type == ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID &&
+            CheckIfStringContainsPattern(device_id, target_info.pattern, true) != target_info.is_an_inverted_target) {
+            is_match = true;
+        }
+
+        if (is_match) {
+            if (target_info.target_device_name.length() > 0 && target_info.target_device_name.find(it_adapter->first.DeviceName) != 0) {
+                // We aren't the specific display requested. Skip this display.
+                continue;
+            }
+
+            DEVMODE* p_dev_mode;
+            p_dev_mode = &it_adapter->second;
+            p_dev_mode->dmPelsWidth = target_info.default_width;
+            p_dev_mode->dmPelsHeight = target_info.default_height;
+
+            auto ret = ChangeDisplaySettingsEx(it_adapter->first.DeviceName, p_dev_mode, NULL, CDS_UPDATEREGISTRY | CDS_NORESET, NULL);
+            if (!CheckAndPrintDisplayChangeStatus(ret)) {
+                return -1;
+            }
+        }
+    }
+
+    // This function just applies all pushed changes, making screen blink for ~1s
+    //
+    // As result you should see stacked displays in correct order and MSFT Basic will be last one
+#if !DRY_RUN
+    auto ret = ChangeDisplaySettingsEx(NULL, NULL, NULL, 0, NULL);
+    if (!CheckAndPrintDisplayChangeStatus(ret)) {
+        return -1;
+    }
+#endif
+
+    return 0;
+}
+
+int EnableDisableDisplayManager(tstring Pattern, list_of_settings active_settings, bool enable)
+{
+    Pattern = StringToLowerCase(Pattern);
+
+    tstring temp_string = TEXT("disable");
+    if (enable) {
+        temp_string = TEXT("enable");
+    }
+
+    int status = 1;
+
+    for (EnableDisablePatternStruct& possible_pattern_match : SupportedEnableDisablePatterns) {
+        bool is_a_full_match = false;
+        if (Pattern.find(possible_pattern_match.Abbreviation) == 0) {
+            is_a_full_match = true;
+            tstring target_device_name = TEXT("");
+            int32_t target_index = 0;
+            // We match this abbreviated pattern. Lets check if it has an index on it.
+            if (Pattern.length() > possible_pattern_match.Abbreviation.length()) {
+                // We might have an index. Lets verify.
+                bool has_index_string = true;
+                tstring index_string = tstring(Pattern.begin() + possible_pattern_match.Abbreviation.size(), Pattern.end());
+                for (auto character : index_string) {
+                    if (tstring(TEXT("0123456789")).find(character) == tstring::npos) {
+                        // Oops what we though was an index has non-numeric contents. Guess we didnt match...
+                        has_index_string = false;
+                    }
+                }
+
+                if (has_index_string) {
+                    // We have an index. Lets extract it.
+                    target_index = get_int_from_tstring(index_string);
+                    // Check if the index we got is valid. If not we will alert user and continue.
+                    if (target_index < 1 || target_index > PatternMatchCounts[possible_pattern_match.Abbreviation]) {
+                        tcout << FormatOutputWithOffset(1, 
+                        L"The specified display to %s '%s' matches a valid display pattern '%s' but index '%d' is out of range (max of '%d', min of '1').",
+                        temp_string.c_str(),
+                        Pattern.c_str(),
+                        possible_pattern_match.Abbreviation.c_str(),
+                        target_index,
+                        PatternMatchCounts[possible_pattern_match.Abbreviation]) << endl;
+                        is_a_full_match = false;
+                    } else {
+                        target_device_name = DeviceNamesForIndexedPatterns[possible_pattern_match.Abbreviation][target_index - 1];
+                    }
+                } else {
+                    is_a_full_match = false;
+                }
+            }
+
+            if (is_a_full_match) {
+                for (tstring sub_pattern : possible_pattern_match.DisplaysToMatch) {
+                    display_target_info_t target_info;
+                    target_info.pattern = sub_pattern;
+                    target_info.is_an_inverted_target = possible_pattern_match.IsAnInvertedTarget;
+                    target_info.target_device_name = target_device_name;
+                    target_info.pattern_type = possible_pattern_match.PatternType;
+                    if (enable) {
+                        target_info.default_width = 1920;
+                        target_info.default_height = 1080;
+                        if (DisplayToResolutionMap.find(sub_pattern) != DisplayToResolutionMap.end() &&
+                            DisplayToResolutionMap[sub_pattern].PatternType == possible_pattern_match.PatternType) {
+                            target_info.default_width = DisplayToResolutionMap[sub_pattern].width;
+                            target_info.default_height = DisplayToResolutionMap[sub_pattern].height;
+                        }
+                    } else {
+                        target_info.default_width = 0;
+                        target_info.default_height = 0;
+                    }
+                    status &= EnableDisableDisplay(active_settings, target_info);
+                }
+                return status;
+            }
+        }
+    }
+
+    tcout << FormatOutputWithOffset(1, 
+        L"The specified display to %s '%s' matched no display patterns supported by this tool.", temp_string.c_str(), Pattern.c_str()) << endl;
+    return status;
+}
+
+int DisableDisplay(tstring Pattern, list_of_settings active_settings)
+{
+    return EnableDisableDisplayManager(Pattern, active_settings, false);
+}
+
+int EnableDisplay(tstring Pattern, list_of_settings active_settings)
+{
+    return EnableDisableDisplayManager(Pattern, active_settings, true);
+}

--- a/sources/apps/idd-setup-tool/RearrangeDisplays.h
+++ b/sources/apps/idd-setup-tool/RearrangeDisplays.h
@@ -1,0 +1,39 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Utility.h"
+
+using device_settings_pair = std::pair<DISPLAY_DEVICE, DEVMODE>;
+using list_of_settings = std::list<device_settings_pair>;
+
+struct display_target_info_t
+{
+    tstring                      pattern;
+    bool                         is_an_inverted_target;
+    tstring                      target_device_name;
+    ENABLE_DISABLE_PATTERN_TYPES pattern_type;
+    int32_t                      default_width;
+    int32_t                      default_height;
+};
+
+// This function actually queries topology of screen and returns it back. No changes to displays arrangement happen here
+list_of_settings QueryActiveSettings(bool verbose = true, bool extract_only_attached = true);
+
+int RearrangeDisplays(list_of_settings active_settings);
+int DisableDisplay(tstring Pattern, list_of_settings active_settings);
+int EnableDisplay(tstring Pattern, list_of_settings active_settings);

--- a/sources/apps/idd-setup-tool/Utility.cpp
+++ b/sources/apps/idd-setup-tool/Utility.cpp
@@ -1,0 +1,347 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "IddSetupToolCommandParser.h"
+#include "Utility.h"
+
+#include <initguid.h>
+#include "Guids.h"
+
+std::unique_ptr<IddSetupToolCommandParser> g_params;
+
+std::filesystem::path getExePath()
+{
+    tstring exe(MAX_PATH, 0);
+    auto path_len = GetModuleFileName(nullptr, exe.data(), exe.size());
+    if (path_len == 0) {
+        tcout << FormatOutput(L"Error: GetModuleFileName() failed") << std::endl;
+        return std::filesystem::path();
+    }
+    return std::filesystem::path(exe);
+}
+
+tstring StringToLowerCase(tstring TargetString)
+{
+    std::transform(TargetString.begin(), TargetString.end(), TargetString.begin(),
+        [](TCHAR SubChar){ return std::tolower(SubChar); });
+    return TargetString;
+}
+
+// Compare strings, ignore case by default.
+bool CheckIfStringContainsPattern(tstring target, tstring pattern, bool ignore_case)
+{
+    if (ignore_case) {
+        target = StringToLowerCase(target);
+        pattern = StringToLowerCase(pattern);
+    }
+    // Check if target by comparing strings
+    return tstring(target).find(pattern) != tstring::npos;
+};
+
+std::vector<tstring> SplitStringOnDelimiter(tstring Content, tstring Delimeter)
+{
+    std::vector<tstring> Result;
+    auto PreviousPosition = Content.begin();
+    auto NextPosition = std::search(PreviousPosition, Content.end(),
+                               Delimeter.begin(), Delimeter.end());
+    while (NextPosition != Content.end())
+    {
+        Result.emplace_back(PreviousPosition, NextPosition);
+        PreviousPosition = NextPosition + Delimeter.size();
+        NextPosition = std::search(PreviousPosition, Content.end(),
+                               Delimeter.begin(), Delimeter.end());
+    }
+
+    if (PreviousPosition != Content.end())
+    {
+        Result.emplace_back(PreviousPosition, Content.end());
+    }
+    return Result;
+}
+
+std::string GetLastErrorString()
+{
+    using namespace std;
+
+    //Get the error message ID, if any.
+    DWORD errorMessageID = GetLastError();
+    if (errorMessageID == 0)
+    {
+        return string(); //No error message has been recorded
+    }
+
+    LPSTR messageBuffer = nullptr;
+
+    //Ask Win32 to give us the string version of that message ID.
+    //The parameters we pass in, tell Win32 to create the buffer that holds the message for us (because we don't yet know how long the message string will be).
+    size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+    //Copy the error message into a string.
+    string message(messageBuffer, size);
+
+    //Free the Win32's string's buffer.
+    LocalFree(messageBuffer);
+
+    // Remove trailing \r\n
+    message.erase(remove(begin(message), end(message), '\n'), cend(message));
+    message.erase(remove(begin(message), end(message), '\r'), cend(message));
+
+    return message;
+}
+
+void GetLastErrorAndThrow(tstring function_name)
+{
+    tstringstream ss;
+    ss << "ERROR: " << function_name << " failed with status " << std::hex << GetLastError() << " (" << s2ws(GetLastErrorString()) << ")\n";
+    throw ss.str();
+}
+
+/**
+ * Create child process executes system command and return result in string
+ *
+ * @param cmd [in] The command to execute
+ * @param result [out] The return result in string
+ *
+ * @return Returns true if success, false otherwise
+ */
+bool RunSystemCommand(const tstring& cmdline, tstring& result) {
+    result.clear();
+
+    bool ResultStatus = true;
+
+    HANDLE h_child_stdin_read = nullptr, h_child_stdin_write = nullptr;
+    HANDLE h_child_stdout_read = nullptr, h_child_stdout_write = nullptr;
+    SECURITY_ATTRIBUTES sa = {};
+
+    sa.nLength              = sizeof(SECURITY_ATTRIBUTES);
+    sa.bInheritHandle       = TRUE;
+    sa.lpSecurityDescriptor = nullptr;
+
+    /*
+     * +---------------------+                +---------------------+
+     * |   Parent Process    |                |   Child Process     |
+     * +---------------------+                +---------------------+
+     * |                     |                |                     |
+     * | h_child_stdin_write | -------------> | h_child_stdin_Read  |
+     * |                     |                |                     |
+     * | h_child_stdout_read | <------------- | h_child_stdout_write|
+     * |                     |                |                     |
+     * +---------------------+                +---------------------+
+     *
+     */
+
+    // Create child stdin read/write pipe
+    if (CreatePipe(&h_child_stdin_read, &h_child_stdin_write, &sa, 0) == FALSE)
+        return false;
+
+    // Create child stdout read/write pipe
+    if (CreatePipe(&h_child_stdout_read, &h_child_stdout_write, &sa, 0) == FALSE) {
+        CloseHandle(h_child_stdin_read);
+        CloseHandle(h_child_stdin_write);
+        return false;
+    }
+
+    STARTUPINFO si = {};
+    PROCESS_INFORMATION pi = {};
+
+    // Set STRTUPINFO for the spawned process
+    // The dwFlags member tells CreateProcess how to make the process
+    //   STARTF_USESTDHANDLES: validates the hStd* members.
+    //   STARTF_USESHOWWINDOW: validates the wShowWindow member
+    GetStartupInfo(&si);
+
+    si.dwFlags      = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+    si.wShowWindow  = SW_HIDE;  // Silent command window
+    si.hStdOutput   = h_child_stdout_write;
+    si.hStdError    = h_child_stdout_write;
+    si.hStdInput    = h_child_stdin_read;
+
+    // spawn the child process to executes the command
+    if (CreateProcess(nullptr, (LPWSTR)cmdline.c_str(), nullptr, nullptr, TRUE, CREATE_NEW_CONSOLE, nullptr, nullptr, &si, &pi)) {
+        const size_t max_buffer_size = 4096;
+        unsigned long bytes_read = 0;
+        unsigned long bytes_avail = 0;
+        CHAR buf[max_buffer_size] = {};
+
+        // Command executes normally quick respond.
+        // Wait until child process exits just in-case.
+        WaitForSingleObject(pi.hProcess, INFINITE);
+
+        for (;;) {
+            PeekNamedPipe(h_child_stdout_read, buf, sizeof(buf) - 1, &bytes_read, &bytes_avail, nullptr);
+            // Check to see if there is any data ready to read from stdout
+            if (bytes_read != 0) {
+                if (ReadFile(h_child_stdout_read, buf, sizeof(buf) - 1, &bytes_read, nullptr)) {
+                    // Convert to a wchar_t*
+                    size_t buf_size = strlen(buf) + 1;
+                    const size_t new_size = max_buffer_size;
+                    size_t converted_chars = 0;
+                    wchar_t wcstring[new_size];
+                    mbstowcs_s(&converted_chars, wcstring, buf_size, buf, _TRUNCATE);
+                    result += tstring(wcstring);
+                    break;
+                }
+            }
+        }
+        // Close thread and process handles
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+    } else {
+        ResultStatus = false;
+    }
+    // Close all pipe handles
+    CloseHandle(h_child_stdin_read);
+    CloseHandle(h_child_stdin_write);
+    CloseHandle(h_child_stdout_read);
+    CloseHandle(h_child_stdout_write);
+
+    // Remove last newline if appeared
+    if (!result.empty() && result[result.size() - 1] == '\n') {
+        result.pop_back();
+    }
+
+    return ResultStatus;
+}
+
+tstring FormatString(const TCHAR *format_string, ...)
+{
+    // Construct the formatted source message
+    TCHAR buffer[4096];
+    va_list args;
+    va_start(args, format_string);
+    vswprintf(buffer, 4096, format_string, args);
+    va_end(args);
+    tstring source_message = tstring(buffer);
+
+    return source_message;
+}
+
+tstring FormatOutput(const TCHAR *format_string, ...)
+{
+    // Construct the formatted source message
+    TCHAR buffer[4096];
+    va_list args;
+    va_start(args, format_string);
+    vswprintf(buffer, 4096, format_string, args);
+    va_end(args);
+    tstring source_message = tstring(buffer);
+
+    // Prepare indentation to insert
+    tstring indentation_string = L"";
+    if (g_params != NULL)
+    {
+        for (int indent = 0; indent < g_params->Options.IndentationLevel; indent++)
+        {
+            indentation_string += L"  ";
+        }
+    }
+
+    // Iterate over lines in source message and insert indentation
+    int32_t start_location = 0;
+    size_t end_location = source_message.find(L'\n', start_location);
+    tstring destination = L"";
+    while (end_location != tstring::npos)
+    {
+        tstring substring = source_message.substr(start_location, end_location - start_location);
+        substring.erase(remove(begin(substring), end(substring), '\n'), cend(substring));
+        substring.erase(remove(begin(substring), end(substring), '\r'), cend(substring));
+        destination += indentation_string + substring + L"\n";
+        start_location = end_location + 1;
+        end_location = source_message.find(L'\n', start_location);
+    }
+
+    tstring substring = source_message.substr(start_location, source_message.length() - start_location);
+    substring.erase(remove(begin(substring), end(substring), '\n'), cend(substring));
+    substring.erase(remove(begin(substring), end(substring), '\r'), cend(substring));
+    destination += indentation_string + substring;
+
+    return destination;
+}
+
+tstring FormatOutputWithOffset(uint32_t offset_amount, const TCHAR *format_string, ...)
+{
+    // Construct the formatted source message
+    TCHAR buffer[4096];
+    va_list args;
+    va_start(args, format_string);
+    vswprintf(buffer, 4096, format_string, args);
+    va_end(args);
+    tstring source_message = tstring(buffer);
+
+    // Call FormatOutput with temporary indentation
+    for (int indent = 0; indent < offset_amount; indent++)
+    {
+        IncIndentation();
+    }
+    tstring formatted_message = FormatOutput(source_message.c_str());
+    for (int indent = 0; indent < offset_amount; indent++)
+    {
+        DecIndentation();
+    }
+
+    return formatted_message;
+}
+
+void IncIndentation()
+{
+    if (g_params == NULL) return;
+    g_params->Options.IndentationLevel++;
+}
+
+void DecIndentation()
+{
+    if (g_params == NULL) return;
+    g_params->Options.IndentationLevel--;
+}
+
+LONG OpenKeyAndEnumerateInfo(HKEY base_key, tstring target_key, HKEY* key_handle, DWORD* sub_key_count, DWORD* sub_value_count)
+{
+    LONG ret_status = RegOpenKeyExW(
+        base_key,           // Key
+        target_key.c_str(), // Subkey
+        0,                  // Reserved
+        KEY_ALL_ACCESS,     // desired access rights to the key
+        key_handle          // variable that receives a handle to the opened key
+    );
+
+    if(ret_status != ERROR_SUCCESS) {
+        return ret_status;
+    }
+
+    // Get the class name and the value count.
+    ret_status = RegQueryInfoKeyW(
+        *key_handle,     // key handle
+        NULL,            // buffer for class name
+        NULL,            // size of class string
+        NULL,            // reserved
+        sub_key_count,   // number of subkeys
+        NULL,            // longest subkey size
+        NULL,            // longest class string
+        sub_value_count, // number of values for this key
+        NULL,            // longest value name
+        NULL,            // longest value data
+        NULL,            // security descriptor
+        NULL             // last write time
+    );
+
+    if(ret_status != ERROR_SUCCESS) {
+        RegCloseKey(*key_handle);
+        return ret_status;
+    }
+
+    return ERROR_SUCCESS;
+}

--- a/sources/apps/idd-setup-tool/Utility.h
+++ b/sources/apps/idd-setup-tool/Utility.h
@@ -1,0 +1,165 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <list>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <windows.h>
+#include <Wingdi.h>
+#include <Winuser.h>
+#include <SetupAPI.h>
+#include <stringapiset.h>
+
+#define DRY_RUN 0// Debug regime, no changes really applied
+#define MAX_KEY_LENGTH 255
+#define MAX_VALUE_NAME 16383
+
+#define INDIRECT_DISPLAY_SUPPORT_KEY_PATH L"SYSTEM\\CurrentControlSet\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}"
+// "HKLM\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}"
+
+std::filesystem::path getExePath();
+
+static inline std::filesystem::path GetDefaultIddPath(void) {
+    return getExePath().replace_filename("idd");
+}
+
+static inline bool isIddOk(const std::filesystem::path& idd) {
+    bool check = true;
+    check &= std::filesystem::is_regular_file(idd / "IddSampleDriver.inf");
+    check &= std::filesystem::is_regular_file(idd / "IddSampleDriver.dll");
+    check &= std::filesystem::is_regular_file(idd / "iddsampledriver.cat");
+
+    return check;
+}
+
+// Wide / regular chars supported in entire code
+
+static std::wstring s2ws(const std::string& str)
+{
+    int32_t size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
+    std::wstring wstr(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstr[0], size_needed);
+    return wstr;
+}
+static std::string ws2s(const std::wstring& wstr)
+{
+    int32_t size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, 0, 0);
+    std::string str(size_needed, 0);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], size_needed, 0, 0);
+    return str;
+}
+#if defined(UNICODE) || defined(_UNICODE)
+#define tcout std::wcout
+#define PROPER_FUNCTION(FUNCTION) FUNCTION##"W"
+#define get_tstring_from_chars(CHAR_ARRAY) s2ws(std::string(CHAR_ARRAY))
+#define get_tstring_from_wchars(CHAR_ARRAY) std::wstring(CHAR_ARRAY)
+#define get_int_from_string(STRING) std::stoi(STRING)
+#define get_int_from_wstring(STRING) std::stoi(ws2s(STRING))
+#define get_int_from_tstring(STRING) get_int_from_wstring(STRING)
+#else
+#define tcout std::cout
+#define PROPER_FUNCTION(FUNCTION) FUNCTION##"A"
+#define get_tstring_from_chars(CHAR_ARRAY) std::string(CHAR_ARRAY)
+#define get_tstring_from_wchars(CHAR_ARRAY) ws2s(std::wstring(CHAR_ARRAY))
+#define get_int_from_string(STRING) std::stoi(STRING)
+#define get_int_from_wstring(STRING) std::stoi(ws2s(STRING))
+#define get_int_from_tstring(STRING) get_int_from_string(STRING)
+#endif
+
+using tstring = std::basic_string<TCHAR>;
+using tstringstream = std::basic_stringstream<TCHAR>;
+
+enum ENABLE_DISABLE_PATTERN_TYPES {
+    DESCRIPTION = 0,
+    VENDOR_AND_DEVICE_ID
+};
+
+typedef struct ENABLE_DISABLE_PATTERN {
+    tstring Abbreviation = TEXT("");
+    std::list<tstring> DisplaysToMatch = {};
+    std::list<tstring> AdaptersToMatch = {};
+    bool IsAnInvertedTarget = false;
+    ENABLE_DISABLE_PATTERN_TYPES PatternType;
+} EnableDisablePatternStruct;
+
+static std::list<EnableDisablePatternStruct> SupportedEnableDisablePatterns = {
+    {TEXT("flex")    , {}                                        , {TEXT("VEN_8086&DEV_56C0"),
+                                                                    TEXT("VEN_8086&DEV_56C1")}               , false, ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID},
+    {TEXT("non-flex"), {TEXT("VEN_8086&DEV_56C1"),
+                        TEXT("VEN_8086&DEV_56C1")}               , {}                                        , true , ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID},
+    {TEXT("idd")     , {TEXT("Intel IddSampleDriver Device")}    , {TEXT("Intel IddSampleDriver Device")}    , false, ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION},
+    {TEXT("non-idd") , {TEXT("Intel IddSampleDriver Device")}    , {}                                        , true , ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION},
+    {TEXT("msft")    , {TEXT("Microsoft Basic Display")}         , {TEXT("Microsoft Basic Display Adapter")} , false, ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION},
+    {TEXT("virtio")  , {TEXT("Red Hat VirtIO GPU DOD controller"),
+                        TEXT("Red Hat QXL controller")          }, {}                                        , false, ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION}
+};
+
+typedef struct RESOLUTION {
+    int32_t width = 0;
+    int32_t height = 0;
+    ENABLE_DISABLE_PATTERN_TYPES PatternType;
+} ResolutionStruct;
+
+static std::unordered_map<tstring, ResolutionStruct> DisplayToResolutionMap = {
+    {TEXT("VEN_8086&DEV_56C0")                , {1920, 1080, ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID}},
+    {TEXT("VEN_8086&DEV_56C1")                , {1920, 1080, ENABLE_DISABLE_PATTERN_TYPES::VENDOR_AND_DEVICE_ID}},
+    {TEXT("Intel IddSampleDriver Device")     , {1920, 1080, ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION}},
+    {TEXT("Microsoft Basic Display")          , {1024, 768 , ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION}},
+    {TEXT("Red Hat VirtIO GPU DOD controller"), {1280, 1024, ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION}},
+    {TEXT("Red Hat QXL controller")           , {1024, 768 , ENABLE_DISABLE_PATTERN_TYPES::DESCRIPTION}},
+};
+
+class ClassDevsScopedStorage
+{
+public:
+    ClassDevsScopedStorage(HDEVINFO devs)
+        : m_devs(devs)
+    {}
+
+    ~ClassDevsScopedStorage()
+    {
+        if (m_devs != INVALID_HANDLE_VALUE)
+        {
+            // (unclear from docs whether SetupDiDeleteDeviceInfo must also be called explicitly, or will be called inside here)
+            std::ignore = SetupDiDestroyDeviceInfoList(m_devs);
+        }
+    }
+
+private:
+    HDEVINFO m_devs = INVALID_HANDLE_VALUE;
+};
+
+tstring StringToLowerCase(tstring str);
+bool CheckIfStringContainsPattern(tstring target, tstring pattern, bool ignore_case = true);
+std::vector<tstring> SplitStringOnDelimiter(tstring Content, tstring Delimeter);
+std::string GetLastErrorString();
+void GetLastErrorAndThrow(tstring function_name);
+bool RunSystemCommand(const tstring& cmdline, tstring& result);
+tstring FormatString(const TCHAR *format_string, ...);
+tstring FormatOutput(const TCHAR *format_string, ...);
+tstring FormatOutputWithOffset(uint32_t offset_amount, const TCHAR *format_string, ...);
+void IncIndentation();
+void DecIndentation();
+LONG OpenKeyAndEnumerateInfo(HKEY base_key, tstring target_key, HKEY* key_handle, DWORD* sub_key_count, DWORD* sub_value_count);

--- a/sources/apps/idd-setup-tool/idd-setup-tool.cpp
+++ b/sources/apps/idd-setup-tool/idd-setup-tool.cpp
@@ -1,0 +1,287 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Utility.h"
+#include "ChangeDisplaySettings.h"
+#include "RearrangeDisplays.h"
+#include "PairIdd.h"
+#include "EnableDisableAdapters.h"
+#include "InstallIDD.h"
+#include "IddSetupToolCommandParser.h"
+
+#include <limits>
+#include <chrono>
+#include <thread>
+
+using namespace std;
+
+extern std::unique_ptr<IddSetupToolCommandParser> g_params;
+
+void ApplyExecutionDelayBeforeDisplayChange(void)
+{
+    if (g_params->Options.PostActionDelay > 0) {
+        tcout << FormatOutput(TEXT("Waiting for %ums before changing display settings..."), g_params->Options.PostActionDelay) << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(g_params->Options.PostActionDelay));
+    }
+}
+
+int main(int argc, char** argv)
+{
+    int32_t status = 0;
+    uint32_t StepCounter = 1;
+    size_t num_idd_compatible_adapters = numeric_limits<size_t>::max();
+    list_of_settings active_settings;
+    bool reboot_required = false;
+    bool delay_required_before_display_change = false;
+
+    g_params = std::make_unique<IddSetupToolCommandParser>();
+
+    if (!g_params->ParseCommands(argc, argv)) {
+        return -1;
+    }
+
+    tcout << FormatOutput(L"Starting IDD Setup Tool") << endl;
+    IncIndentation();
+
+    try
+    {
+        if (g_params->Options.UninstallIdd)
+        {
+            tcout << FormatOutput(L"%u: Starting uninstallation of previous IDD displays", StepCounter++) << endl;
+            IncIndentation();
+            if (!UninstallIDD()) {
+                return -1;
+            }
+            DecIndentation();
+        }
+
+        if (StringToLowerCase(g_params->Options.ShowAdaptersInfo) == TEXT("yes") || StringToLowerCase(g_params->Options.ShowIddCount) == TEXT("yes"))
+        {
+            tcout << FormatOutput(L"%u: Showing adapter info", StepCounter++) << endl;
+            IncIndentation();
+
+            auto adapter_list = GetAdapterList(StringToLowerCase(g_params->Options.ShowAdaptersInfo) == TEXT("yes") || g_params->Options.Verbose);
+            num_idd_compatible_adapters = GetNumIddCompatibleAdapters(adapter_list);
+
+            if (StringToLowerCase(g_params->Options.ShowIddCount) == TEXT("yes"))
+            {
+                tcout << FormatOutput(L"Number of IDD compatible adapters found on system: %llu", num_idd_compatible_adapters) << endl;
+            }
+
+            DecIndentation();
+        }
+
+        if (StringToLowerCase(g_params->Options.ShowDisplaysInfo) == TEXT("yes"))
+        {
+            tcout << FormatOutput(L"%u: Showing display info", StepCounter++) << endl;
+            IncIndentation();
+            active_settings = QueryActiveSettings(true, true);
+            DecIndentation();
+        }
+
+        if (g_params->Options.TrustInf)
+        {
+            tcout << FormatOutput(L"%u: Trusting IDD INF file", StepCounter++) << endl;
+            IncIndentation();
+            if (!TrustIDD(g_params->Options.InfPath)) {
+                return -1;
+            }
+            DecIndentation();
+        }
+
+        if (g_params->Options.InstallIdd)
+        {
+            tcout << FormatOutput(L"%u: Installing IDD drivers", StepCounter++) << endl;
+            tcout << FormatOutputWithOffset(1, L"This will take several seconds and the screen will flash several times. Be patient!") << endl;
+            IncIndentation();
+
+            auto adapter_list = GetAdapterList(g_params->Options.Verbose);
+            num_idd_compatible_adapters = GetNumIddCompatibleAdapters(adapter_list);
+
+            for (int i = 0; i < num_idd_compatible_adapters; ++i)
+            {
+                if (!InstallIDD(g_params->Options.InfPath, TEXT("root\\iddsampledriver"), reboot_required, g_params->Options.Verbose)) {
+                    return -1;
+                }
+            }
+            tcout << FormatOutput(L"Successfully installed %llu IDD drivers. Reboot is %s", num_idd_compatible_adapters, (reboot_required ? L"REQUIRED" : L"NOT REQUIRED")) << endl;
+            DecIndentation();
+
+            tcout << FormatOutput(L"%u: Setting up additional register keys required by IDD", StepCounter++) << endl;
+            IncIndentation();
+            if (!SetIDDRegisterKeys()) {
+                return -1;
+            }
+            DecIndentation();
+
+            tcout << FormatOutput(L"%u: Restarting all display adapters", StepCounter++) << endl;
+            IncIndentation();
+            DisableDisplayAdapter(TEXT("idd"), g_params->Options.Verbose);
+            DisableDisplayAdapter(TEXT("flex"), g_params->Options.Verbose);
+            EnableDisplayAdapter(TEXT("flex"), g_params->Options.Verbose);
+            EnableDisplayAdapter(TEXT("idd"), g_params->Options.Verbose);
+            DecIndentation();
+            delay_required_before_display_change = true;
+        }
+
+        if (g_params->Options.PairIdd)
+        {
+            tcout << FormatOutput(L"%u: Pairing each IDD display adapter with IDD compatible adapter", StepCounter++) << endl;
+            IncIndentation();
+            PairIddLUIDsToGpuLUIDs();
+            DecIndentation();
+        }
+
+        if (g_params->Options.DisplaysToDisable.size() > 0)
+        {
+            if (delay_required_before_display_change) {
+                ApplyExecutionDelayBeforeDisplayChange();
+                delay_required_before_display_change = false;
+            }
+
+            if (g_params->Options.Verbose)
+                tcout << FormatOutput(L"%u: Querying Display Info", StepCounter++) << endl;
+
+            IncIndentation();
+            active_settings = QueryActiveSettings(g_params->Options.Verbose, true);
+            DecIndentation();
+
+            tcout << FormatOutput(L"%u: Disabling requested displays", StepCounter++) << endl;
+            IncIndentation();
+            for (tstring Pattern : g_params->Options.DisplaysToDisable) {
+                tcout << FormatOutput(L"Acting on display pattern: %s", Pattern.c_str()) << endl;
+
+                if (DisableDisplay(Pattern, active_settings)) {
+                    return -1;
+                }
+            }
+            DecIndentation();
+        }
+
+        if (g_params->Options.AdaptersToDisable.size() > 0)
+        {
+            tcout << FormatOutput(L"%u: Disabling requested display adapters", StepCounter++) << endl;
+            IncIndentation();
+            for (tstring Pattern : g_params->Options.AdaptersToDisable) {
+                tcout << FormatOutput(L"Acting on display adapter pattern: %s", Pattern.c_str()) << endl;
+                DisableDisplayAdapter(Pattern, g_params->Options.Verbose);
+            }
+            DecIndentation();
+            delay_required_before_display_change = true;
+        }
+
+        if (g_params->Options.AdaptersToEnable.size() > 0)
+        {
+            tcout << FormatOutput(L"%u: Enabling requested display adapters", StepCounter++) << endl;
+            IncIndentation();
+            for (tstring Pattern : g_params->Options.AdaptersToEnable) {
+                tcout << FormatOutput(L"Acting on display adapter pattern: %s", Pattern.c_str()) << endl;
+                EnableDisplayAdapter(Pattern, g_params->Options.Verbose);
+            }
+            DecIndentation();
+            delay_required_before_display_change = true;
+        }
+
+        if (g_params->Options.DisplaysToEnable.size() > 0)
+        {
+            if (delay_required_before_display_change) {
+                ApplyExecutionDelayBeforeDisplayChange();
+                delay_required_before_display_change = false;
+            }
+
+            if (g_params->Options.Verbose)
+                tcout << FormatOutput(L"%u: Querying Display Info", StepCounter++) << endl;
+
+            IncIndentation();
+            active_settings = QueryActiveSettings(g_params->Options.Verbose, false);
+            DecIndentation();
+
+            tcout << FormatOutput(L"%u: Enabling requested displays", StepCounter++) << endl;
+            IncIndentation();
+            for (tstring Pattern : g_params->Options.DisplaysToEnable) {
+                tcout << FormatOutput(L"Acting on display pattern: %s", Pattern.c_str()) << endl;
+
+                if (EnableDisplay(Pattern, active_settings)) {
+                    return -1;
+                }
+            }
+            DecIndentation();
+        }
+
+        if (g_params->Options.Resolutions[0] != 0 && g_params->Options.Resolutions[1] != 0)
+        {
+            if (delay_required_before_display_change) {
+                ApplyExecutionDelayBeforeDisplayChange();
+                delay_required_before_display_change = false;
+            }
+            tcout << FormatOutput(L"%u: Adjusting IDD display resolution settings", StepCounter++) << endl;
+            IncIndentation();
+            SetDisplayResolution(g_params->Options.Resolutions[0], g_params->Options.Resolutions[1]);
+            DecIndentation();
+        }
+
+        if (g_params->Options.RearrangeDisplays)
+        {
+            if (delay_required_before_display_change) {
+                ApplyExecutionDelayBeforeDisplayChange();
+                delay_required_before_display_change = false;
+            }
+
+            if (g_params->Options.Verbose)
+                tcout << FormatOutput(L"%u: Querying Display Info", StepCounter++) << endl;
+
+            IncIndentation();
+            active_settings = QueryActiveSettings(g_params->Options.Verbose, true);
+            DecIndentation();
+
+            tcout << FormatOutput(L"%u: Rearranging displays", StepCounter++) << endl;
+            IncIndentation();
+
+            if (RearrangeDisplays(active_settings))
+                return -1;
+
+            DecIndentation();
+        }
+
+        if (g_params->Options.Scale != 0)
+        {
+            if (delay_required_before_display_change) {
+                ApplyExecutionDelayBeforeDisplayChange();
+                delay_required_before_display_change = false;
+            }
+
+            tcout << FormatOutput(L"%u: Adjusting IDD display scaling settings", StepCounter++) << endl;
+            IncIndentation();
+            SetDisplayDPI(g_params->Options.Scale, g_params->Options.Verbose);
+            DecIndentation();
+        }
+    }
+    catch (const tstring& ex)
+    {
+        tcout << FormatOutput(L"ERROR: Exception caught!") << endl;
+        tcout << FormatOutputWithOffset(1, L"%s", ex.c_str()) << endl;
+        return -1;
+    }
+    catch (...)
+    {
+        tcout << FormatOutput(L"ERROR: Unexpected exception caught!") << endl;
+        return -1;
+    }
+
+    DecIndentation();
+    tcout << FormatOutput(L"IDD Setup Tool Finished") << endl;
+    return 0;
+}

--- a/sources/apps/idd-setup-tool/idd-setup-tool.rc
+++ b/sources/apps/idd-setup-tool/idd-setup-tool.rc
@@ -1,0 +1,106 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+#include "cg-version.h"
+
+#define DESCRIPTION         "Install, Setup, and Enumerate IDD on all GPU adapters"
+#define INTERNALNAME        "idd-setup-tool.exe"
+#define ORIGINALFILENAME    "idd-setup-tool.exe"
+
+#ifndef _DEBUG
+#define VER_DEBUG   0x00000000L
+#else
+#define VER_DEBUG   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    CG_FILEVERSION
+ PRODUCTVERSION CG_PRODUCTVERSION
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      VER_DEBUG
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_APP
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",        CG_MANUFACTURER
+            VALUE "FileDescription",    DESCRIPTION
+            VALUE "FileVersion",        CG_VERSION_STR
+            VALUE "InternalName",       INTERNALNAME
+            VALUE "LegalCopyright",     CG_LEGALCOPYRIGHT
+            VALUE "OriginalFilename",   ORIGINALFILENAME
+            VALUE "ProductName",        CG_PRODUCTNAME
+            VALUE "ProductVersion",     CG_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/sources/apps/idd-setup-tool/install_certificate.ps1
+++ b/sources/apps/idd-setup-tool/install_certificate.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+Install certificate into certificate store
+
+.DESCRIPTION
+Given the path to a certificate (.cat file) this installs the sertificate as a trusted in all certificate stores on the system.
+
+.PARAMETER driverFile
+Path to the certificate (.cat file) to be installed.
+
+.OUTPUTS
+No outputs.
+
+#>
+
+#Requires -RunAsAdministrator
+
+param (
+    [string]$driverFile = ''
+)
+
+$tempFile = New-TemporaryFile;
+$certStores = "TrustedPublisher";
+$exportType = [System.Security.Cryptography.X509Certificates.X509ContentType]::Cert;
+
+write-Output "Trusting certificate for: $driverFile"
+
+$cert = (Get-AuthenticodeSignature $driverFile).SignerCertificate;
+if ($NULL -eq $cert) {
+    $msg = "  Warning: {0} is not signed, cannot extract certificate" -f $driverFile
+    Write-Output $msg
+    exit 0
+}
+[System.IO.File]::WriteAllBytes($tempFile, $cert.Export($exportType));
+
+foreach ($store in $certStores)
+{
+    certutil -addstore $store $tempFile
+}

--- a/sources/apps/idd-setup-tool/meson.build
+++ b/sources/apps/idd-setup-tool/meson.build
@@ -1,0 +1,66 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+srcs = [cgver_file, cgvcs_tgt]
+srcs += files(
+  'ChangeDisplaySettings.cpp',
+  'ChangeDisplaySettings.h',
+  'CommandParserImpl.cpp',
+  'CommandParserImpl.h',
+  'EnableDisableAdapters.cpp',
+  'EnableDisableAdapters.h',
+  'Guids.h',
+  'IddSetupToolCommandParser.cpp',
+  'IddSetupToolCommandParser.h',
+  'InstallIDD.cpp',
+  'InstallIDD.h',
+  'RearrangeDisplays.cpp',
+  'RearrangeDisplays.h',
+  'PairIdd.cpp',
+  'PairIdd.h',
+  'Utility.cpp',
+  'Utility.h',
+  'idd-setup-tool.cpp',
+  )
+
+srcs += windows.compile_resources(
+  files('idd-setup-tool.rc'),
+  args : winres_args,
+  depend_files : [ cgver_file, files('resource.h') ],
+  depends : cgvcs_tgt,
+  )
+
+cpp_args = ['-DNOMINMAX', '-DUNICODE', '-D_UNICODE']
+
+deps = [
+  cpp.find_library('dxgi'),
+  cpp.find_library('user32'),
+  cpp.find_library('advapi32'),
+  ]
+
+executable('idd-setup-tool', srcs,
+  include_directories : include_directories('../../drivers/idd/uapi'),
+  cpp_args : cpp_args,
+  dependencies : deps,
+  install : true,
+  )
+
+install_data(
+  files(
+    'install_certificate.ps1',
+    ),
+  install_dir : get_option('bindir'),
+  )

--- a/sources/apps/idd-setup-tool/resource.h
+++ b/sources/apps/idd-setup-tool/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by idd-setup-tool.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/sources/apps/meson.build
+++ b/sources/apps/meson.build
@@ -1,0 +1,18 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('idd-setup-tool')
+subdir('enum-adapters')

--- a/sources/drivers/idd/.gitignore
+++ b/sources/drivers/idd/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+Debug/
+Release/
+x64/

--- a/sources/drivers/idd/Driver.cpp
+++ b/sources/drivers/idd/Driver.cpp
@@ -1,0 +1,1064 @@
+// Copyright (C) Microsoft Corporation
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// This file contains modifications made to the original Microsoft sample code from
+// https://github.com/microsoft/Windows-driver-samples/tree/main/video/IndirectDisplay/IddSampleDriver
+//
+// List of modifications:
+// 1. Customize list of supported resolutions and modes
+// 2. Customize supported registry key values
+// 3. Add multi-adapter support
+// 4. Add support for hw cursor
+
+#include "Driver.h"
+#include "Driver.tmh"
+
+using namespace std;
+using namespace Microsoft::IndirectDisp;
+using namespace Microsoft::WRL;
+
+#pragma region SampleMonitors
+
+//
+// This device Interface Guid for IddSampleDriver device class.
+//    is used in SetupDiEnumDeviceInterfaces to enumrates all registered interfaces
+//
+const GUID GUID_DEVINTERFACE_IDD_DEVICE = \
+{ 0x881EF630, 0x82B2, 0x81d2, { 0x88, 0x82,  0x80,  0x80,  0x8E,  0x8F,  0x82,  0x82 } };
+
+
+static constexpr DWORD IDD_SAMPLE_MONITOR_COUNT = 2; // If monitor count > ARRAYSIZE(s_SampleMonitors), we create edid-less monitors
+ULONG MonitorNumberRegsitryValue = 0; // Will be used to get the numbert of monitors
+ULONG MonitorTypeRegsitryValue = 0; // Will be used to get the type of monitor 1080p,1440p,2160p
+ULONG MonitorCursorRegsitryValue = 0; // Will be used to set software or hardware cursor.
+ULONG AdapterLUIDLowPart = 0; // Will be used to set the preferred render adapter.
+WDFDEVICE g_Device = nullptr;
+
+// Default modes reported for edid-less monitors. The first mode is set as preferred
+static const struct IndirectSampleMonitor::SampleMonitorMode s_SampleDefaultModes[] =
+{
+    { 1920, 1080, 60 },
+    { 1600,  900, 60 },
+    { 1024,  768, 75 },
+};
+
+// FOR SAMPLE PURPOSES ONLY, Static info about monitors that will be reported to OS
+static const struct IndirectSampleMonitor s_SampleMonitors[] =
+{
+    // 1080p EDID
+    {
+        {
+            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0x03,0x42,0x01,0x01,0x01,0x01,
+            0x01,0x18,0x01,0x03,0x80,0x7A,0x44,0x78,0x0A,0x0D,0xC9,0xA0,0x57,0x47,0x98,0x27,
+            0x12,0x48,0x4C,0x21,0x08,0x00,0x81,0x80,0xA9,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,
+            0x01,0x01,0x01,0x01,0x01,0x01,0x02,0x3A,0x80,0x18,0x71,0x38,0x2D,0x40,0x58,0x2C,
+            0x45,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x01,0x1D,0x00,0x72,0x51,0xD0,0x1E,0x20,
+            0x6E,0x28,0x55,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x00,0x00,0x00,0xFC,0x00,0x31,
+            0x30,0x38,0x30,0x70,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x00,0x00,0x00,0xFD,
+            0x00,0x30,0x3E,0x0E,0x46,0x0F,0x00,0x0A,0x20,0x20,0x20,0x20,0x20,0x20,0x00,0x36
+        },
+        { //SampleMonitorMode
+            { 1920, 1080,  60 },
+            { 1600,  900,  60 },
+            { 1024,  768,  60 },
+        },
+        0
+    },
+    // 1440p EDID
+    {
+        {
+            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0x01,0x00,0x01,0x00,0x00,0x00,
+            0x24,0x1D,0x01,0x04,0xA5,0x3C,0x22,0x78,0xFB,0x6C,0xE5,0xA5,0x55,0x50,0xA0,0x23,
+            0x0B,0x50,0x54,0x00,0x02,0x00,0xD1,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,
+            0x01,0x01,0x01,0x01,0x01,0x01,0x6A,0x5E,0x00,0xA0,0xA0,0xA0,0x29,0x50,0x30,0x20,
+            0x35,0x00,0x55,0x50,0x21,0x00,0x00,0x1A,0x00,0x00,0x00,0xFF,0x00,0x37,0x4A,0x51,
+            0x58,0x42,0x59,0x32,0x0A,0x20,0x20,0x20,0x20,0x20,0x00,0x00,0x00,0xFC,0x00,0x31,
+            0x34,0x34,0x30,0x70,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x00,0x00,0x00,0xFD,
+            0x00,0x28,0x9B,0xFA,0xFA,0x40,0x01,0x0A,0x20,0x20,0x20,0x20,0x20,0x20,0x00,0xE6
+        },
+        { //SampleMonitorMode
+            { 2560, 1440,  60 },
+            { 2048, 1536,  60 },
+            { 1920, 1080,  60 },
+            { 1024,  768,  60 },
+        },
+        0
+    },
+    // 2160p EDID
+    {
+        {
+            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0xBF,0x65,0x01,0x01,0x01,0x01,
+            0x20,0x1A,0x01,0x04,0xA5,0x3C,0x22,0x78,0x3B,0xEE,0xD1,0xA5,0x55,0x48,0x9B,0x26,
+            0x12,0x50,0x54,0x00,0x08,0x00,0xA9,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,
+            0x01,0x01,0x01,0x01,0x01,0x01,0x68,0xD8,0x00,0x18,0xF1,0x70,0x2D,0x80,0x58,0x2C,
+            0x45,0x00,0x53,0x50,0x21,0x00,0x00,0x1E,0x02,0x3A,0x80,0x18,0x71,0x38,0x2D,0x40,
+            0x58,0x2C,0x45,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x6A,0x5E,0x00,0xA0,0xA0,0xA0,
+            0x29,0x50,0x30,0x20,0x35,0x00,0x55,0x50,0x21,0x00,0x00,0x1A,0x00,0x00,0x00,0xFC,
+            0x00,0x32,0x31,0x36,0x30,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x20,0x00,0x5A
+        },
+        { //SampleMonitorMode
+            { 1920, 1080,  60 },
+            { 3840, 2160,  60 },
+            { 2048, 1536,  60 },
+            { 1024,  768,  60 },
+        },
+        0
+    }
+};
+
+#pragma endregion
+
+#pragma region helpers
+
+
+static inline void FillSignalInfo(DISPLAYCONFIG_VIDEO_SIGNAL_INFO& Mode, DWORD Width, DWORD Height, DWORD VSync, bool bMonitorMode)
+{
+    Mode.totalSize.cx = Mode.activeSize.cx = Width;
+    Mode.totalSize.cy = Mode.activeSize.cy = Height;
+
+    // See https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-displayconfig_video_signal_info
+    Mode.AdditionalSignalInfo.vSyncFreqDivider = bMonitorMode ? 0 : 1;
+    Mode.AdditionalSignalInfo.videoStandard = 255;
+
+    Mode.vSyncFreq.Numerator = VSync;
+    Mode.vSyncFreq.Denominator = 1;
+    Mode.hSyncFreq.Numerator = VSync * Height;
+    Mode.hSyncFreq.Denominator = 1;
+
+    Mode.scanLineOrdering = DISPLAYCONFIG_SCANLINE_ORDERING_PROGRESSIVE;
+
+    Mode.pixelRate = ((UINT64)VSync) * ((UINT64)Width) * ((UINT64)Height);
+}
+
+static IDDCX_MONITOR_MODE CreateIddCxMonitorMode(DWORD Width, DWORD Height, DWORD VSync, IDDCX_MONITOR_MODE_ORIGIN Origin = IDDCX_MONITOR_MODE_ORIGIN_DRIVER)
+{
+    IDDCX_MONITOR_MODE Mode = {};
+
+    Mode.Size = sizeof(Mode);
+    Mode.Origin = Origin;
+    FillSignalInfo(Mode.MonitorVideoSignalInfo, Width, Height, VSync, true);
+
+    return Mode;
+}
+
+static IDDCX_TARGET_MODE CreateIddCxTargetMode(DWORD Width, DWORD Height, DWORD VSync)
+{
+    IDDCX_TARGET_MODE Mode = {};
+
+    Mode.Size = sizeof(Mode);
+    FillSignalInfo(Mode.TargetVideoSignalInfo.targetVideoSignalInfo, Width, Height, VSync, false);
+
+    return Mode;
+}
+
+ULONG IddReadRegistryDword(WDFDEVICE Device, PCUNICODE_STRING ValueName)
+{
+    NTSTATUS Status = STATUS_SUCCESS;
+    ULONG RegistryValue = 0, Length, ValueType;
+    WDFKEY Regkey;
+
+    // Read and update the registry values to select the type of monitor and preferred render adpater.
+    Status = WdfDeviceOpenRegistryKey(Device, PLUGPLAY_REGKEY_DEVICE, PLUGPLAY_REGKEY_DEVICE, WDF_NO_OBJECT_ATTRIBUTES, &Regkey);
+    Status = WdfRegistryQueryValue(
+        Regkey,
+        ValueName,
+        sizeof(ULONG),
+        &RegistryValue,
+        &Length,
+        &ValueType
+    );
+    if (NT_SUCCESS(Status))
+    {
+        WdfRegistryClose(Regkey);
+    }
+
+    return RegistryValue;
+}
+
+
+#pragma endregion
+
+extern "C" DRIVER_INITIALIZE DriverEntry;
+
+EVT_IDD_CX_DEVICE_IO_CONTROL      IddSampleAdapterIoDeviceControl;
+EVT_WDF_DRIVER_DEVICE_ADD IddSampleDeviceAdd;
+EVT_WDF_DEVICE_D0_ENTRY IddSampleDeviceD0Entry;
+
+EVT_IDD_CX_ADAPTER_INIT_FINISHED IddSampleAdapterInitFinished;
+EVT_IDD_CX_ADAPTER_COMMIT_MODES IddSampleAdapterCommitModes;
+
+EVT_IDD_CX_PARSE_MONITOR_DESCRIPTION IddSampleParseMonitorDescription;
+EVT_IDD_CX_MONITOR_GET_DEFAULT_DESCRIPTION_MODES IddSampleMonitorGetDefaultModes;
+EVT_IDD_CX_MONITOR_QUERY_TARGET_MODES IddSampleMonitorQueryModes;
+
+EVT_IDD_CX_MONITOR_ASSIGN_SWAPCHAIN IddSampleMonitorAssignSwapChain;
+EVT_IDD_CX_MONITOR_UNASSIGN_SWAPCHAIN IddSampleMonitorUnassignSwapChain;
+
+struct IndirectDeviceContextWrapper
+{
+    IndirectDeviceContext* pContext;
+
+    void Cleanup()
+    {
+        delete pContext;
+        pContext = nullptr;
+    }
+};
+
+struct IndirectMonitorContextWrapper
+{
+    IndirectMonitorContext* pContext;
+
+    void Cleanup()
+    {
+        delete pContext;
+        pContext = nullptr;
+    }
+};
+
+// This macro creates the methods for accessing an IndirectDeviceContextWrapper as a context for a WDF object
+WDF_DECLARE_CONTEXT_TYPE(IndirectDeviceContextWrapper);
+
+WDF_DECLARE_CONTEXT_TYPE(IndirectMonitorContextWrapper);
+
+extern "C" BOOL WINAPI DllMain(
+    _In_ HINSTANCE hInstance,
+    _In_ UINT dwReason,
+    _In_opt_ LPVOID lpReserved)
+{
+    UNREFERENCED_PARAMETER(hInstance);
+    UNREFERENCED_PARAMETER(lpReserved);
+    UNREFERENCED_PARAMETER(dwReason);
+
+    return TRUE;
+}
+
+#define DBG_PRINTF(...) {char msg[512]; sprintf_s(msg, 512, __VA_ARGS__);  OutputDebugStringA(msg);}
+
+#define MONITOR_1080p 1
+#define MONITOR_1440p 2
+#define MONITOR_2160p 4
+
+#define CURSOR_SOFTWARE 0
+#define CURSOR_HARDWARE 1
+
+#define REMOTE_SESSION 0x01000000
+
+ULONG GetMonitorIdx()
+{
+    // TBD : Need to check if this () is required, can be replaced with macro
+    if (MonitorTypeRegsitryValue & MONITOR_1080p)
+    {
+        return 2;
+    }
+    else if (MonitorTypeRegsitryValue & MONITOR_1440p)
+    {
+        return 2;
+    }
+    else if (MonitorTypeRegsitryValue & MONITOR_2160p)
+    {
+       return 2;
+    }
+
+    return 2;
+}
+
+ULONG GetMonitorNumber()
+{
+    if (!MonitorNumberRegsitryValue || MonitorNumberRegsitryValue > 2)
+        return 1; // if the value read from registry is not proper, return 1.
+
+    return MonitorNumberRegsitryValue;
+}
+
+ULONG GetMonitorCursor()
+{
+    if (MonitorCursorRegsitryValue == CURSOR_HARDWARE) {
+        return CURSOR_HARDWARE;
+    }
+    return CURSOR_SOFTWARE;
+}
+
+_Use_decl_annotations_
+extern "C" NTSTATUS DriverEntry(
+    PDRIVER_OBJECT  pDriverObject,
+    PUNICODE_STRING pRegistryPath
+)
+{
+    WDF_DRIVER_CONFIG Config;
+    NTSTATUS Status;
+
+    WDF_OBJECT_ATTRIBUTES Attributes;
+    WDF_OBJECT_ATTRIBUTES_INIT(&Attributes);
+
+    WDF_DRIVER_CONFIG_INIT(&Config,
+        IddSampleDeviceAdd
+    );
+
+    Status = WdfDriverCreate(pDriverObject, pRegistryPath, &Attributes, &Config, WDF_NO_HANDLE);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
+{
+    NTSTATUS Status = STATUS_SUCCESS;
+    WDF_PNPPOWER_EVENT_CALLBACKS PnpPowerCallbacks;
+    DECLARE_CONST_UNICODE_STRING(MonitorTypeName, L"IddCustomControl");
+    DECLARE_CONST_UNICODE_STRING(MonitorNumber, L"IddMonitorNumber");
+    DECLARE_CONST_UNICODE_STRING(MonitorCursor, L"IddCursorControl");
+    UNREFERENCED_PARAMETER(Driver);
+
+    // Register for power callbacks - in this sample only power-on is needed
+    WDF_PNPPOWER_EVENT_CALLBACKS_INIT(&PnpPowerCallbacks);
+    PnpPowerCallbacks.EvtDeviceD0Entry = IddSampleDeviceD0Entry;
+    WdfDeviceInitSetPnpPowerEventCallbacks(pDeviceInit, &PnpPowerCallbacks);
+
+    IDD_CX_CLIENT_CONFIG IddConfig;
+    IDD_CX_CLIENT_CONFIG_INIT(&IddConfig);
+
+    // If the driver wishes to handle custom IoDeviceControl requests, it's necessary to use this callback since IddCx
+    // redirects IoDeviceControl requests to an internal queue. This sample does not need this.
+    // IddConfig.EvtIddCxDeviceIoControl = IddSampleIoDeviceControl;
+
+    IddConfig.EvtIddCxAdapterInitFinished = IddSampleAdapterInitFinished;
+    IddConfig.EvtIddCxDeviceIoControl     = IddSampleAdapterIoDeviceControl;
+    IddConfig.EvtIddCxParseMonitorDescription = IddSampleParseMonitorDescription;
+    IddConfig.EvtIddCxMonitorGetDefaultDescriptionModes = IddSampleMonitorGetDefaultModes;
+    IddConfig.EvtIddCxMonitorQueryTargetModes = IddSampleMonitorQueryModes;
+    IddConfig.EvtIddCxAdapterCommitModes = IddSampleAdapterCommitModes;
+    IddConfig.EvtIddCxMonitorAssignSwapChain = IddSampleMonitorAssignSwapChain;
+    IddConfig.EvtIddCxMonitorUnassignSwapChain = IddSampleMonitorUnassignSwapChain;
+
+    Status = IddCxDeviceInitConfig(pDeviceInit, &IddConfig);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+
+    WDF_OBJECT_ATTRIBUTES Attr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attr, IndirectDeviceContextWrapper);
+    Attr.EvtCleanupCallback = [](WDFOBJECT Object)
+    {
+        // Automatically cleanup the context when the WDF object is about to be deleted
+        auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(Object);
+        if (pContext)
+        {
+            pContext->Cleanup();
+        }
+    };
+
+    WDFDEVICE Device = nullptr;
+    Status = WdfDeviceCreate(&pDeviceInit, &Attr, &Device);
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+    MonitorTypeRegsitryValue = IddReadRegistryDword(Device, &MonitorTypeName);
+    MonitorNumberRegsitryValue = IddReadRegistryDword(Device, &MonitorNumber);
+    MonitorCursorRegsitryValue = IddReadRegistryDword(Device, &MonitorCursor);
+
+    // Create device interface for this device.
+    Status = WdfDeviceCreateDeviceInterface(
+        Device,
+        &GUID_DEVINTERFACE_IDD_DEVICE,
+        NULL // No Reference String. If you provide one it will appended to the
+    );
+
+    if (!NT_SUCCESS(Status))
+    {
+        return Status;
+    }
+
+    Status = IddCxDeviceInitialize(Device);
+
+    // Create a new device context object and attach it to the WDF device object
+    auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
+    pContext->pContext = new IndirectDeviceContext(Device);
+
+    return Status;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleDeviceD0Entry(WDFDEVICE Device, WDF_POWER_DEVICE_STATE PreviousState)
+{
+    UNREFERENCED_PARAMETER(PreviousState);
+
+    // This function is called by WDF to start the device in the fully-on power state.
+
+    auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
+    pContext->pContext->InitAdapter();
+
+    return STATUS_SUCCESS;
+}
+
+#pragma region Direct3DDevice
+
+Direct3DDevice::Direct3DDevice(LUID AdapterLuid) : AdapterLuid(AdapterLuid)
+{
+
+}
+
+Direct3DDevice::Direct3DDevice()
+{
+    AdapterLuid = LUID{};
+}
+
+HRESULT Direct3DDevice::Init()
+{
+    // The DXGI factory could be cached, but if a new render adapter appears on the system, a new factory needs to be
+    // created. If caching is desired, check DxgiFactory->IsCurrent() each time and recreate the factory if !IsCurrent.
+    HRESULT hr = CreateDXGIFactory2(0, IID_PPV_ARGS(&DxgiFactory));
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    // Find the specified render adapter
+    hr = DxgiFactory->EnumAdapterByLuid(AdapterLuid, IID_PPV_ARGS(&Adapter));
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    // Create a D3D device using the render adapter. BGRA support is required by the WHQL test suite.
+    hr = D3D11CreateDevice(Adapter.Get(), D3D_DRIVER_TYPE_UNKNOWN, nullptr, D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0, D3D11_SDK_VERSION, &Device, nullptr, &DeviceContext);
+    if (FAILED(hr))
+    {
+        // If creating the D3D device failed, it's possible the render GPU was lost (e.g. detachable GPU) or else the
+        // system is in a transient state.
+        return hr;
+    }
+
+    return S_OK;
+}
+
+#pragma endregion
+
+#pragma region SwapChainProcessor
+
+SwapChainProcessor::SwapChainProcessor(IDDCX_SWAPCHAIN hSwapChain, shared_ptr<Direct3DDevice> Device, HANDLE NewFrameEvent)
+    : m_hSwapChain(hSwapChain), m_Device(Device), m_hAvailableBufferEvent(NewFrameEvent)
+{
+    m_hTerminateEvent.Attach(CreateEvent(nullptr, FALSE, FALSE, nullptr));
+
+    // Immediately create and run the swap-chain processing thread, passing 'this' as the thread parameter
+    m_hThread.Attach(CreateThread(nullptr, 0, RunThread, this, 0, nullptr));
+}
+
+SwapChainProcessor::~SwapChainProcessor()
+{
+    // Alert the swap-chain processing thread to terminate
+    SetEvent(m_hTerminateEvent.Get());
+
+    if (m_hThread.Get())
+    {
+        // Wait for the thread to terminate
+        WaitForSingleObject(m_hThread.Get(), INFINITE);
+    }
+}
+
+DWORD CALLBACK SwapChainProcessor::RunThread(LPVOID Argument)
+{
+    reinterpret_cast<SwapChainProcessor*>(Argument)->Run();
+    return 0;
+}
+
+void SwapChainProcessor::Run()
+{
+    // For improved performance, make use of the Multimedia Class Scheduler Service, which will intelligently
+    // prioritize this thread for improved throughput in high CPU-load scenarios.
+    DWORD AvTask = 0;
+    HANDLE AvTaskHandle = AvSetMmThreadCharacteristicsW(L"Distribution", &AvTask);
+
+    RunCore();
+
+    // Always delete the swap-chain object when swap-chain processing loop terminates in order to kick the system to
+    // provide a new swap-chain if necessary.
+    WdfObjectDelete((WDFOBJECT)m_hSwapChain);
+    m_hSwapChain = nullptr;
+
+    AvRevertMmThreadCharacteristics(AvTaskHandle);
+}
+
+void SwapChainProcessor::RunCore()
+{
+    // Get the DXGI device interface
+    ComPtr<IDXGIDevice> DxgiDevice;
+    HRESULT hr = m_Device->Device.As(&DxgiDevice);
+    if (FAILED(hr))
+    {
+        return;
+    }
+
+    IDARG_IN_SWAPCHAINSETDEVICE SetDevice = {};
+    SetDevice.pDevice = DxgiDevice.Get();
+
+    hr = IddCxSwapChainSetDevice(m_hSwapChain, &SetDevice);
+
+    if (FAILED(hr))
+    {
+        return;
+    }
+
+    // Acquire and release buffers in a loop
+    for (;;)
+    {
+        ComPtr<IDXGIResource> AcquiredBuffer;
+
+        // Ask for the next buffer from the producer
+        IDARG_OUT_RELEASEANDACQUIREBUFFER Buffer = {};
+        hr = IddCxSwapChainReleaseAndAcquireBuffer(m_hSwapChain, &Buffer);
+
+        // AcquireBuffer immediately returns STATUS_PENDING if no buffer is yet available
+        if (hr == E_PENDING)
+        {
+            // We must wait for a new buffer
+            HANDLE WaitHandles[] =
+            {
+                m_hAvailableBufferEvent,
+                m_hTerminateEvent.Get()
+            };
+            DWORD WaitResult = WaitForMultipleObjects(ARRAYSIZE(WaitHandles), WaitHandles, FALSE, 16);
+            if (WaitResult == WAIT_OBJECT_0 || WaitResult == WAIT_TIMEOUT)
+            {
+                // We have a new buffer, so try the AcquireBuffer again
+                continue;
+            }
+            else if (WaitResult == WAIT_OBJECT_0 + 1)
+            {
+                // We need to terminate
+                break;
+            }
+            else
+            {
+                // The wait was cancelled or something unexpected happened
+                hr = HRESULT_FROM_WIN32(WaitResult);
+                break;
+            }
+        }
+        else if (SUCCEEDED(hr))
+        {
+            // We have new frame to process, the surface has a reference on it that the driver has to release
+            AcquiredBuffer.Attach(Buffer.MetaData.pSurface);
+
+            // ==============================
+            // TODO: Process the frame here
+            //
+            // This is the most performance-critical section of code in an IddCx driver. It's important that whatever
+            // is done with the acquired surface be finished as quickly as possible. This operation could be:
+            //  * a GPU copy to another buffer surface for later processing (such as a staging surface for mapping to CPU memory)
+            //  * a GPU encode operation
+            //  * a GPU VPBlt to another surface
+            //  * a GPU custom compute shader encode operation
+            // ==============================
+
+            // We have finished processing this frame hence we release the reference on it.
+            // If the driver forgets to release the reference to the surface, it will be leaked which results in the
+            // surfaces being left around after swapchain is destroyed.
+            // NOTE: Although in this sample we release reference to the surface here; the driver still
+            // owns the Buffer.MetaData.pSurface surface until IddCxSwapChainReleaseAndAcquireBuffer returns
+            // S_OK and gives us a new frame, a driver may want to use the surface in future to re-encode the desktop 
+            // for better quality if there is no new frame for a while
+            AcquiredBuffer.Reset();
+
+            // Indicate to OS that we have finished inital processing of the frame, it is a hint that
+            // OS could start preparing another frame
+            hr = IddCxSwapChainFinishedProcessingFrame(m_hSwapChain);
+            if (FAILED(hr))
+            {
+                break;
+            }
+
+            // ==============================
+            // TODO: Report frame statistics once the asynchronous encode/send work is completed
+            //
+            // Drivers should report information about sub-frame timings, like encode time, send time, etc.
+            // ==============================
+            // IddCxSwapChainReportFrameStatistics(m_hSwapChain, ...);
+        }
+        else
+        {
+            // The swap-chain was likely abandoned (e.g. DXGI_ERROR_ACCESS_LOST), so exit the processing loop
+            break;
+        }
+    }
+}
+
+#pragma endregion
+
+#pragma region IndirectDeviceContext
+
+IndirectDeviceContext::IndirectDeviceContext(_In_ WDFDEVICE WdfDevice) :
+    m_WdfDevice(WdfDevice)
+{
+    m_Adapter = {};
+}
+
+IndirectDeviceContext::~IndirectDeviceContext()
+{
+}
+
+void IndirectDeviceContext::InitAdapter()
+{
+    // ==============================
+    // TODO: Update the below diagnostic information in accordance with the target hardware. The strings and version
+    // numbers are used for telemetry and may be displayed to the user in some situations.
+    //
+    // This is also where static per-adapter capabilities are determined.
+    // ==============================
+
+    IDDCX_ADAPTER_CAPS AdapterCaps = {0};
+    AdapterCaps.Size = sizeof(AdapterCaps);
+
+
+    // Declare basic feature support for the adapter (required)
+    AdapterCaps.MaxMonitorsSupported = IDD_SAMPLE_MONITOR_COUNT;
+    AdapterCaps.EndPointDiagnostics.Size = sizeof(AdapterCaps.EndPointDiagnostics);
+    AdapterCaps.EndPointDiagnostics.GammaSupport = IDDCX_FEATURE_IMPLEMENTATION_NONE;
+    AdapterCaps.EndPointDiagnostics.TransmissionType = IDDCX_TRANSMISSION_TYPE_WIRED_OTHER;
+
+    // Declare your device strings for telemetry (required)
+    AdapterCaps.EndPointDiagnostics.pEndPointFriendlyName = L"Intel IddSample Device";
+    AdapterCaps.EndPointDiagnostics.pEndPointManufacturerName = L"Intel IddSample Device";
+    AdapterCaps.EndPointDiagnostics.pEndPointModelName = L"Intel IddSample Model";
+    // AdapterCaps.Flags = IDDCX_ADAPTER_FLAGS_REMOTE_SESSION_DRIVER;
+
+    // Declare your hardware and firmware versions (required)
+    IDDCX_ENDPOINT_VERSION Version = {};
+    Version.Size = sizeof(Version);
+    Version.MajorVer = 1;
+    AdapterCaps.EndPointDiagnostics.pFirmwareVersion = &Version;
+    AdapterCaps.EndPointDiagnostics.pHardwareVersion = &Version;
+
+    // Initialize a WDF context that can store a pointer to the device context object
+    WDF_OBJECT_ATTRIBUTES Attr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attr, IndirectDeviceContextWrapper);
+
+    IDARG_IN_ADAPTER_INIT AdapterInit = {};
+    AdapterInit.WdfDevice = m_WdfDevice;
+    AdapterInit.pCaps = &AdapterCaps;
+    AdapterInit.ObjectAttributes = &Attr;
+
+    // Start the initialization of the adapter, which will trigger the AdapterFinishInit callback later
+    IDARG_OUT_ADAPTER_INIT AdapterInitOut;
+    NTSTATUS Status = IddCxAdapterInitAsync(&AdapterInit, &AdapterInitOut);
+
+    if (NT_SUCCESS(Status))
+    {
+        // Store a reference to the WDF adapter handle
+        m_Adapter = AdapterInitOut.AdapterObject;
+
+        // Store the device context object into the WDF object context
+        auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(AdapterInitOut.AdapterObject);
+        pContext->pContext = this;
+    }
+}
+
+void IndirectDeviceContext::FinishInit(UINT ConnectorIndex)
+{
+    // ==============================
+    // TODO: In a real driver, the EDID should be retrieved dynamically from a connected physical monitor. The EDIDs
+    // provided here are purely for demonstration.
+    // Monitor manufacturers are required to correctly fill in physical monitor attributes in order to allow the OS
+    // to optimize settings like viewing distance and scale factor. Manufacturers should also use a unique serial
+    // number every single device to ensure the OS can tell the monitors apart.
+    // ==============================
+
+    WDF_OBJECT_ATTRIBUTES Attr;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attr, IndirectMonitorContextWrapper);
+
+    // In the sample driver, we report a monitor right away but a real driver would do this when a monitor connection event occurs
+    IDDCX_MONITOR_INFO MonitorInfo = {};
+    MonitorInfo.Size = sizeof(MonitorInfo);
+    // Reporting as INDIRECT_WIRED for detecting IDD displays in QDC.
+    MonitorInfo.MonitorType = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_WIRED;
+    MonitorInfo.ConnectorIndex = ConnectorIndex;
+
+    MonitorInfo.MonitorDescription.Size = sizeof(MonitorInfo.MonitorDescription);
+    MonitorInfo.MonitorDescription.Type = IDDCX_MONITOR_DESCRIPTION_TYPE_EDID;
+    if (ConnectorIndex >= ARRAYSIZE(s_SampleMonitors))
+    {
+        MonitorInfo.MonitorDescription.DataSize = 0;
+        MonitorInfo.MonitorDescription.pData = nullptr;
+    }
+    else
+    {
+        MonitorInfo.MonitorDescription.DataSize = IndirectSampleMonitor::szEdidBlock;
+        // MonitorInfo.MonitorDescription.pData = const_cast<BYTE*>(s_SampleMonitors[ConnectorIndex].pEdidBlock);
+        MonitorInfo.MonitorDescription.pData = const_cast<BYTE*>(s_SampleMonitors[GetMonitorIdx()].pEdidBlock);
+
+    }
+
+    // ==============================
+    // TODO: The monitor's container ID should be distinct from "this" device's container ID if the monitor is not
+    // permanently attached to the display adapter device object. The container ID is typically made unique for each
+    // monitor and can be used to associate the monitor with other devices, like audio or input devices. In this
+    // sample we generate a random container ID GUID, but it's best practice to choose a stable container ID for a
+    // unique monitor or to use "this" device's container ID for a permanent/integrated monitor.
+    // ==============================
+
+    // Create a container ID
+    CoCreateGuid(&MonitorInfo.MonitorContainerId);
+
+    IDARG_IN_MONITORCREATE MonitorCreate = {};
+    MonitorCreate.ObjectAttributes = &Attr;
+    MonitorCreate.pMonitorInfo = &MonitorInfo;
+
+    // Create a monitor object with the specified monitor descriptor
+    IDARG_OUT_MONITORCREATE MonitorCreateOut;
+    NTSTATUS Status = IddCxMonitorCreate(m_Adapter, &MonitorCreate, &MonitorCreateOut);
+    if (NT_SUCCESS(Status))
+    {
+        // Create a new monitor context object and attach it to the Idd monitor object
+        auto* pMonitorContextWrapper = WdfObjectGet_IndirectMonitorContextWrapper(MonitorCreateOut.MonitorObject);
+        pMonitorContextWrapper->pContext = new IndirectMonitorContext(MonitorCreateOut.MonitorObject);
+        pMonitorContextWrapper->pContext->m_Adapter = m_Adapter;
+
+        // Tell the OS that the monitor has been plugged in
+        IDARG_OUT_MONITORARRIVAL ArrivalOut;
+        Status = IddCxMonitorArrival(MonitorCreateOut.MonitorObject, &ArrivalOut);
+    }
+}
+
+NTSTATUS IndirectDeviceContext::UpdateLUID(PIDD_UPDATE_LUID pUpdateLUID)
+{
+    NTSTATUS Status = STATUS_SUCCESS;
+
+    //TraceEvents(TRACE_LEVEL_ERROR,TRACE_DEVICE,"%!FUNC! LUID ( %ud.%ud)", pUpdateLUID->luid.LowPart, pUpdateLUID->luid.HighPart);
+    if (AdapterLUIDLowPart != pUpdateLUID->luid.LowPart)
+    {
+        IDARG_IN_ADAPTERSETRENDERADAPTER PreferredAdapter;
+        AdapterLUIDLowPart = pUpdateLUID->luid.LowPart;
+        PreferredAdapter.PreferredRenderAdapter.HighPart = pUpdateLUID->luid.HighPart;
+        PreferredAdapter.PreferredRenderAdapter.LowPart = pUpdateLUID->luid.LowPart; 
+        IddCxAdapterSetRenderAdapter(m_Adapter, &PreferredAdapter);
+        return STATUS_GRAPHICS_INDIRECT_DISPLAY_ABANDON_SWAPCHAIN;
+    }
+
+    return Status;
+}
+
+NTSTATUS IndirectDeviceContext::CheckandSetRenderAdapter(LUID RenderAdapter)
+{
+    if (AdapterLUIDLowPart != RenderAdapter.LowPart)
+    {
+        IDARG_IN_ADAPTERSETRENDERADAPTER PreferredAdapter;
+        PreferredAdapter.PreferredRenderAdapter.LowPart = AdapterLUIDLowPart;
+        IddCxAdapterSetRenderAdapter(m_Adapter, &PreferredAdapter);
+        return STATUS_GRAPHICS_INDIRECT_DISPLAY_ABANDON_SWAPCHAIN;
+    }
+    return STATUS_SUCCESS;
+}
+
+
+IndirectMonitorContext::IndirectMonitorContext(_In_ IDDCX_MONITOR Monitor) :
+    m_Monitor(Monitor)
+{
+    m_Adapter = {};
+}
+
+IndirectMonitorContext::~IndirectMonitorContext()
+{
+    m_ProcessingThread.reset();
+}
+
+NTSTATUS IndirectMonitorContext::AssignSwapChain(IDDCX_MONITOR MonitorObject,IDDCX_SWAPCHAIN SwapChain, LUID RenderAdapter, HANDLE NewFrameEvent)
+{
+    m_ProcessingThread.reset();
+    auto Device = make_shared<Direct3DDevice>(RenderAdapter);
+    auto* pMonitorContextWrapper = WdfObjectGet_IndirectMonitorContextWrapper(MonitorObject);
+    if (FAILED(Device->Init()))
+    {
+        // It's important to delete the swap-chain if D3D initialization fails, so that the OS knows to generate a new
+        // swap-chain and try again.
+        WdfObjectDelete(SwapChain);
+        IDARG_IN_ADAPTERSETRENDERADAPTER PreferredAdapter;
+        if (AdapterLUIDLowPart != 0 && AdapterLUIDLowPart != RenderAdapter.LowPart)
+        {
+            PreferredAdapter.PreferredRenderAdapter.LowPart = AdapterLUIDLowPart;
+            IddCxAdapterSetRenderAdapter(pMonitorContextWrapper->pContext->m_Adapter, &PreferredAdapter);
+            return STATUS_GRAPHICS_INDIRECT_DISPLAY_ABANDON_SWAPCHAIN;
+        }
+
+    }
+    else
+    {
+        // Create a new swap-chain processing thread
+        m_ProcessingThread.reset(new SwapChainProcessor(SwapChain, Device, NewFrameEvent));
+
+        if (GetMonitorCursor() == CURSOR_HARDWARE)
+        {
+            HANDLE hCursorData = CreateEventA(NULL, FALSE, FALSE, NULL);
+            if (hCursorData == NULL) {
+                DBG_PRINTF("IDD : CreateEventA return NULL\n");
+                return STATUS_UNSUCCESSFUL;
+            }
+
+            // Setup Hardware cursor
+            IDARG_IN_SETUP_HWCURSOR IdArgHwCursor;
+            ZeroMemory(&IdArgHwCursor, sizeof(IdArgHwCursor));
+            IdArgHwCursor.CursorInfo.Size = sizeof(IDDCX_CURSOR_CAPS);
+            IdArgHwCursor.CursorInfo.ColorXorCursorSupport = IDDCX_XOR_CURSOR_SUPPORT_FULL;
+            IdArgHwCursor.CursorInfo.AlphaCursorSupport = TRUE;
+            IdArgHwCursor.CursorInfo.MaxX = 256;
+            IdArgHwCursor.CursorInfo.MaxY = 256;
+            IdArgHwCursor.hNewCursorDataAvailable = hCursorData;
+
+            NTSTATUS Status = IddCxMonitorSetupHardwareCursor(MonitorObject, &IdArgHwCursor);
+            DBG_PRINTF("IDD : IddCxMonitorSetupHardwareCursor Status (0x%x)\n", Status);
+            if (!NT_SUCCESS(Status)) {   
+                return Status;
+            }
+        }
+        return STATUS_SUCCESS;
+    }
+    return STATUS_SUCCESS;
+}
+
+void IndirectMonitorContext::UnassignSwapChain()
+{
+    // Stop processing the last swap-chain
+    m_ProcessingThread.reset();
+}
+
+#pragma endregion
+
+#pragma region DDI Callbacks
+
+_Use_decl_annotations_
+NTSTATUS IddSampleAdapterInitFinished(IDDCX_ADAPTER AdapterObject, const IDARG_IN_ADAPTER_INIT_FINISHED* pInArgs)
+{
+    // This is called when the OS has finished setting up the adapter for use by the IddCx driver. It's now possible
+    // to report attached monitors.
+    auto* pDeviceContextWrapper = WdfObjectGet_IndirectDeviceContextWrapper(AdapterObject);
+    if (NT_SUCCESS(pInArgs->AdapterInitStatus) && pDeviceContextWrapper)
+    {
+        for (DWORD i = 0; i < GetMonitorNumber(); i++)
+        {
+            pDeviceContextWrapper->pContext->FinishInit(i);
+        }
+    }
+
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleAdapterCommitModes(IDDCX_ADAPTER AdapterObject, const IDARG_IN_COMMITMODES* pInArgs)
+{
+    UNREFERENCED_PARAMETER(AdapterObject);
+    UNREFERENCED_PARAMETER(pInArgs);
+
+    // For the sample, do nothing when modes are picked - the swap-chain is taken care of by IddCx
+
+    // ==============================
+    // TODO: In a real driver, this function would be used to reconfigure the device to commit the new modes. Loop
+    // through pInArgs->pPaths and look for IDDCX_PATH_FLAGS_ACTIVE. Any path not active is inactive (e.g. the monitor
+    // should be turned off).
+    // ==============================
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleParseMonitorDescription(const IDARG_IN_PARSEMONITORDESCRIPTION* pInArgs, IDARG_OUT_PARSEMONITORDESCRIPTION* pOutArgs)
+{
+    // ==============================
+    // TODO: In a real driver, this function would be called to generate monitor modes for an EDID by parsing it. In
+    // this sample driver, we hard-code the EDID, so this function can generate known modes.
+    // ==============================
+
+    pOutArgs->MonitorModeBufferOutputCount = IndirectSampleMonitor::szModeList;
+
+    if (pInArgs->MonitorModeBufferInputCount < IndirectSampleMonitor::szModeList)
+    {
+        // Return success if there was no buffer, since the caller was only asking for a count of modes
+        return (pInArgs->MonitorModeBufferInputCount > 0) ? STATUS_BUFFER_TOO_SMALL : STATUS_SUCCESS;
+    }
+    else
+    {
+        // In the sample driver, we have reported some static information about connected monitors
+        // Check which of the reported monitors this call is for by comparing it to the pointer of
+        // our known EDID blocks.
+
+        if (pInArgs->MonitorDescription.DataSize != IndirectSampleMonitor::szEdidBlock)
+            return STATUS_INVALID_PARAMETER;
+
+        DWORD SampleMonitorIdx = 0;
+        for (; SampleMonitorIdx < ARRAYSIZE(s_SampleMonitors); SampleMonitorIdx++)
+        {
+            if (memcmp(pInArgs->MonitorDescription.pData, s_SampleMonitors[SampleMonitorIdx].pEdidBlock, IndirectSampleMonitor::szEdidBlock) == 0)
+            {
+                // Copy the known modes to the output buffer
+                for (DWORD ModeIndex = 0; ModeIndex < IndirectSampleMonitor::szModeList; ModeIndex++)
+                {
+                    pInArgs->pMonitorModes[ModeIndex] = CreateIddCxMonitorMode(
+                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].Width,
+                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].Height,
+                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].VSync,
+                        IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR
+                    );
+                }
+
+                // Set the preferred mode as represented in the EDID
+                pOutArgs->PreferredMonitorModeIdx = s_SampleMonitors[SampleMonitorIdx].ulPreferredModeIdx;
+
+                return STATUS_SUCCESS;
+            }
+        }
+
+        // This EDID block does not belong to the monitors we reported earlier
+        return STATUS_INVALID_PARAMETER;
+    }
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleMonitorGetDefaultModes(IDDCX_MONITOR MonitorObject, const IDARG_IN_GETDEFAULTDESCRIPTIONMODES* pInArgs, IDARG_OUT_GETDEFAULTDESCRIPTIONMODES* pOutArgs)
+{
+    UNREFERENCED_PARAMETER(MonitorObject);
+
+    // ==============================
+    // TODO: In a real driver, this function would be called to generate monitor modes for a monitor with no EDID.
+    // Drivers should report modes that are guaranteed to be supported by the transport protocol and by nearly all
+    // monitors (such 640x480, 800x600, or 1024x768). If the driver has access to monitor modes from a descriptor other
+    // than an EDID, those modes would also be reported here.
+    // ==============================
+
+    if (pInArgs->DefaultMonitorModeBufferInputCount == 0)
+    {
+        pOutArgs->DefaultMonitorModeBufferOutputCount = ARRAYSIZE(s_SampleDefaultModes);
+    }
+    else
+    {
+        for (DWORD ModeIndex = 0; ModeIndex < ARRAYSIZE(s_SampleDefaultModes); ModeIndex++)
+        {
+            pInArgs->pDefaultMonitorModes[ModeIndex] = CreateIddCxMonitorMode(
+                s_SampleDefaultModes[ModeIndex].Width,
+                s_SampleDefaultModes[ModeIndex].Height,
+                s_SampleDefaultModes[ModeIndex].VSync,
+                IDDCX_MONITOR_MODE_ORIGIN_DRIVER
+            );
+        }
+
+        pOutArgs->DefaultMonitorModeBufferOutputCount = ARRAYSIZE(s_SampleDefaultModes);
+        pOutArgs->PreferredMonitorModeIdx = 0;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleMonitorQueryModes(IDDCX_MONITOR MonitorObject, const IDARG_IN_QUERYTARGETMODES* pInArgs, IDARG_OUT_QUERYTARGETMODES* pOutArgs)
+{
+    UNREFERENCED_PARAMETER(MonitorObject);
+
+    vector<IDDCX_TARGET_MODE> TargetModes;
+
+    // Create a set of modes supported for frame processing and scan-out. These are typically not based on the
+    // monitor's descriptor and instead are based on the static processing capability of the device. The OS will
+    // report the available set of modes for a given output as the intersection of monitor modes with target modes.
+
+   
+     TargetModes.push_back(CreateIddCxTargetMode(3840, 2160, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(3200, 2400, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(3200, 1800, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(3008, 1692, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(2880, 1800, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(2880, 1620, 60));
+
+     TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 144));
+     TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 90));
+     TargetModes.push_back(CreateIddCxTargetMode(2560, 1600, 60));
+
+     TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(2048, 1536, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1920, 1440, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1920, 1200, 60));
+
+     TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 144));
+     TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 90));
+     TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 60));
+     
+     TargetModes.push_back(CreateIddCxTargetMode(1600, 1024, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1680, 1050, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1600, 900, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1440, 900, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1400, 1050,60));
+     TargetModes.push_back(CreateIddCxTargetMode(1366, 768, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1360, 768, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 1024, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 960, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 800, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 768, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 720, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1280, 600, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(1152, 864, 60));
+     
+     TargetModes.push_back(CreateIddCxTargetMode(1024, 768, 75));
+     TargetModes.push_back(CreateIddCxTargetMode(1024, 768, 60));
+
+     TargetModes.push_back(CreateIddCxTargetMode(800, 600, 60));
+     TargetModes.push_back(CreateIddCxTargetMode(640, 480, 60));
+
+    pOutArgs->TargetModeBufferOutputCount = (UINT)TargetModes.size();
+
+    if (pInArgs->TargetModeBufferInputCount >= TargetModes.size())
+    {
+        copy(TargetModes.begin(), TargetModes.end(), pInArgs->pTargetModes);
+    }
+
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleMonitorAssignSwapChain(IDDCX_MONITOR MonitorObject, const IDARG_IN_SETSWAPCHAIN* pInArgs)
+{
+    auto* pMonitorContextWrapper = WdfObjectGet_IndirectMonitorContextWrapper(MonitorObject);
+    return pMonitorContextWrapper->pContext->AssignSwapChain(MonitorObject, pInArgs->hSwapChain, pInArgs->RenderAdapterLuid, pInArgs->hNextSurfaceAvailable);
+}
+
+_Use_decl_annotations_
+NTSTATUS IddSampleMonitorUnassignSwapChain(IDDCX_MONITOR MonitorObject)
+{
+    auto* pMonitorContextWrapper = WdfObjectGet_IndirectMonitorContextWrapper(MonitorObject);
+    pMonitorContextWrapper->pContext->UnassignSwapChain();
+    return STATUS_SUCCESS;
+}
+
+_Use_decl_annotations_
+VOID
+IddSampleAdapterIoDeviceControl(WDFDEVICE Device, WDFREQUEST Request, size_t OutputBufferLength, size_t InputBufferLength, ULONG IoControlCode)
+{
+    UNREFERENCED_PARAMETER(OutputBufferLength);
+    UNREFERENCED_PARAMETER(InputBufferLength);
+    UNREFERENCED_PARAMETER(Device);
+
+    NTSTATUS Status = STATUS_SUCCESS;
+    PVOID  Buffer;
+    size_t BufSize;
+    int bytesRead = 0;
+    auto* pContext = WdfObjectGet_IndirectDeviceContextWrapper(Device);
+    switch (IoControlCode)
+    {
+    case IOCTL_IDD_UPDATE_LUID:
+        PIDD_UPDATE_LUID pUpdateLUID;
+        Status = WdfRequestRetrieveInputBuffer(Request, sizeof(IDD_UPDATE_LUID), &Buffer, &BufSize);
+        if (!NT_SUCCESS(Status)) {
+            break;
+        }
+        pUpdateLUID = (PIDD_UPDATE_LUID)Buffer;
+        pContext->pContext->UpdateLUID(pUpdateLUID);
+        Status = STATUS_SUCCESS;
+        break;
+     default:
+        Status = STATUS_NOT_IMPLEMENTED;
+        break;
+    }
+
+    WdfRequestCompleteWithInformation(Request, Status, bytesRead);
+}
+
+#pragma endregion

--- a/sources/drivers/idd/Driver.h
+++ b/sources/drivers/idd/Driver.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#define NOMINMAX
+#include <windows.h>
+#include <bugcodes.h>
+#include <wudfwdm.h>
+#include <wdf.h>
+#include <iddcx.h>
+
+#include <dxgi1_5.h>
+#include <d3d11_2.h>
+#include <avrt.h>
+#include <wrl.h>
+
+#include <memory>
+#include <vector>
+
+#include "Trace.h"
+
+#include "uapi/idd_io.h"
+
+namespace Microsoft
+{
+    namespace WRL
+    {
+        namespace Wrappers
+        {
+            // Adds a wrapper for thread handles to the existing set of WRL handle wrapper classes
+            typedef HandleT<HandleTraits::HANDLENullTraits> Thread;
+        }
+    }
+}
+
+namespace Microsoft
+{
+    namespace IndirectDisp
+    {
+        /// <summary>
+        /// Manages the creation and lifetime of a Direct3D render device.
+        /// </summary>
+        struct IndirectSampleMonitor
+        {
+            static constexpr size_t szEdidBlock = 128;
+            static constexpr size_t szModeList = 4;
+
+            const BYTE pEdidBlock[szEdidBlock];
+            const struct SampleMonitorMode {
+                DWORD Width;
+                DWORD Height;
+                DWORD VSync;
+            } pModeList[szModeList];
+            const DWORD ulPreferredModeIdx;
+        };
+
+        /// <summary>
+        /// Manages the creation and lifetime of a Direct3D render device.
+        /// </summary>
+        struct Direct3DDevice
+        {
+            Direct3DDevice(LUID AdapterLuid);
+            Direct3DDevice();
+            HRESULT Init();
+
+            LUID AdapterLuid;
+            Microsoft::WRL::ComPtr<IDXGIFactory5> DxgiFactory;
+            Microsoft::WRL::ComPtr<IDXGIAdapter1> Adapter;
+            Microsoft::WRL::ComPtr<ID3D11Device> Device;
+            Microsoft::WRL::ComPtr<ID3D11DeviceContext> DeviceContext;
+        };
+
+        /// <summary>
+        /// Manages a thread that consumes buffers from an indirect display swap-chain object.
+        /// </summary>
+        class SwapChainProcessor
+        {
+        public:
+            SwapChainProcessor(IDDCX_SWAPCHAIN hSwapChain, std::shared_ptr<Direct3DDevice> Device, HANDLE NewFrameEvent);
+            ~SwapChainProcessor();
+
+        private:
+            static DWORD CALLBACK RunThread(LPVOID Argument);
+
+            void Run();
+            void RunCore();
+
+            IDDCX_SWAPCHAIN m_hSwapChain;
+            std::shared_ptr<Direct3DDevice> m_Device;
+            HANDLE m_hAvailableBufferEvent;
+            Microsoft::WRL::Wrappers::Thread m_hThread;
+            Microsoft::WRL::Wrappers::Event m_hTerminateEvent;
+        };
+
+        /// <summary>
+        /// Provides a sample implementation of an indirect display driver.
+        /// </summary>
+        class IndirectDeviceContext
+        {
+        public:
+            IndirectDeviceContext(_In_ WDFDEVICE WdfDevice);
+            virtual ~IndirectDeviceContext();
+
+            void InitAdapter();
+            void FinishInit(UINT ConnectorIndex);
+            NTSTATUS CheckandSetRenderAdapter(LUID RenderAdapter);
+            NTSTATUS UpdateLUID(PIDD_UPDATE_LUID Param);
+        protected:
+            WDFDEVICE m_WdfDevice;
+            IDDCX_ADAPTER m_Adapter;
+        };
+
+        class IndirectMonitorContext
+        {
+        public:
+            IndirectMonitorContext(_In_ IDDCX_MONITOR Monitor);
+            virtual ~IndirectMonitorContext();
+
+            NTSTATUS AssignSwapChain(IDDCX_MONITOR MonitorObject, IDDCX_SWAPCHAIN SwapChain, LUID RenderAdapter, HANDLE NewFrameEvent);
+            void UnassignSwapChain();
+            IDDCX_ADAPTER m_Adapter;
+        private:
+            IDDCX_MONITOR m_Monitor;
+            std::unique_ptr<SwapChainProcessor> m_ProcessingThread;
+        };
+    }
+}

--- a/sources/drivers/idd/IddSampleDriver.inf
+++ b/sources/drivers/idd/IddSampleDriver.inf
@@ -1,0 +1,82 @@
+;
+; IddSampleDriver.inf
+;
+
+[Version]
+; DriverVer will be set by stampinf, see .vcxproj settings
+PnpLockDown=1
+Signature="$Windows NT$"
+ClassGUID = {4D36E968-E325-11CE-BFC1-08002BE10318}
+Class = Display
+ClassVer = 2.0
+Provider=%ManufacturerName%
+CatalogFile=IddSampleDriver.cat
+
+[Manufacturer]
+%ManufacturerName%=Standard, NT$ARCH$.10.0...18362
+
+[Standard.NT$ARCH$.10.0...18362]
+%DeviceName%=IddDevice_Install, Root\IddSampleDriver ; TODO: edit hw-id, this hardware id is used by Visual Studio remote debugging
+%DeviceName%=IddDevice_Install, IddSampleDriver      ; TODO: edit hw-id, this hardware id is used by the idd-setup-tool.exe
+
+[SourceDisksFiles]
+IddSampleDriver.dll=1
+
+[SourceDisksNames]
+1 = %DiskName%
+
+; =================== UMDF Device ==================================
+
+[IddDevice_Install.NT]
+CopyFiles=UMDriverCopy
+
+[IddDevice_Install.NT.hw]
+AddReg = IddDevice_HardwareDeviceSettings
+
+[IddDevice_HardwareDeviceSettings]
+HKR,, "UpperFilters",  %REG_MULTI_SZ%, "IndirectKmd"
+HKR, "WUDF", "DeviceGroupId", %REG_SZ%, "IddSampleDriverGroup" ; TODO: edit driver group name, see README.md for more info
+HKR,,"IddCustomControl",0x00010001,1 ; 1 - 1080p Monitor, 2 - 1440p Monitor, 4 - 2160p Monitor
+HKR,,"IddMonitorNumber",0x00010001,1 ; 1 - 1 monitor, 2 - 2 monitors
+HKR,,"IddCursorControl",0x00010001,0 ; 0 - Software Cursor, 1 - Hardware Cursor
+HKR,,Security,,"D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GA;;;UD)(A;;GA;;;AU)"
+
+[IddDevice_Install.NT.Services]
+AddService=WUDFRd,0x000001fa,WUDFRD_ServiceInstall
+
+[IddDevice_Install.NT.Wdf]
+UmdfService=IddSampleDriver,IddSampleDriver_Install
+UmdfServiceOrder=IddSampleDriver
+UmdfKernelModeClientPolicy = AllowKernelModeClients
+
+[IddSampleDriver_Install]
+UmdfLibraryVersion=$UMDFVERSION$
+ServiceBinary=%12%\UMDF\IddSampleDriver.dll
+UmdfExtensions = IddCx0102
+
+[WUDFRD_ServiceInstall]
+DisplayName = %WudfRdDisplayName%
+ServiceType = 1
+StartType = 3
+ErrorControl = 1
+ServiceBinary = %12%\WUDFRd.sys
+
+[DestinationDirs]
+UMDriverCopy=12,UMDF ; copy to drivers\umdf
+
+[UMDriverCopy]
+IddSampleDriver.dll
+
+; =================== Generic ==================================
+
+[Strings]
+ManufacturerName="Intel Idd Sample Driver" ; TODO: Replace with your manufacturer name
+DiskName = "IddSampleDriver Installation Disk" ; TODO: Replace with driver disk name
+WudfRdDisplayName="Windows Driver Foundation - User-mode Driver Framework Reflector"
+DeviceName="Intel IddSampleDriver Device" ; TODO: Replace with correct device name
+
+
+REG_MULTI_SZ  = 0x00010000
+REG_SZ        = 0x00000000
+REG_EXPAND_SZ = 0x00020000
+REG_DWORD     = 0x00010001

--- a/sources/drivers/idd/IddSampleDriver.rc
+++ b/sources/drivers/idd/IddSampleDriver.rc
@@ -1,0 +1,19 @@
+#include <windows.h>
+
+#define VER_FILEFLAGS               0
+#define VER_FILEFLAGSMASK           VS_FFI_FILEFLAGSMASK
+#define VER_FILEOS                  VOS_NT_WINDOWS32
+#define VER_FILETYPE                VFT_DLL
+#define VER_FILESUBTYPE             VFT_UNKNOWN
+#define VER_FILEDESCRIPTION_STR     "Indirect Display Driver"
+#define VER_INTERNALNAME_STR        "IddSampleDriver"
+#define VER_ORIGINALFILENAME_STR    "IddSampleDriver.dll"
+#define VER_LEGALCOPYRIGHT_YEARS    "2022-2023"
+#define VER_LEGALCOPYRIGHT_STR_WITH_YEARS "Copyright (C) 2022-2023 Intel Corporation"
+#define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2022-2023 Intel Corporation"
+#define VER_PRODUCTNAME_STR         "Cloud Streaming Reference Stack"
+#define VER_COMPANYNAME_STR         "Intel Corporation"
+#define VER_PRODUCTVERSION          0,5,0,0
+#define VER_PRODUCTVERSION_STR      "0.5.0.0"
+
+#include "common.ver"

--- a/sources/drivers/idd/IddSampleDriver.sln
+++ b/sources/drivers/idd/IddSampleDriver.sln
@@ -1,0 +1,51 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "IddSampleDriver", "IddSampleDriver.vcxproj", "{2D54CB75-8B17-4F11-97DC-847B0244CD46}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM.ActiveCfg = Debug|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM.Build.0 = Debug|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM.Deploy.0 = Debug|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM64.Build.0 = Debug|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x64.ActiveCfg = Debug|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x64.Build.0 = Debug|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x64.Deploy.0 = Debug|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x86.ActiveCfg = Debug|Win32
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x86.Build.0 = Debug|Win32
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Debug|x86.Deploy.0 = Debug|Win32
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM.ActiveCfg = Release|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM.Build.0 = Release|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM.Deploy.0 = Release|ARM
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM64.ActiveCfg = Release|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM64.Build.0 = Release|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|ARM64.Deploy.0 = Release|ARM64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x64.ActiveCfg = Release|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x64.Build.0 = Release|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x64.Deploy.0 = Release|x64
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x86.ActiveCfg = Release|Win32
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x86.Build.0 = Release|Win32
+		{2D54CB75-8B17-4F11-97DC-847B0244CD46}.Release|x86.Deploy.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C92CFF5-AC99-48BC-949B-7E7DD3AA4AD7}
+	EndGlobalSection
+EndGlobal

--- a/sources/drivers/idd/IddSampleDriver.vcxproj
+++ b/sources/drivers/idd/IddSampleDriver.vcxproj
@@ -1,0 +1,332 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Driver.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Driver.h" />
+    <ClInclude Include="uapi/idd_io.h" />
+    <ClInclude Include="Trace.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="IddSampleDriver.inf" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2D54CB75-8B17-4F11-97DC-847B0244CD46}</ProjectGuid>
+    <TemplateGuid>{32909489-7be5-497b-aafa-db6669d9b44b}</TemplateGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <Configuration>Debug</Configuration>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <RootNamespace>IddSampleDriver</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <PropertyGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <PlatformToolset>WindowsUserModeDriver10.0</PlatformToolset>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+    <SignMode>Off</SignMode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <TargetVersion>Windows10</TargetVersion>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <UMDF_VERSION_MAJOR>2</UMDF_VERSION_MAJOR>
+    <UMDF_VERSION_MINOR>25</UMDF_VERSION_MINOR>
+    <IndirectDisplayDriver>true</IndirectDisplayDriver>
+    <IDDCX_VERSION_MAJOR>1</IDDCX_VERSION_MAJOR>
+    <IDDCX_VERSION_MINOR>4</IDDCX_VERSION_MINOR>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <DriverProductionSignMinimalRebuildFromTracking>true</DriverProductionSignMinimalRebuildFromTracking>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <DebuggerFlavor>DbgengRemoteDebugger</DebuggerFlavor>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <AdditionalOptions>/DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <AdditionalOptions>/DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/D_ATL_NO_WIN_SUPPORT /DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <PreprocessorDefinitions>_WIN64;_AMD64_;AMD64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/D_ATL_NO_WIN_SUPPORT /DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+      <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
+    </Link>
+    <Inf>
+      <TimeStamp>0.5.0.0</TimeStamp>
+      <SpecifyDriverVerDirectiveVersion>true</SpecifyDriverVerDirectiveVersion>
+    </Inf>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <AdditionalOptions>/DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+      <AdditionalOptions>/DUMDF_DRIVER /DIDDCX_VERSION_MAJOR=1 /DIDDCX_VERSION_MINOR=6 /DIDDCX_MINIMUM_VERSION_REQUIRED=4 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <WppEnabled>true</WppEnabled>
+      <WppRecorderEnabled>true</WppRecorderEnabled>
+      <WppScanConfigurationData Condition="'%(ClCompile.ScanConfigurationData)' == ''">Trace.h</WppScanConfigurationData>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <EnablePREfast>true</EnablePREfast>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);OneCoreUAP.lib;avrt.lib</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <FilesToPackage Include="$(TargetPath)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="IddSampleDriver.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/sources/drivers/idd/IddSampleDriver.vcxproj.filters
+++ b/sources/drivers/idd/IddSampleDriver.vcxproj.filters
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Driver Files">
+      <UniqueIdentifier>{8E41214B-6785-4CFE-B992-037D68949A14}</UniqueIdentifier>
+      <Extensions>inf;inv;inx;mof;mc;</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <Inf Include="IddSampleDriver.inf">
+      <Filter>Driver Files</Filter>
+    </Inf>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Driver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="uapi/idd_io.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Trace.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Driver.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/sources/drivers/idd/LICENSE
+++ b/sources/drivers/idd/LICENSE
@@ -1,0 +1,23 @@
+The Microsoft Public License (MS-PL)
+Copyright (c) 2015 Microsoft
+
+This license governs use of the accompanying software. If you use the software, you
+ accept this license. If you do not accept the license, do not use the software.
+
+1. Definitions
+ The terms "reproduce," "reproduction," "derivative works," and "distribution" have the
+ same meaning here as under U.S. copyright law.
+ A "contribution" is the original software, or any additions or changes to the software.
+ A "contributor" is any person that distributes its contribution under this license.
+ "Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+ (A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+ (B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+ (A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+ (B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+ (C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
+ (D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+ (E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.

--- a/sources/drivers/idd/Trace.h
+++ b/sources/drivers/idd/Trace.h
@@ -1,0 +1,52 @@
+// Copyright (C) Microsoft Corporation
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// This file contains modifications made to the original Microsoft sample code from
+// https://github.com/microsoft/Windows-driver-samples/tree/main/video/IndirectDisplay/IddSampleDriver
+
+//
+// Define the tracing flags.
+//
+// Tracing GUID - b254994f-46e6-4718-80a0-0a3aa50d6ce4
+//
+
+#define WPP_CONTROL_GUIDS                                              \
+    WPP_DEFINE_CONTROL_GUID(                                           \
+        MyDriver1TraceGuid, (b254994f,46e6,4718,80a0,0a3aa50d6ce4),                  \
+                                                                       \
+        WPP_DEFINE_BIT(MYDRIVER_ALL_INFO)                              \
+        WPP_DEFINE_BIT(TRACE_DRIVER)                                   \
+        WPP_DEFINE_BIT(TRACE_DEVICE)                                   \
+        WPP_DEFINE_BIT(TRACE_QUEUE)                                    \
+        )                             
+
+#define WPP_FLAG_LEVEL_LOGGER(flag, level)                             \
+    WPP_LEVEL_LOGGER(flag)
+
+#define WPP_FLAG_LEVEL_ENABLED(flag, level)                            \
+    (WPP_LEVEL_ENABLED(flag) &&                                        \
+     WPP_CONTROL(WPP_BIT_ ## flag).Level >= level)
+
+#define WPP_LEVEL_FLAGS_LOGGER(lvl,flags)                              \
+           WPP_LEVEL_LOGGER(flags)
+               
+#define WPP_LEVEL_FLAGS_ENABLED(lvl, flags)                            \
+           (WPP_LEVEL_ENABLED(flags) && WPP_CONTROL(WPP_BIT_ ## flags).Level >= lvl)
+
+//
+// This comment block is scanned by the trace preprocessor to define our
+// Trace function.
+//
+// begin_wpp config
+// FUNC Trace{FLAG=MYDRIVER_ALL_INFO}(LEVEL, MSG, ...);
+// FUNC TraceEvents(LEVEL, FLAGS, MSG, ...);
+// end_wpp
+
+//
+//
+// Driver specific #defines
+//
+
+// TODO: Use a unique driver tracing ID here,
+// see https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/adding-wpp-software-tracing-to-a-windows-driver
+#define MYDRIVER_TRACING_ID L"Microsoft\\UMDF2.25\\IddSampleDriver v1.0"

--- a/sources/drivers/idd/meson.build
+++ b/sources/drivers/idd/meson.build
@@ -1,0 +1,34 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# 'idd_install_dir' is location where built IDD driver should be installed.
+# Mind that currently we don't build IDD driver by meson. Instead, user should
+# build it using provided 'IddSampleDriver.sln' MSVC solution file. Here in
+# meson script we are just doing simple book keeping for the installation path
+# to limit work done by MSVC solution to the bare minimum. In a future once
+# meson support to build Windows UMDF/KMDF will mature we will switch to building
+# driver by meson.
+# See: https://github.com/mesonbuild/meson/issues/11965
+idd_install_dir = get_option('bindir') / 'idd'
+
+# 'idd_src_install_dir' is location to install IDD sources
+idd_src_install_dir = get_option('prefix') / 'src' / 'drivers' / 'idd'
+
+install_data(
+  files(
+    'LICENSE',
+    ),
+  install_dir : idd_install_dir)

--- a/sources/drivers/idd/uapi/idd_io.h
+++ b/sources/drivers/idd/uapi/idd_io.h
@@ -1,0 +1,39 @@
+// Copyright (C) 2022-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <minwindef.h>
+#include <winioctl.h>
+#include <guiddef.h>
+
+typedef enum _IDD_STATUS
+{
+    IDD_STATUS_SUCCESS,
+    IDD_STATUS_ACCESS_DENIED,
+    IDD_INVALID_PARAM,
+    IDD_INVALID_HANDLE
+}IDD_STATUS;
+
+#define IOCTL_IDD_UPDATE_LUID                CTL_CODE(IOCTL_CHANGER_BASE, \
+                                                       0x8001, \
+                                                       METHOD_BUFFERED, \
+                                                       FILE_READ_ACCESS | FILE_WRITE_ACCESS)
+
+typedef struct _update_luid {
+    LUID luid;
+} IDD_UPDATE_LUID, * PIDD_UPDATE_LUID;
+
+

--- a/sources/drivers/meson.build
+++ b/sources/drivers/meson.build
@@ -1,0 +1,17 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('idd')

--- a/sources/meson.build
+++ b/sources/meson.build
@@ -34,6 +34,11 @@ cgver_file = configure_file(
     },
 )
 
+if host_machine.system() == 'windows' and build_machine.cpu_family() != 'x86'
+  subdir('drivers')
+  subdir('apps')
+endif
+
 if host_machine.system() == 'linux'
   subdir('encoder')
 endif

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,5 +1,4 @@
-*
+/*
 !*.wrap
 !.gitignore
-!packagefiles
-
+!/packagefiles


### PR DESCRIPTION
This PR adds implementation for Indirect Display Driver (IDD) customized to work with Intel GPUs in headless environment (i.e. on ATS-M systems). Commit also adds idd-setup-tool for IDD driver installation and system display settings customizations and
enum-adapters to enumerate available video adapters on the system.

That's the first commit in a series to upstream Windows streaming support for headless setups with Intel GPUs. IDD driver should be built directly via MSVC solution. The rest of the targets can be built with meson. Currently it's required to explicitly disable streamer component which is not yet upstreamed for Windows:
```
  meson setup -Dstreamer=disabled _build
```

This PR adds code. Documentation will follow.