### PR TITLE
win: upstream webrtc-client

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-Format: https: www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Disclaimer:
   This project is not part of Debian and just reuses copyright file format to
   state which files are licensed under which license.
@@ -6,6 +6,11 @@ Disclaimer:
 Files: *
 Copyright: Copyright (C) 2022-2023 Intel Corporation
 License: Apache-2.0
+
+Files: sources/apps/webrtc-client/implot-window.cc
+Copyright: Copyright (C) 2022 Evan Pezent
+           Copyright (C) 2023 Intel Corporation
+License: MIT
 
 Files: sources/streamer/core/asource.cpp
        sources/streamer/core/asource.h
@@ -91,6 +96,27 @@ License: BSD-3-clause
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sub license, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice (including the
+ next paragraph) shall be included in all copies or substantial portions
+ of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+ IN NO EVENT SHALL PRECISION INSIGHT AND/OR ITS SUPPLIERS BE LIABLE FOR
+ ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 License: MS-PL
  This license governs use of the accompanying software. If you use the

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,6 +16,12 @@ option('streamer',
   description : 'Build streamer service ingredients',
 )
 
+option('client',
+  type : 'feature',
+  value : 'auto',
+  description : 'Build (webrtc) client',
+)
+
 option('prebuilt-path',
   type : 'string',
   value : '',

--- a/sources/apps/meson.build
+++ b/sources/apps/meson.build
@@ -16,3 +16,6 @@
 
 subdir('idd-setup-tool')
 subdir('enum-adapters')
+if get_option('client').allowed()
+  subdir('webrtc-client')
+endif

--- a/sources/apps/webrtc-client/control-handler.cc
+++ b/sources/apps/webrtc-client/control-handler.cc
@@ -1,0 +1,217 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2
+
+// clang-format off
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+#include "control-handler.h"
+#include "window-handler.h"
+// clang-format on
+
+extern float screen_scale_factor_;
+
+std::string InputEventHandler::OnKeyboardEvent(KeyboardOptions *p_key_options) {
+  WPARAM wparam = p_key_options->v_key_;
+  UINT msg = p_key_options->msg_;
+
+  rapidjson::Document event;
+  event.SetObject();
+  rapidjson::Document::AllocatorType &alloc = event.GetAllocator();
+
+  rapidjson::Value parameters(rapidjson::kObjectType);
+  parameters.SetObject();
+  parameters.AddMember("which", wparam, alloc);
+
+  rapidjson::Value data(rapidjson::kObjectType);
+  switch (msg) {
+    case WM_KEYDOWN:
+      data.AddMember("event", "keydown", alloc);
+      break;
+    case WM_KEYUP:
+      data.AddMember("event", "keyup", alloc);
+      break;
+    default:
+      break;
+  }
+  data.AddMember("parameters", parameters, alloc);
+  event.AddMember("type", "control", alloc);
+  event.AddMember("data", data, alloc);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  event.Accept(writer);
+  return buffer.GetString();
+}
+
+std::string InputEventHandler::OnMouseEvent(MouseOptions *p_m_options,
+                                           bool is_raw) {
+  rapidjson::Document event;
+  event.SetObject();
+  rapidjson::Document::AllocatorType& alloc = event.GetAllocator();
+
+  float screen_scale_factor = screen_scale_factor_ >= 1.0f ? screen_scale_factor_ : 1.0f;
+  
+  int client_window_width, client_window_height;
+  WindowHandler::GetInstance()->GetWindowSize(client_window_width, client_window_height);
+  int x = (int) (((float) p_m_options->x_pos_ * screen_scale_factor_ / client_window_width) * 32767);
+  int y = (int) (((float) p_m_options->y_pos_ * screen_scale_factor_ / client_window_height) * 32767);
+
+  rapidjson::Value parameters(rapidjson::kObjectType);
+  parameters.SetObject();
+
+  parameters.AddMember("x", x, alloc);
+  parameters.AddMember("y", y, alloc);
+  parameters.AddMember("movementX", x, alloc);
+  parameters.AddMember("movementY", y, alloc);
+
+  rapidjson::Value data(rapidjson::kObjectType);
+  switch (p_m_options->m_event_) {
+  case kMouseMove:
+    data.AddMember("event", "mousemove", alloc);
+    break;
+  case kMouseLeftButton:
+    if (p_m_options->m_button_state_ == kMouseButtonDown) {
+      data.AddMember("event", "mousedown", alloc);
+      parameters.AddMember("which", 1, alloc);
+    } else {
+      data.AddMember("event", "mouseup", alloc);
+      parameters.AddMember("which", 1, alloc);
+    }
+    break;
+  case kMouseMiddleButton:
+    if (p_m_options->m_button_state_ == kMouseButtonDown) {
+      data.AddMember("event", "mousedown", alloc);
+      parameters.AddMember("which", 2, alloc);
+    } else {
+      data.AddMember("event", "mouseup", alloc);
+      parameters.AddMember("which", 2, alloc);
+    }
+    break;
+  case kMouseRightButton:
+    if (p_m_options->m_button_state_ == kMouseButtonDown) {
+      data.AddMember("event", "mousedown", alloc);
+      parameters.AddMember("which", 3, alloc);
+    } else {
+      data.AddMember("event", "mouseup", alloc);
+      parameters.AddMember("which", 3, alloc);
+    }
+    break;
+  case kMouseWheel:
+    data.AddMember("event", "wheel", alloc);
+  // Javascript client allows deltaX and deltaZ to be set.. so we have
+  // to set them to 0, otherwise ga server will crash.
+  parameters.AddMember("deltaX", 0, alloc);
+    parameters.AddMember("deltaY", p_m_options->delta_y_, alloc);
+  parameters.AddMember("deltaZ", 0, alloc);
+    break;
+  default:
+    break;
+  }
+
+  data.AddMember("parameters", parameters, alloc);
+  event.AddMember("type", "control", alloc);
+  event.AddMember("data", data, alloc);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+  event.Accept(writer);
+  return buffer.GetString();
+}
+
+std::string InputEventHandler::OnSizeChange(UINT render_w, UINT render_h)
+{
+  rapidjson::Document event;
+  event.SetObject();
+  rapidjson::Document::AllocatorType& alloc = event.GetAllocator();
+
+  float screen_scale_factor = screen_scale_factor_ >= 1.0f ? screen_scale_factor_ : 1.0f;
+
+  int x = (float)(render_w)*screen_scale_factor;
+  int y = (float)(render_h)*screen_scale_factor;
+
+  rapidjson::Value renderSize(rapidjson::kObjectType);
+  renderSize.SetObject();
+  renderSize.AddMember("width", x, alloc);
+  renderSize.AddMember("height", y, alloc);
+
+  rapidjson::Value parameters(rapidjson::kObjectType);
+  parameters.SetObject();
+
+  parameters.AddMember("mode", "stretch", alloc);
+  parameters.AddMember("rendererSize", renderSize, alloc);
+
+  rapidjson::Value data(rapidjson::kObjectType);
+  data.AddMember("event", "sizechange", alloc);
+  data.AddMember("parameters", parameters, alloc);
+  event.AddMember("type", "control", alloc);
+  event.AddMember("data", data, alloc);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+  event.Accept(writer);
+  return buffer.GetString();
+}
+
+std::string InputEventHandler::onPointerlockchange(bool reativeMode)
+{
+  rapidjson::Document event;
+  event.SetObject();
+  rapidjson::Document::AllocatorType& alloc = event.GetAllocator();
+
+  rapidjson::Value parameters(rapidjson::kObjectType);
+  parameters.SetObject();
+  parameters.AddMember("locked", reativeMode, alloc);
+
+  rapidjson::Value data(rapidjson::kObjectType);
+  data.AddMember("event", "pointerlockchange", alloc);
+  data.AddMember("parameters", parameters, alloc);
+  event.AddMember("type", "control", alloc);
+  event.AddMember("data", data, alloc);
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+
+  event.Accept(writer);
+  return buffer.GetString();
+}
+
+std::string InputEventHandler::OnStatsRequest(FrameStats* p_framestats)
+{
+    int64_t ts = p_framestats->ts;
+    int64_t size = p_framestats->size;
+    int delay = p_framestats->delay;
+    int64_t start_delay = p_framestats->start_delay;
+    int64_t p_loss = p_framestats->p_loss;
+    UINT64 latencymsg = p_framestats->latencymsg_;
+
+    rapidjson::Document event;
+    event.SetObject();
+    rapidjson::Document::AllocatorType& alloc = event.GetAllocator();
+
+    rapidjson::Value parameters(rapidjson::kObjectType);
+    parameters.SetObject();
+    parameters.AddMember("framets", ts, alloc);
+    parameters.AddMember("framesize", size, alloc);
+    parameters.AddMember("framedelay", delay, alloc);
+    parameters.AddMember("framestartdelay", start_delay, alloc);
+    parameters.AddMember("packetloss", p_loss, alloc);
+
+    if (latencymsg > 0) {
+        parameters.AddMember("E2ELatency", latencymsg, alloc);
+    }
+
+    rapidjson::Value data(rapidjson::kObjectType);
+    data.AddMember("event", "framestats", alloc);
+    data.AddMember("parameters", parameters, alloc);
+    event.AddMember("type", "control", alloc);
+    event.AddMember("data", data, alloc);
+
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    event.Accept(writer);
+    return buffer.GetString();
+}

--- a/sources/apps/webrtc-client/control-handler.h
+++ b/sources/apps/webrtc-client/control-handler.h
@@ -1,0 +1,75 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_CONTROL_HANDLER_H_
+#define GA_CONTROL_HANDLER_H_
+
+#include <map>
+#include <string>
+#include <windows.h>
+
+#define GA_LEGACY_INPUT 1
+#define GA_RAW_INPUT 2
+
+enum MouseEvent {
+  kMouseMove = 0,
+  kMouseLeftButton = 1,
+  kMouseMiddleButton = 2,
+  kMouseRightButton = 3,
+  kMouseWheel = 4
+};
+
+enum MouseButtonState {
+  kMouseButtonUp = 1,
+  kMouseButtonDown = 2 
+};
+
+struct KeyboardOptions {
+  WPARAM v_key_;
+  UINT msg_;
+};
+
+struct MouseOptions {
+  int x_pos_;
+  int y_pos_;
+  int delta_x_;
+  int delta_y_;
+  int delta_z_;
+  int is_cursor_relative_;
+  MouseEvent m_event_;
+  MouseButtonState m_button_state_;
+};
+
+struct FrameStats {
+  long ts = 0;
+  long size;
+  int  delay;
+  long start_delay = 0;
+  long p_loss;
+  UINT64 latencymsg_;
+};
+
+class InputEventHandler {
+public:
+  static std::string OnKeyboardEvent(KeyboardOptions *p_k_options);
+  static std::string OnMouseEvent(MouseOptions *p_m_options, bool is_raw);
+  static std::string OnSizeChange(UINT render_w, UINT render_h);
+  static std::string onPointerlockchange(bool relativeMode);
+  static std::string OnStatsRequest(FrameStats* p_framestats);
+};
+
+#endif // GA_CONTROL_HANDLER_H_
+

--- a/sources/apps/webrtc-client/ga-option.cc
+++ b/sources/apps/webrtc-client/ga-option.cc
@@ -1,0 +1,368 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "ga-option.h"
+#include "game-session.h"
+#include <windows.h>
+#include "control-handler.h"
+// clang-format on
+
+// utility helper functions
+void PopulateCommonMouseOptionsLegacy(MouseOptions *ptr_m_options,
+  LPARAM l_param);
+bool PopulateCommonMouseOptionsRaw(MouseOptions *ptr_m_options,
+  RAWINPUT *p_raw_input);
+DWORD GetInputTypeFromRawInput(LPARAM l_param);
+
+
+// globals for getting raw input
+static bool g_bCursorRelativemode = false;
+static const int kRawInputSize = 1024;
+static char g_rawinput[kRawInputSize];
+
+std::unique_ptr<GameSession> g_remote_connection;
+
+void ga::remote::ChangeCursorReportMode(bool RelativeMode)
+{
+  g_bCursorRelativemode = RelativeMode;
+  g_remote_connection->SendPointerlockchange(RelativeMode);
+}
+
+int ga::remote::StartGame(const ga::remote::SessionMetaData& session_opts, const ga::remote::ClientSettings client_opts, StreamingStatistics* streamingStatistics) {
+  int ret_code = 0;
+  g_remote_connection.reset(new GameSession);
+  g_remote_connection->SendSizeChange(GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN));
+  g_remote_connection->ConfigConnection(session_opts, client_opts);
+  g_remote_connection->ConnectPeerServer(streamingStatistics);
+  //TODO: need to add logic to see whether webrtc connect success or not.
+  // Assume it is success, try to send SizeChange request to server to report current render resolution.
+  return ret_code;
+}
+
+void ga::remote::SendInput(UINT input_message, WPARAM w_param,
+  LPARAM l_param) {
+  std::string m;
+  KeyboardOptions key_options;
+  MouseOptions m_options;
+  DWORD raw_input_type;
+  RAWINPUT *p_raw;
+
+  switch (input_message) {
+  case WM_KEYDOWN:
+  case WM_KEYUP:
+    key_options.msg_ = input_message;
+    key_options.v_key_ = w_param;
+    g_remote_connection->SendKeyboardEvent(&key_options);
+    break;
+
+  case WM_INPUT:
+    if (g_bCursorRelativemode) {
+      raw_input_type = GetInputTypeFromRawInput(l_param);
+      if (raw_input_type == (DWORD)RIM_TYPEMOUSE) {
+        p_raw = (RAWINPUT *)g_rawinput;
+        if (PopulateCommonMouseOptionsRaw(&m_options, p_raw)) {
+          g_remote_connection->SendMouseEvent(&m_options, true);
+        }
+      }
+      else if (raw_input_type == (DWORD)RIM_TYPEKEYBOARD) {
+        p_raw = (RAWINPUT *)g_rawinput;
+        key_options.msg_ = p_raw->data.keyboard.Message;
+        key_options.v_key_ = p_raw->data.keyboard.VKey;
+        g_remote_connection->SendKeyboardEvent(&key_options);
+      }
+    }
+    break;
+  case WM_MOUSEMOVE:
+   if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseMove;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+   }
+    break;
+  case WM_LBUTTONUP:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseLeftButton;
+      m_options.m_button_state_ = kMouseButtonUp;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_LBUTTONDOWN:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseLeftButton;
+      m_options.m_button_state_ = kMouseButtonDown;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_MBUTTONUP:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseMiddleButton;
+      m_options.m_button_state_ = kMouseButtonUp;
+
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_MBUTTONDOWN:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseMiddleButton;
+      m_options.m_button_state_ = kMouseButtonDown;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_RBUTTONUP:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseRightButton;
+      m_options.m_button_state_ = kMouseButtonUp;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_RBUTTONDOWN:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseRightButton;
+      m_options.m_button_state_ = kMouseButtonDown;
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  case WM_MOUSEWHEEL:
+    if (!g_bCursorRelativemode) {
+      PopulateCommonMouseOptionsLegacy(&m_options, l_param);
+      m_options.m_event_ = kMouseWheel;
+      m_options.delta_y_ = GET_WHEEL_DELTA_WPARAM(w_param);
+      g_remote_connection->SendMouseEvent(&m_options, false);
+    }
+    break;
+  default:
+    break;
+  }
+}
+
+void PopulateCommonMouseOptionsLegacy(MouseOptions *ptr_m_options,
+  LPARAM l_param) {
+  ptr_m_options->x_pos_ = l_param & 0xFFFF;
+  ptr_m_options->y_pos_ = (l_param >> 16) & 0xFFFF;
+  ptr_m_options->is_cursor_relative_ = 0;
+}
+
+DWORD GetInputTypeFromRawInput(LPARAM l_param) {
+  UINT dwSize;
+  RAWINPUT *raw;
+
+  GetRawInputData((HRAWINPUT)l_param, RID_INPUT, NULL, &dwSize,
+    sizeof(RAWINPUTHEADER));
+  if (GetRawInputData((HRAWINPUT)l_param, RID_INPUT, g_rawinput, &dwSize,
+    sizeof(RAWINPUTHEADER)) != dwSize) {
+  }
+
+  raw = (RAWINPUT *)g_rawinput;
+  return (raw->header.dwType);
+}
+
+bool PopulateCommonMouseOptionsRaw(MouseOptions *ptr_m_options,
+  RAWINPUT *p_raw_input) {
+
+  bool ret_value = TRUE;
+  ptr_m_options->is_cursor_relative_ = 1;
+  ptr_m_options->x_pos_ = p_raw_input->data.mouse.lLastX;
+  ptr_m_options->y_pos_ = p_raw_input->data.mouse.lLastY;
+  switch (p_raw_input->data.mouse.usButtonFlags) {
+  case RI_MOUSE_LEFT_BUTTON_DOWN:
+    ptr_m_options->m_event_ = kMouseLeftButton;
+    ptr_m_options->m_button_state_ = kMouseButtonDown;
+    break;
+  case RI_MOUSE_LEFT_BUTTON_UP:
+    ptr_m_options->m_event_ = kMouseLeftButton;
+    ptr_m_options->m_button_state_ = kMouseButtonUp;
+    break;
+  case RI_MOUSE_MIDDLE_BUTTON_DOWN:
+    ptr_m_options->m_event_ = kMouseMiddleButton;
+    ptr_m_options->m_button_state_ = kMouseButtonDown;
+    break;
+  case RI_MOUSE_MIDDLE_BUTTON_UP:
+    ptr_m_options->m_event_ = kMouseMiddleButton;
+    ptr_m_options->m_button_state_ = kMouseButtonUp;
+    break;
+  case RI_MOUSE_RIGHT_BUTTON_DOWN:
+    ptr_m_options->m_event_ = kMouseRightButton;
+    ptr_m_options->m_button_state_ = kMouseButtonDown;
+    break;
+  case RI_MOUSE_RIGHT_BUTTON_UP:
+    ptr_m_options->m_event_ = kMouseRightButton;
+    ptr_m_options->m_button_state_ = kMouseButtonUp;
+    break;
+  case RI_MOUSE_BUTTON_4_DOWN:
+  case RI_MOUSE_BUTTON_4_UP:
+  case RI_MOUSE_BUTTON_5_DOWN:
+  case RI_MOUSE_BUTTON_5_UP:
+    ret_value = FALSE;
+    break;
+  case RI_MOUSE_WHEEL:
+    ptr_m_options->m_event_ = kMouseWheel;
+    ptr_m_options->delta_y_ = p_raw_input->data.mouse.usButtonData;
+    break;
+  default:
+    if (ptr_m_options->x_pos_ != 0 || ptr_m_options->y_pos_ != 0) {
+      ptr_m_options->m_event_ = kMouseMove;
+    }
+    else {
+      ret_value = FALSE;
+    }
+    break;
+  }
+  return ret_value;
+}
+
+
+int ga::remote::ExitGame(const string &session_id) {
+  int err_code = 0;
+  err_code = g_remote_connection->StopConnection();
+  return err_code;
+}
+
+void ga::remote::SetWindowSize(UINT x_offset, UINT y_offset, UINT width,
+  UINT height) {
+  g_remote_connection->SetWindowSize(x_offset, y_offset, width, height);
+}
+
+FILE *ga::log::OpenFile(std::string fileName, std::string fileType)
+{
+    FILE* file = NULL;
+    errno_t file_error = 0;
+
+    std::string fullFileName = "C:\\Temp\\" + fileName + "_" + std::to_string(GetCurrentThreadId()) + "." + fileType;
+
+    file_error = fopen_s(&file, fullFileName.c_str(), "a+");
+    if (file_error) {
+        perror("Client: OpenFile: Error opening log file.");
+        return NULL;
+    }
+
+    return file;
+}
+
+void ga::log::WriteToMsg(std::string &logMsg, const char *format_string, ...)
+{
+    if (format_string == NULL) {
+        return;
+    }
+
+    // Construct the formatted source message
+    char buffer[MAX_LOG_BUFFER_SIZE];
+    va_list args;
+    va_start(args, format_string);
+    vsnprintf(buffer, MAX_LOG_BUFFER_SIZE, format_string, args);
+    va_end(args);
+
+    logMsg += std::string(buffer);
+}
+
+bool ga::log::FlushMsgToFile(FILE *destFile, std::string &logMsg)
+{
+    if (destFile != NULL) {
+        fprintf(destFile, "%s", logMsg.c_str());
+        logMsg = "";
+        return true;
+    }
+
+    logMsg = "";
+    return false;
+}
+
+void ga::log::CloseFile(FILE *file)
+{
+    if (file != NULL) {
+        fclose(file);
+    }
+}
+
+bool ga::log::WriteToFile(std::string fileName, std::string fileType, const char *format_string, ...)
+{
+    FILE *file = ga::log::OpenFile(fileName, fileType);
+    if (file == NULL) {
+        return false;
+    }
+
+    std::string msg = "";
+
+    if (format_string == NULL) {
+        return false;
+    }
+
+    // Construct the formatted source message
+    char buffer[MAX_LOG_BUFFER_SIZE];
+    va_list args;
+    va_start(args, format_string);
+    vsnprintf(buffer, MAX_LOG_BUFFER_SIZE, format_string, args);
+    va_end(args);
+
+    msg += std::string(buffer);
+    if (ga::log::FlushMsgToFile(file, msg) == false) {
+        return false;
+    }
+
+    ga::log::CloseFile(file);
+    return true;
+}
+
+bool ga::json::ParseMessage(rapidjson::Document& document, const std::string& message)
+{
+    document.Parse(message.c_str());
+    if (document.HasParseError() || document.IsNull()) {
+        return false;
+    }
+    return true;
+}
+
+rapidjson::Type ga::json::MemberType(const rapidjson::Document& document, const std::string& message)
+{
+    if (document.IsNull()) {
+        return rapidjson::Type::kNullType;
+    }
+    if (!document.HasMember(message.c_str())) {
+        return rapidjson::Type::kNullType;
+    }
+    return document[message.c_str()].GetType();
+}
+
+uint64_t ga::json::FromUint64(const rapidjson::Document& document, const std::string& message)
+{
+    if (ga::json::MemberType(document, message) != rapidjson::Type::kNumberType) {
+        return (uint64_t) 0;
+    }
+    return document[message.c_str()].GetUint64();
+}
+
+std::string ga::json::FromString(const rapidjson::Document& document, const std::string& message)
+{
+    if (ga::json::MemberType(document, message) != rapidjson::Type::kStringType) {
+        return "";
+    }
+    return document[message.c_str()].GetString();
+}
+
+bool ga::json::FromBool(const rapidjson::Document& document, const std::string& message)
+{
+    rapidjson::Type type = ga::json::MemberType(document, message);
+    if (type != rapidjson::Type::kTrueType && type != rapidjson::Type::kFalseType) {
+        return false;
+    }
+    return document[message.c_str()].GetBool();
+}

--- a/sources/apps/webrtc-client/ga-option.h
+++ b/sources/apps/webrtc-client/ga-option.h
@@ -1,0 +1,100 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_OPTION_H_
+#define GA_OPTION_H_
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <windows.h>
+#include "statistics-window-class.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+using std::function;
+using std::string;
+
+#define MAX_CURSOR_SIZE 64*64*4
+#define MAX_LOG_BUFFER_SIZE 1024
+
+namespace ga {
+  namespace remote {
+    struct CursorInfo {
+      UINT type;
+      BOOL isVisible;
+      LONG pos_x;
+      LONG pos_y;
+      UINT width;
+      UINT height;
+      UINT pitch;
+      UINT cursorDataUpdate;
+      std::vector<uint8_t> cursordata;
+    };
+
+    typedef function<int(string &)>             ConnectionCallback;
+    typedef function<void(struct CursorInfo &)> MouseStateCallback;
+
+    struct SessionMetaData {
+      string session_id_;
+      string client_id_;
+      string peer_server_url_;
+    };
+
+    // All options for starting the client. Provides interfaces for client application
+    // to register all necessary callbacks to handle audio/video and register callbacks
+    // for delivering input, as well as cursor things, etc.
+    struct ClientSettings {
+      HWND hwnd_;
+      ConnectionCallback connection_callback_;
+      MouseStateCallback mousestate_callback_;
+    };
+
+    int  StartGame(const SessionMetaData &session_opts, const ClientSettings opts, StreamingStatistics* streamingStatistics);
+    int  ExitGame(const string &sessionid);
+    void SendInput(UINT input_message, WPARAM w_param, LPARAM l_param);
+    void SetWindowSize(UINT x_offset, UINT y_offset, UINT width, UINT height);
+    void ChangeCursorReportMode(bool RelativeMode);
+  } // namespace remote
+
+  namespace log {
+    FILE* OpenFile(std::string fileName, std::string fileType);
+    void  WriteToMsg(std::string &logMsg, const char *format_string, ...);
+    bool  FlushMsgToFile(FILE *destFile, std::string &logMsg);
+    void  CloseFile(FILE *file);
+    bool  WriteToFile(std::string fileName, std::string fileType, const char *format_string, ...);
+  } // namespace log
+
+  namespace json {
+    bool            ParseMessage(rapidjson::Document& document, const std::string& message);
+    rapidjson::Type MemberType(const rapidjson::Document& document, const std::string& message);
+    uint64_t        FromUint64(const rapidjson::Document& document, const std::string& message);
+    std::string     FromString(const rapidjson::Document& document, const std::string& message);
+    bool            FromBool(const rapidjson::Document& document, const std::string& message);
+  } // namespace json
+} // namespace ga
+
+extern std::string FLAGS_peer_server_url;
+extern std::string FLAGS_sessionid;
+extern std::string FLAGS_clientid;
+extern bool FLAGS_show_statistics;
+extern bool FLAGS_logging;
+extern bool FLAGS_streamdump;
+extern bool FLAGS_verbose;
+extern std::string FLAGS_stunsvr;
+
+#endif GA_OPTION_H_

--- a/sources/apps/webrtc-client/game-session.cc
+++ b/sources/apps/webrtc-client/game-session.cc
@@ -1,0 +1,167 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "game-session.h"
+#include "peer-connection.h"
+
+// clang-format on
+GameSession::GameSession() {
+  pc_.reset(new PeerConnection());
+  prev_pointerlock_status_ = false;
+  render_width_  = 0;
+  render_height_ = 0;
+}
+
+GameSession::~GameSession() {
+  if( NULL != cursor_data_ )
+  {
+    free(cursor_data_);
+    cursor_data_ = NULL;
+  }
+}
+
+void GameSession::OnStreamAdded()
+{
+  // start negotiation with server.
+
+  // Step1: report client display resolution to server
+  if (render_width_ !=0 && render_height_ != 0 ) {//TODO: need to add protocol between server and client for the negotiate
+      std::string m;
+      m = InputEventHandler::OnSizeChange(render_width_, render_height_);
+      pc_->SendMessage(m);
+  }
+  //
+}
+void GameSession::SendSizeChange(UINT render_w, UINT render_h) {
+
+  if (render_w != render_width_ || render_h != render_height_) {
+      render_width_  = render_w;
+      render_height_ = render_h;
+  }
+}
+
+void GameSession::OnDataReceivedHandler(
+  const std::string &message) {
+  rapidjson::Document msg;
+
+  if (!ga::json::ParseMessage(msg, message)) {
+    ga::log::WriteToFile("ClientErrorLog", "txt", "[%s][%lu][WARNING]: Failed to parse message: %s\n", __FUNCTION__, __LINE__, message.c_str());
+    return;
+  }
+
+  std::string type = ga::json::FromString(msg, "type");
+  if (type == "cursor") {
+    if (connect_settings_.mousestate_callback_) {
+      struct ga::remote::CursorInfo cursorInfo = {0};
+      //receive cursor info
+      cursorInfo.isVisible = ga::json::FromBool(msg, "visible");
+      if (cursorInfo.isVisible) {
+          cursorInfo.width  = ga::json::FromUint64(msg, "width");
+          cursorInfo.height = ga::json::FromUint64(msg, "height");
+          cursorInfo.pitch  = ga::json::FromUint64(msg, "pitch");
+          cursorInfo.cursorDataUpdate = !ga::json::FromBool(msg, "noShapeChange");
+          if (cursorInfo.cursorDataUpdate) {
+            cursorInfo.cursordata.clear();
+            if (ga::json::MemberType(msg, "cursorData") == rapidjson::Type::kArrayType && msg["cursorData"].Size() <= MAX_CURSOR_SIZE) {
+              for (auto it = msg["cursorData"].Begin(); it != msg["cursorData"].End(); ++it) {
+                  cursorInfo.cursordata.push_back(it->GetUint());
+              }
+            } else {
+              //TODO: current server maximum is 64x64x4
+            }
+          }
+        }
+        connect_settings_.mousestate_callback_(cursorInfo);
+    }
+  }
+}
+
+void GameSession::SendPointerlockchange(bool relativeMode)
+{
+  if (prev_pointerlock_status_ != relativeMode) {
+    std::string m;
+    m = InputEventHandler::onPointerlockchange(relativeMode);
+    pc_->SendMessage(m);
+    prev_pointerlock_status_ = relativeMode;
+  }
+}
+
+void CALLBACK GameSession::SendFrameStats(FrameStats *p_frame_stats)
+{
+
+  std::string m;
+  m = InputEventHandler::OnStatsRequest(p_frame_stats);
+  pc_->SendMessage(m);
+}
+
+void GameSession::SendMouseEvent(MouseOptions *p_m_options, bool is_raw) {
+  std::string m;
+  m = InputEventHandler::OnMouseEvent(p_m_options, is_raw);
+  pc_->SendMessage(m);
+}
+
+void GameSession::SendKeyboardEvent(
+    KeyboardOptions *p_key_options) {
+  std::string m;
+  m = InputEventHandler::OnKeyboardEvent(p_key_options);
+  pc_->SendMessage(m);
+}
+
+int GameSession::ConnectPeerServer(StreamingStatistics* streamingStatistics) {
+  pc_->Init(session_id_);
+  pc_->SetWindowHandle(connect_settings_.hwnd_);
+  pc_->SetWindowSize(0, 0, GetSystemMetrics(SM_CXSCREEN),
+      GetSystemMetrics(SM_CYSCREEN));
+  if (streamingStatistics) {
+      pc_->setStreamingStatistics(streamingStatistics);
+  }
+  pc_->Connect(peer_server_url_, session_id_, client_id_);
+  pc_->Start();
+  return 0;
+}
+
+void GameSession::ConfigConnection(const ga::remote::SessionMetaData &session_info,
+  const ga::remote::ClientSettings client_settings) {
+  int error_code = 0;
+  peer_server_url_ = session_info.peer_server_url_;
+  session_id_ = session_info.session_id_;
+  client_id_ = session_info.client_id_;
+  connect_settings_.mousestate_callback_ = client_settings.mousestate_callback_;
+  connect_settings_.connection_callback_ = client_settings.connection_callback_;
+  connect_settings_.hwnd_ = client_settings.hwnd_;
+  pc_->session_ = this;
+}
+
+int GameSession::OnServerConnected(string &game_session_id) {
+  int err_num = 0;
+  if (connect_settings_.connection_callback_) {
+    err_num = connect_settings_.connection_callback_(game_session_id);
+  }
+  else {
+  }
+  return err_num;
+}
+
+int GameSession::StopConnection(void) {
+  pc_->Stop();
+  return 0;
+}
+
+void GameSession::SetWindowSize(UINT x_offset, UINT y_offset,
+                                            UINT width, UINT height) {
+  pc_->SetWindowSize(x_offset, y_offset, width, height);
+}

--- a/sources/apps/webrtc-client/game-session.h
+++ b/sources/apps/webrtc-client/game-session.h
@@ -1,0 +1,58 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_REMOTE_CONECTION_HANDLER_H_
+#define GA_REMOTE_CONECTION_HANDLER_H_
+
+#include "peer-connection.h"
+#include "ga-option.h"
+#include "stdlib.h"
+#include "control-handler.h"
+#include <memory>
+
+#include <Windows.h>
+
+class GameSession {
+public:
+  explicit GameSession();
+  ~GameSession();
+  void OnDataReceivedHandler(const std::string &message);
+  int OnServerConnected(string &session_id);
+  void ConfigConnection(const ga::remote::SessionMetaData &opts, const ga::remote::ClientSettings launch_options);
+  void SendSizeChange(UINT render_w, UINT render_h);
+  void SendMouseEvent(MouseOptions *p_m_options, bool is_raw);
+  void SendKeyboardEvent(KeyboardOptions *p_key_options);
+  int ConnectPeerServer(StreamingStatistics* streamingStatistics);
+  int StopConnection(void);
+  void SetWindowSize(UINT x_offset, UINT y_offset, UINT width, UINT height);
+  void OnStreamAdded();
+  void SendPointerlockchange(bool change);
+
+  void CALLBACK SendFrameStats(FrameStats* p_frame_stats);
+
+private:
+  std::string session_id_;
+  std::string client_id_;
+  std::string peer_server_url_;
+  std::unique_ptr<PeerConnection> pc_;
+  ga::remote::ClientSettings connect_settings_;
+  char *cursor_data_;  // Store the cursor data
+  UINT render_width_;  // local display resoluiton width
+  UINT render_height_; // local display resoluiton height
+  BOOL prev_pointerlock_status_; // track client cursor mode change between absolute and relatie mode
+  void* gpMsg_ = nullptr;
+};
+#endif

--- a/sources/apps/webrtc-client/implot-window.cc
+++ b/sources/apps/webrtc-client/implot-window.cc
@@ -1,0 +1,532 @@
+// MIT License
+
+// Copyright (c) 2022 Evan Pezent
+// Copyright (c) 2023 Intel Corporation
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// We define this so that the demo does not accidentally use deprecated API
+#ifndef IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#define IMPLOT_DISABLE_OBSOLETE_FUNCTIONS
+#endif
+
+#include "implot.h"
+#include "statistics-window-class.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <tuple>
+#include <chrono>
+
+using std::chrono::duration_cast;
+using std::chrono::high_resolution_clock;
+using std::chrono::milliseconds;
+
+#ifdef _MSC_VER
+#define sprintf sprintf_s
+#endif
+
+#ifndef PI
+#define PI 3.14159265358979323846
+#endif
+
+#define CHECKBOX_FLAG(flags, flag) ImGui::CheckboxFlags(#flag, (unsigned int*)&flags, flag)
+
+// Encapsulates examples for customizing ImPlot.
+namespace MyImPlot {
+
+// Example for Custom Data and Getters section.
+struct Vector2f {
+    Vector2f(float _x, float _y) { x = _x; y = _y; }
+    float x, y;
+};
+
+// Example for Custom Data and Getters section.
+struct WaveData {
+    double X, Amp, Freq, Offset;
+    WaveData(double x, double amp, double freq, double offset) { X = x; Amp = amp; Freq = freq; Offset = offset; }
+};
+ImPlotPoint SineWave(int idx, void* wave_data);
+ImPlotPoint SawWave(int idx, void* wave_data);
+ImPlotPoint Spiral(int idx, void* wave_data);
+
+// Example for Tables section.
+void Sparkline(const char* id, const float* values, int count, float min_v, float max_v, int offset, const ImVec4& col, const ImVec2& size);
+
+// Example for Custom Plotters and Tooltips section.
+void PlotCandlestick(const char* label_id, const double* xs, const double* opens, const double* closes, const double* lows, const double* highs, int count, bool tooltip = true, float width_percent = 0.25f, ImVec4 bullCol = ImVec4(0,1,0,1), ImVec4 bearCol = ImVec4(1,0,0,1));
+
+// Example for Custom Styles section.
+void StyleSeaborn();
+
+} // namespace MyImPlot
+
+namespace ImPlot {
+
+template <typename T>
+inline T RandomRange(T min, T max) {
+    T scale = rand() / (T) RAND_MAX;
+    return min + scale * ( max - min );
+}
+
+ImVec4 RandomColor() {
+    ImVec4 col;
+    col.x = RandomRange(0.0f,1.0f);
+    col.y = RandomRange(0.0f,1.0f);
+    col.z = RandomRange(0.0f,1.0f);
+    col.w = 1.0f;
+    return col;
+}
+
+double RandomGauss() {
+    static double V1, V2, S;
+    static int phase = 0;
+    double X;
+    if(phase == 0) {
+        do {
+            double U1 = (double)rand() / RAND_MAX;
+            double U2 = (double)rand() / RAND_MAX;
+            V1 = 2 * U1 - 1;
+            V2 = 2 * U2 - 1;
+            S = V1 * V1 + V2 * V2;
+            } while(S >= 1 || S == 0);
+
+        X = V1 * sqrt(-2 * log(S) / S);
+    } else
+        X = V2 * sqrt(-2 * log(S) / S);
+    phase = 1 - phase;
+    return X;
+}
+
+template <int N>
+struct NormalDistribution {
+    NormalDistribution(double mean, double sd) {
+        for (int i = 0; i < N; ++i)
+            Data[i] = RandomGauss()*sd + mean;
+    }
+    double Data[N];
+};
+
+// utility structure for realtime plot
+struct ScrollingBuffer {
+    int MaxSize;
+    int Offset;
+    ImVector<ImVec2> Data;
+    ScrollingBuffer(int max_size = 2000) {
+        MaxSize = max_size;
+        Offset  = 0;
+        Data.reserve(MaxSize);
+    }
+    std::tuple<int, int> GetMinMaxY(float x_start, float x_end) {
+        int i = 0;
+        int ymax = 0;
+        int ymin = 9000;
+
+        for (i = 0; i < Data.size(); i++) {
+            if (Data[i].x >= x_start && Data[i].x <= x_end){
+                if (ymax < (int)Data[i].y) {
+                    ymax = (int)Data[i].y;
+                }
+                if (ymin > (int)Data[i].y) {
+                    ymin = (int)Data[i].y;
+                }
+            }
+        }
+        return std::tuple<int, int>{ymin, ymax};
+    }
+
+    void AddPoint(float x, float y) {
+        int i;
+        if (y > 2000)
+            return;
+
+        if (Data.size() < MaxSize)
+            Data.push_back(ImVec2(x,y));
+        else {
+            Data[Offset] = ImVec2(x,y);
+            Offset =  (Offset + 1) % MaxSize;
+        }
+    }
+    void Erase() {
+        if (Data.size() > 0) {
+            Data.shrink(0);
+            Offset  = 0;
+        }
+    }
+};
+
+//-----------------------------------------------------------------------------
+// [SECTION] Demo Functions
+//-----------------------------------------------------------------------------
+
+void Demo_Help() {
+    ImGui::Text("ABOUT THIS DEMO:");
+    ImGui::BulletText("Sections below are demonstrating many aspects of the library.");
+    ImGui::BulletText("The \"Tools\" menu above gives access to: Style Editors (ImPlot/ImGui)\n"
+                        "and Metrics (general purpose Dear ImGui debugging tool).");
+    ImGui::Separator();
+    ImGui::Text("PROGRAMMER GUIDE:");
+    ImGui::BulletText("See the ShowDemoWindow() code in implot_demo.cpp. <- you are here!");
+    ImGui::BulletText("If you see visual artifacts, do one of the following:");
+    ImGui::Indent();
+    ImGui::BulletText("Handle ImGuiBackendFlags_RendererHasVtxOffset for 16-bit indices in your backend.");
+    ImGui::BulletText("Or, enable 32-bit indices in imconfig.h.");
+    ImGui::BulletText("Your current configuration is:");
+    ImGui::Indent();
+    ImGui::BulletText("ImDrawIdx: %d-bit", (int)(sizeof(ImDrawIdx) * 8));
+    ImGui::BulletText("ImGuiBackendFlags_RendererHasVtxOffset: %s", (ImGui::GetIO().BackendFlags & ImGuiBackendFlags_RendererHasVtxOffset) ? "True" : "False");
+    ImGui::Unindent();
+    ImGui::Unindent();
+    ImGui::Separator();
+    ImGui::Text("USER GUIDE:");
+    ShowUserGuide();
+}
+
+//-----------------------------------------------------------------------------
+
+void ButtonSelector(const char* label, ImGuiMouseButton* b) {
+    ImGui::PushID(label);
+    if (ImGui::RadioButton("LMB",*b == ImGuiMouseButton_Left))
+        *b = ImGuiMouseButton_Left;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("RMB",*b == ImGuiMouseButton_Right))
+        *b = ImGuiMouseButton_Right;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("MMB",*b == ImGuiMouseButton_Middle))
+        *b = ImGuiMouseButton_Middle;
+    ImGui::PopID();
+}
+
+void ModSelector(const char* label, ImGuiModFlags* k) {
+    ImGui::PushID(label);
+    ImGui::CheckboxFlags("Ctrl", (unsigned int*)k, ImGuiModFlags_Ctrl); ImGui::SameLine();
+    ImGui::CheckboxFlags("Shift", (unsigned int*)k, ImGuiModFlags_Shift); ImGui::SameLine();
+    ImGui::CheckboxFlags("Alt", (unsigned int*)k, ImGuiModFlags_Alt); ImGui::SameLine();
+    ImGui::CheckboxFlags("Super", (unsigned int*)k, ImGuiModFlags_Super);
+    ImGui::PopID();
+}
+
+void InputMapping(const char* label, ImGuiMouseButton* b, ImGuiModFlags* k) {
+    ImGui::LabelText("##","%s",label);
+    if (b != NULL) {
+        ImGui::SameLine(100);
+        ButtonSelector(label,b);
+    }
+    if (k != NULL) {
+        ImGui::SameLine(300);
+        ModSelector(label,k);
+    }
+}
+
+void ShowInputMapping() {
+    ImPlotInputMap& map = ImPlot::GetInputMap();
+    InputMapping("Pan",&map.Pan,&map.PanMod);
+    InputMapping("Fit",&map.Fit,NULL);
+    InputMapping("Select",&map.Select,&map.SelectMod);
+    InputMapping("SelectHorzMod",NULL,&map.SelectHorzMod);
+    InputMapping("SelectVertMod",NULL,&map.SelectVertMod);
+    InputMapping("SelectCancel",&map.SelectCancel,NULL);
+    InputMapping("Menu",&map.Menu,NULL);
+    InputMapping("OverrideMod",NULL,&map.OverrideMod);
+    InputMapping("ZoomMod",NULL,&map.ZoomMod);
+    ImGui::SliderFloat("ZoomRate",&map.ZoomRate,-1,1);
+}
+
+void Demo_Config() {
+    ImGui::ShowFontSelector("Font");
+    ImGui::ShowStyleSelector("ImGui Style");
+    ImPlot::ShowStyleSelector("ImPlot Style");
+    ImPlot::ShowColormapSelector("ImPlot Colormap");
+    ImPlot::ShowInputMapSelector("Input Map");
+    ImGui::Separator();
+    ImGui::Checkbox("Use Local Time", &ImPlot::GetStyle().UseLocalTime);
+    ImGui::Checkbox("Use ISO 8601", &ImPlot::GetStyle().UseISO8601);
+    ImGui::Checkbox("Use 24 Hour Clock", &ImPlot::GetStyle().Use24HourClock);
+    ImGui::Separator();
+    if (ImPlot::BeginPlot("Preview")) {
+        static double now = (double)time(0);
+        ImPlot::SetupAxisScale(ImAxis_X1, ImPlotScale_Time);
+        ImPlot::SetupAxisLimits(ImAxis_X1, now, now + 24*3600);
+        for (int i = 0; i < 10; ++i) {
+            double x[2] = {now, now + 24*3600};
+            double y[2] = {0,i/9.0};
+            ImGui::PushID(i);
+            ImPlot::PlotLine("##Line",x,y,2);
+            ImGui::PopID();
+        }
+        ImPlot::EndPlot();
+    }
+}
+
+//-----------------------------------------------------------------------------
+
+
+void Demo_RealtimePlots_FPS(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, streamingStatistics->captureFps);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Game FPS", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "fps", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::PlotLine("Game FPS", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_Latency(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, (int)streamingStatistics->e2erealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("E2E Latency", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("E2E Latency", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_FSize(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, (int)streamingStatistics->framesizerealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Frame Size", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "Bytes/Frame", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Frame Size", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_FDelay(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, (int)streamingStatistics->framedelayrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Frame Delay", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Frame Delay", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_PLoss(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, (int)streamingStatistics->packetlossrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Packet Loss", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "%", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Packet Loss", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_FTime(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, (int)streamingStatistics->framedelayrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Frame Time", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 2, std::get<1>(bounds) + 5, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Frame Time", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_CDec(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, streamingStatistics->decrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Client Decode", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 1, std::get<1>(bounds) + 2, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Latency", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_CRen(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, streamingStatistics->crenrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Client Render", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 1, std::get<1>(bounds) + 2, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Latency", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_SRen(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, streamingStatistics->srenrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Server Render", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 1, std::get<1>(bounds) + 2, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Latency", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+void Demo_RealtimePlots_SEnc(StreamingStatistics* streamingStatistics) {
+    static ScrollingBuffer sdata1;
+    static float t = 0;
+    t += ImGui::GetIO().DeltaTime;
+    sdata1.AddPoint(t, streamingStatistics->encrealtime);
+
+    static float history = 10.0f;
+    std::tuple<int, int> bounds = sdata1.GetMinMaxY(t - history, t);
+
+    static ImPlotAxisFlags flags = ImPlotAxisFlags_NoTickLabels;
+
+    ImPlot::BeginPlot("Server Encode", ImVec2(-1, 150));
+    ImPlot::SetupAxes(NULL, "ms", flags, NULL);
+    ImPlot::SetupAxisLimits(ImAxis_X1, t - history, t, ImGuiCond_Always);
+    ImPlot::SetupAxisLimits(ImAxis_Y1, std::get<0>(bounds) - 1, std::get<1>(bounds) + 2, ImGuiCond_Always);
+    ImPlot::SetNextLineStyle(IMPLOT_AUTO_COL, 3);
+    ImPlot::PlotLine("Latency", &sdata1.Data[0].x, &sdata1.Data[0].y, sdata1.Data.size(), 0, sdata1.Offset, 2 * sizeof(float));
+    ImPlot::EndPlot();
+}
+
+//-----------------------------------------------------------------------------
+// DEMO WINDOW
+//-----------------------------------------------------------------------------
+
+void DemoHeader(const char* label, StreamingStatistics* streamingStatistics, void(*demo)(StreamingStatistics* streamingStatistics)) {
+    if (ImGui::TreeNodeEx(label)) {
+        demo(streamingStatistics);
+        ImGui::TreePop();
+    }
+}
+
+void ShowImplotWindow(StreamingStatistics* streamingStatistics) {
+    static StreamingStatistics g_displayed_stats = { 0 };
+    static std::chrono::steady_clock::time_point g_last_display_time;
+
+    std::chrono::steady_clock::time_point now = high_resolution_clock::now();
+    auto ms_since_last_update = duration_cast<milliseconds>(now - g_last_display_time).count();
+
+    //Update stats every 120 times a minute to maintain readability.
+    //Real time stats can be acquired in either the plots or the log files.
+    if (ms_since_last_update >= 500) {
+        memcpy(&g_displayed_stats, streamingStatistics, sizeof(g_displayed_stats));
+        g_last_display_time = high_resolution_clock::now();
+    }
+
+    ImGui::Begin("Statistics", NULL, ImGuiWindowFlags_MenuBar);
+    ImGui::Text("Game FPS %3d fps", g_displayed_stats.captureFps);
+    ImGui::Text("Captured Frame Width: %d", g_displayed_stats.framewidth);
+    ImGui::Text("Captured Frame Height: %d", g_displayed_stats.frameheight);
+    ImGui::Text("Client Render: %.2lf ms", g_displayed_stats.crenrealtime);
+    ImGui::Text("Client Decode: %.2lf ms", g_displayed_stats.decrealtime);
+    ImGui::Text("Server Render: %.2lf ms", g_displayed_stats.srenrealtime);
+    ImGui::Text("Server Encode: %.2lf ms", g_displayed_stats.encrealtime);
+    ImGui::Text("E2E Latency: %.2lf ms", g_displayed_stats.e2erealtime);
+    ImGui::Text("Frame Size: %.2lf bytes", g_displayed_stats.framesizerealtime);
+    ImGui::Text("Frame Delay: %.2lf ms", g_displayed_stats.framedelayrealtime);
+    ImGui::Text("Packet Loss: %.2lf%%", g_displayed_stats.packetlossrealtime);
+    DemoHeader("FPS Plot", streamingStatistics, Demo_RealtimePlots_FPS);
+    DemoHeader("Client Render Plot", streamingStatistics, Demo_RealtimePlots_CRen);
+    DemoHeader("Client Decode Plot", streamingStatistics, Demo_RealtimePlots_CDec);
+    DemoHeader("Server Render Plot", streamingStatistics, Demo_RealtimePlots_SRen);
+    DemoHeader("Server Encode Plot", streamingStatistics, Demo_RealtimePlots_SEnc);
+    DemoHeader("E2E Latency Plot", streamingStatistics, Demo_RealtimePlots_Latency);
+    DemoHeader("Frame Size Plot", streamingStatistics, Demo_RealtimePlots_FSize);
+    DemoHeader("Frame Delay Plot", streamingStatistics, Demo_RealtimePlots_FDelay);
+    DemoHeader("Packet Loss Plot", streamingStatistics, Demo_RealtimePlots_PLoss);
+    DemoHeader("Frame Time Plot", streamingStatistics, Demo_RealtimePlots_FTime);
+
+    ImGui::End();
+}
+
+} // namespace ImPlot

--- a/sources/apps/webrtc-client/meson.build
+++ b/sources/apps/webrtc-client/meson.build
@@ -1,0 +1,92 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+imgui_dep = dependency('imgui', required : get_option('client'),
+  default_options: ['default_library=static'])
+implot_dep = dependency('implot', required : get_option('client'),
+  default_options: ['default_library=static'])
+
+libavcodec_dep = dependency('libavcodec', required : get_option('client'))
+libavutil_dep = dependency('libavutil', required : get_option('client'))
+
+openssl_dep = dependency('openssl', required : get_option('client'))
+owt_client_dep = dependency('owt-client', required : get_option('client'))
+rapidjson_dep = dependency('rapidjson', required : get_option('client'))
+sioclient_tls_dep = dependency('sioclient_tls', required : openssl_dep.found())
+
+deps = [
+  imgui_dep,
+  implot_dep,
+  libavcodec_dep,
+  libavutil_dep,
+  owt_client_dep,
+  rapidjson_dep,
+  sioclient_tls_dep,
+  ]
+
+# Exit if 'client' was set to 'auto' and any of dependencies were not found. If
+# 'client' was set to 'enabled' we will stop earlier with error processing
+# dependencies search above (due to 'required: true').
+foreach dep : deps
+  if not dep.found()
+    warning('webrtc-client will NOT be built because some dependencies are missing')
+    summary({'webrtc-client' : false}, bool_yn : true, section: 'Targets')
+    subdir_done()
+  endif
+endforeach
+
+summary({'webrtc-client' : true}, bool_yn : true, section: 'Targets')
+
+srcs = [
+  # header files
+  'control-handler.h',
+  'ga-option.h',
+  'game-session.h',
+  'peer-connection.h',
+  'rtc-signaling.h',
+  'statistics-window-class.h',
+  'video-renderer.h',
+  'window-class.h',
+  'window-handler.h',
+  # source files
+  'control-handler.cc',
+  'ga-option.cc',
+  'game-session.cc',
+  'implot-window.cc',
+  'peer-connection.cc',
+  'rtc-signaling.cc',
+  'statistics-window-class.cc',
+  'video-renderer.cc',
+  'webrtc-client.cc',
+  'window-class.cc',
+  'window-handler.cc',
+  ]
+
+cpp_args = ['-DWEBRTC_WIN', '-DNOMINMAX', '-DUNICODE', '-D_UNICODE']
+
+core_deps = [
+  cpp.find_library('d3d11'),
+  cpp.find_library('dxgi'),
+  cpp.find_library('iphlpapi'),
+  cpp.find_library('winmm'),
+  ]
+
+executable('gawebrtcclient', srcs,
+  cpp_args : cpp_args,
+  win_subsystem : 'windows',
+  dependencies : [ deps, core_deps],
+  install : true,
+  )

--- a/sources/apps/webrtc-client/peer-connection.cc
+++ b/sources/apps/webrtc-client/peer-connection.cc
@@ -1,0 +1,126 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "control-handler.h"
+#include "peer-connection.h"
+#include "game-session.h"
+// clang-format on
+
+using owt::base::GlobalConfiguration;
+using owt::p2p::P2PClient;
+using owt::p2p::P2PClientObserver;
+
+long PeerConnection::send_invoke_is_safe_ = 1;
+long PeerConnection::send_success_ = 0;
+long PeerConnection::send_timeout_ = 30;
+
+void PeerConnection::Init(const std::string &session_token) {
+  if (FLAGS_logging) {
+    // Typically this will output log in msys2 console. Not sure why CMD shell does not...
+    owt::base::Logging::Severity(owt::base::LoggingSeverity::kInfo);
+    owt::base::Logging::LogToConsole(owt::base::LoggingSeverity::kInfo);
+  }
+  signaling_channel_.reset(new P2PSignalingChannel());
+  GlobalConfiguration::SetLowLatencyStreamingEnabled(true);
+  if (FLAGS_streamdump)
+    GlobalConfiguration::SetPreDecodeDumpEnabled(true);
+  owt::p2p::P2PClientConfiguration configuration_;
+  owt::base::IceServer icesvr;
+  icesvr.urls.push_back(FLAGS_stunsvr);
+  configuration_.ice_servers.push_back(icesvr);
+  AudioCodecParameters audio_codec_params;
+  audio_codec_params.name = AudioCodec::kOpus;
+  AudioEncodingParameters audio_params(audio_codec_params, 0);
+  configuration_.audio_encodings.push_back(audio_params);
+  pc_.reset(new P2PClient(configuration_, signaling_channel_));
+  pc_->AddObserver(*this);
+  remote_peer_id_ = session_token;
+  pc_->AddAllowedRemoteId(remote_peer_id_);
+}
+
+void PeerConnection::SetWindowHandle(HWND hwnd) {
+  render_window_.SetWindowHandle(hwnd);
+  // Initialize DX container
+  dx_renderer_.SetWindow(hwnd);
+}
+
+// Johny: currently this is hard-coded to use id "client"
+void PeerConnection::Connect(const std::string &peer_server_url,
+                             const std::string &session_token,
+                             const std::string &client_id) {
+  std::string token = client_id;
+  pc_->Connect(
+    peer_server_url, token,
+    [this](const std::string &id) {
+      // TODO: we should add some handling here... Otherwise it might crash sending the start message.
+    },
+    [this](std::unique_ptr<Exception> err) {
+    });
+}
+
+void PeerConnection::Start() {
+  long send_success_local = 0;
+
+  while (!send_success_local) {
+    if (send_invoke_is_safe_) {
+      InterlockedExchange(&send_invoke_is_safe_, 0);
+      pc_->Send(
+          remote_peer_id_, "start",
+          [&](void) {
+            InterlockedExchange(&send_success_, 1);
+            InterlockedExchange(&send_invoke_is_safe_, 1);
+            if (session_) {
+              session_->OnServerConnected(remote_peer_id_);
+            }
+          },
+          [&](std::unique_ptr<Exception> err) {
+            err.release();
+            InterlockedExchange(&send_invoke_is_safe_, 1);
+          });
+    }
+    Sleep(1000);
+    InterlockedExchange(&send_success_local, send_success_);
+  }
+  connection_active_ = true;
+}
+
+void PeerConnection::Stop() {
+  dx_renderer_.Cleanup();
+  connection_active_ = false;
+}
+
+void PeerConnection::SendMessage(const std::string &msg) {
+  if (stream_started_) {
+    pc_->Send(remote_peer_id_, msg, nullptr, nullptr);
+  }
+}
+
+// Johny: this is the interface WebRTC receives video/audio streams.
+void PeerConnection::OnStreamAdded(std::shared_ptr<RemoteStream> stream) {
+  stream_started_ = true;
+  remote_stream_ = stream;
+  remote_stream_->AttachVideoRenderer(dx_renderer_);
+  session_->OnStreamAdded();
+}
+
+
+void PeerConnection::OnMessageReceived(const std::string &remote_user_id,
+  const std::string message) {
+  if (session_) {
+    session_->OnDataReceivedHandler(message);
+  }
+}

--- a/sources/apps/webrtc-client/peer-connection.h
+++ b/sources/apps/webrtc-client/peer-connection.h
@@ -1,0 +1,73 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_PEERCONNECTION_H_
+#define GA_PEERCONNECTION_H_
+
+#include "video-renderer.h"
+#include "owt/base/commontypes.h"
+//#include "owt/base/connectionstats.h"
+#include "owt/base/globalconfiguration.h"
+#include "owt/base/logging.h"
+#include "owt/base/network.h"
+#include "owt/base/videorendererinterface.h"
+#include "owt/p2p/p2pclient.h"
+#include "rtc-signaling.h"
+#include <memory>
+
+using owt::base::GlobalConfiguration;
+using owt::p2p::P2PClient;
+using owt::p2p::P2PClientObserver;
+
+class GameSession;
+
+/// This class is the webrtc transport wrapper for gaming client.
+class PeerConnection : public P2PClientObserver {
+public:
+  PeerConnection() : stream_started_(false) {}
+  void Init(const std::string &session_token);
+  void Connect(const std::string &peer_server_url,
+               const std::string &session_token,
+               const std::string &client_id);
+  void SetWindowHandle(HWND hwnd);
+  void Start();
+  void Stop();
+  void SendMessage(const std::string &msg);
+  void SetWindowSize(UINT x, UINT y, UINT w, UINT h) {
+    dx_renderer_.SetWindowSize(x, y, w, h);
+  }
+  void setStreamingStatistics(StreamingStatistics* streamingStatistics) { dx_renderer_.setStreamingStatistics(streamingStatistics); };
+  GameSession* session_;
+
+protected:
+  // PeerClientObserver impl
+  void OnStreamAdded(std::shared_ptr<RemoteStream> stream) override;
+  void OnMessageReceived(const std::string &remote_user_id,
+    const std::string message)override;
+private:
+  std::shared_ptr<P2PClient> pc_;
+  std::shared_ptr<RemoteStream> remote_stream_;
+  owt::base::VideoRenderWindow render_window_;
+  std::shared_ptr<P2PSignalingChannel> signaling_channel_;
+  DXRenderer dx_renderer_;
+  std::string remote_peer_id_;
+  static long send_invoke_is_safe_;
+  static long send_success_;
+  bool stream_started_;
+  static long send_timeout_;
+  bool connection_active_;
+};
+#endif // GA_PEERCONNECTION_H_

--- a/sources/apps/webrtc-client/rtc-signaling.cc
+++ b/sources/apps/webrtc-client/rtc-signaling.cc
@@ -1,0 +1,104 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "rtc-signaling.h"
+
+#include <algorithm>
+#include <map>
+
+P2PSignalingChannel::P2PSignalingChannel() : io_(new sio::client()) {}
+
+void P2PSignalingChannel::AddObserver(P2PSignalingChannelObserver &observer) {
+  observers_.push_back(&observer);
+}
+
+void P2PSignalingChannel::RemoveObserver(
+    P2PSignalingChannelObserver &observer) {
+  observers_.erase(remove(observers_.begin(), observers_.end(), &observer),
+                   observers_.end());
+}
+
+// If the token is not url-encoded, there will be connection issue.
+// TODO: protect the token with URL encoding/decoding.
+void P2PSignalingChannel::Connect(
+    const std::string &host, const std::string &token,
+    std::function<void(const std::string &)> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  connect_success_callback_ = on_success;
+  std::map<std::string, std::string> query;
+  query.insert(std::pair<std::string, std::string>("clientVersion", "4.2"));
+  query.insert(std::pair<std::string, std::string>("clientType", "cpp"));
+  query.insert(std::pair<std::string, std::string>(
+      "token", token));
+  io_->set_open_listener(std::bind(&connection_listener::on_connected,
+                                   connection_listener_.get()));
+  sio::socket::ptr socket = io_->socket();
+  std::string ics_chat = "owt-message";
+  std::string auth_done = "server-authenticated";
+  socket->on(
+      ics_chat,
+      sio::socket::event_listener_aux(
+          [&](std::string const &name, sio::message::ptr const &data,
+              bool has_ack, sio::message::list &ack_resp) {
+            if (data->get_flag() == sio::message::flag_object) {
+              std::string msg = data->get_map()["data"]->get_string().data();
+              std::string from = data->get_map()["from"]->get_string().data();
+              for (auto it = observers_.begin(); it != observers_.end(); ++it)
+                (*it)->OnSignalingMessage(msg, from);
+            }
+          }));
+  socket->on(auth_done,
+             sio::socket::event_listener_aux(
+                 [&](std::string const &name, sio::message::ptr const &data,
+                     bool has_ack, sio::message::list &ack_resp) {
+                   if (data->get_flag() == sio::message::flag_object &&
+                       connect_success_callback_) {
+                     std::string msg =
+                         data->get_map()["uid"]->get_string().data();
+                     connect_success_callback_(msg);
+                   }
+                 }));
+  io_->connect(host, query);
+}
+
+void P2PSignalingChannel::Disconnect(
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {}
+
+void P2PSignalingChannel::SendMessage(
+    const std::string &message, const std::string &target_id,
+    std::function<void()> on_success,
+    std::function<void(std::unique_ptr<Exception>)> on_failure) {
+  sio::message::ptr jsonObject = sio::object_message::create();
+  jsonObject->get_map()["to"] = sio::string_message::create(target_id);
+  jsonObject->get_map()["data"] = sio::string_message::create(message);
+  io_->socket()->emit("owt-message", jsonObject, [=](const sio::message::list& msg) {
+    if (msg.size() > 0 && msg[0]->get_flag() == sio::message::flag_integer) {
+      int64_t error_code = msg[0]->get_int();
+      if (on_failure) {
+        std::unique_ptr<owt::base::Exception> exception(
+          new owt::base::Exception(ExceptionType::kP2PMessageTargetUnreachable,
+            "Remote user cannot be reached."));
+        on_failure(std::move(exception));
+      }
+      return;
+    }
+
+    if (on_success) {
+      on_success();
+    }
+    });
+}

--- a/sources/apps/webrtc-client/rtc-signaling.h
+++ b/sources/apps/webrtc-client/rtc-signaling.h
@@ -1,0 +1,53 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "owt/p2p/p2psignalingchannelinterface.h"
+#include "sio_client.h"
+
+using namespace owt::p2p;
+
+class connection_listener {
+  sio::client &handler;
+
+public:
+  connection_listener(sio::client &hdl) : handler(hdl) {}
+  void on_connected() {}
+};
+
+class P2PSignalingChannel : public P2PSignalingChannelInterface {
+public:
+  explicit P2PSignalingChannel();
+  virtual void AddObserver(P2PSignalingChannelObserver &observer) override;
+  virtual void RemoveObserver(P2PSignalingChannelObserver &observer) override;
+  virtual void
+  Connect(const std::string &host, const std::string &token,
+          std::function<void(const std::string &)> on_success,
+          std::function<void(std::unique_ptr<Exception>)> on_failure) override;
+  virtual void Disconnect(
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure) override;
+  virtual void SendMessage(
+      const std::string &message,
+      const std::string &target_id,
+      std::function<void()> on_success,
+      std::function<void(std::unique_ptr<Exception>)> on_failure) override;
+
+private:
+  std::vector<P2PSignalingChannelObserver *> observers_;
+  std::unique_ptr<sio::client> io_;
+  std::function<void(const std::string &)> connect_success_callback_;
+  std::unique_ptr<connection_listener> connection_listener_;
+};

--- a/sources/apps/webrtc-client/statistics-window-class.cc
+++ b/sources/apps/webrtc-client/statistics-window-class.cc
@@ -1,0 +1,189 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "statistics-window-class.h"
+#include "ga-option.h"
+#include <d3d11.h>
+
+static ID3D11Device* g_pd3dDevice = NULL;
+static ID3D11DeviceContext* g_pd3dDeviceContext = NULL;
+static IDXGISwapChain* g_pSwapChain = NULL;
+static ID3D11RenderTargetView* g_mainRenderTargetView = NULL;
+
+bool CreateDeviceD3D(HWND hWnd);
+void CleanupDeviceD3D();
+void CreateRenderTarget();
+void CleanupRenderTarget();
+
+void StatisticsWindowClass::Destroy(void) {
+    ImGui_ImplDX11_Shutdown();
+    ImGui_ImplWin32_Shutdown();
+    ImGui::DestroyContext();
+
+    CleanupDeviceD3D();
+    if (this->hwnd_) {
+        DestroyWindow(this->hwnd_);
+    }
+    delete this;
+}
+
+StatisticsWindowClass::StatisticsWindowClass(HINSTANCE h_instance, int n_cmd_show) { 
+    LONG l_ex_window_style;
+    RECT client_rect;
+    int width_delta = 0;
+    int height_delta = 0;
+
+    wc_.cbSize = sizeof(WNDCLASSEX);
+    wc_.style = CS_CLASSDC;
+    wc_.lpfnWndProc = StatisticsWindowClass::WndProc;
+    wc_.cbClsExtra = NULL;
+    wc_.cbWndExtra = NULL;
+    wc_.hInstance = h_instance;
+    wc_.hIcon = NULL;
+    wc_.hCursor = NULL;
+    wc_.hbrBackground = NULL;
+    wc_.lpszMenuName = NULL;
+    wc_.lpszClassName = L"GameStatistics";
+    wc_.hIconSm = NULL;
+
+    if (!RegisterClassEx(&wc_)) {
+        MessageBox(NULL, L"Window Registration Failed!", L"Error!",
+            MB_ICONEXCLAMATION | MB_OK);
+    }
+
+    hwnd_ = CreateWindowEx(NULL,
+        L"GameStatistics", L"Game Statistics",
+        WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 400, 500, NULL, NULL, h_instance, NULL);
+    
+    if (!CreateDeviceD3D(hwnd_))
+    {
+        CleanupDeviceD3D();
+        ::UnregisterClass(wc_.lpszClassName, wc_.hInstance);
+        MessageBox(NULL, L"D3D Device Failed!", L"Error!",
+            MB_ICONEXCLAMATION | MB_OK);
+    }
+    SetWindowPos(hwnd_, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+    ShowWindow(hwnd_, n_cmd_show);
+    UpdateWindow(hwnd_);
+    
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImPlot::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+    ImGui::StyleColorsDark();
+    ImFontConfig font_cfg = ImFontConfig();
+    font_cfg.SizePixels = 20;
+    ImFont* font1 = io.Fonts->AddFontDefault(&font_cfg);
+    ImGui_ImplWin32_Init(hwnd_);
+    ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
+}
+
+void StatisticsWindowClass::DrawStatistics() {
+    ImVec4 clear_color = ImVec4(0.45f, 0.55f, 0.60f, 1.00f);
+    ImGui_ImplDX11_NewFrame();
+    ImGui_ImplWin32_NewFrame();
+    ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize(ImVec2(25, 100), ImGuiCond_FirstUseEver);
+    ImGui::NewFrame();
+    ImPlot::ShowImplotWindow(_streamingStatistics);
+    ImGui::Render();
+    const float clear_color_with_alpha[4] = { clear_color.x * clear_color.w, clear_color.y * clear_color.w, clear_color.z * clear_color.w, clear_color.w };
+    g_pd3dDeviceContext->OMSetRenderTargets(1, &g_mainRenderTargetView, NULL);
+    g_pd3dDeviceContext->ClearRenderTargetView(g_mainRenderTargetView, clear_color_with_alpha);
+    ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+
+    g_pSwapChain->Present(0, 0);
+}
+
+bool CreateDeviceD3D(HWND hWnd)
+{
+    // Setup swap chain
+    DXGI_SWAP_CHAIN_DESC sd;
+    ZeroMemory(&sd, sizeof(sd));
+    sd.BufferCount = 2;
+    sd.BufferDesc.Width = 0;
+    sd.BufferDesc.Height = 0;
+    sd.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    sd.BufferDesc.RefreshRate.Numerator = 60;
+    sd.BufferDesc.RefreshRate.Denominator = 1;
+    sd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+    sd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    sd.OutputWindow = hWnd;
+    sd.SampleDesc.Count = 1;
+    sd.SampleDesc.Quality = 0;
+    sd.Windowed = TRUE;
+    sd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+
+    UINT createDeviceFlags = 0;
+    //createDeviceFlags |= D3D11_CREATE_DEVICE_DEBUG;
+    D3D_FEATURE_LEVEL featureLevel;
+    const D3D_FEATURE_LEVEL featureLevelArray[2] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0, };
+    if (D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags, featureLevelArray, 2, D3D11_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext) != S_OK)
+        return false;
+
+    CreateRenderTarget();
+    return true;
+}
+
+void CleanupDeviceD3D()
+{
+    CleanupRenderTarget();
+    if (g_pSwapChain) { g_pSwapChain->Release(); g_pSwapChain = NULL; }
+    if (g_pd3dDeviceContext) { g_pd3dDeviceContext->Release(); g_pd3dDeviceContext = NULL; }
+    if (g_pd3dDevice) { g_pd3dDevice->Release(); g_pd3dDevice = NULL; }
+}
+
+void CreateRenderTarget()
+{
+    ID3D11Texture2D* pBackBuffer = NULL;
+    HRESULT hr = g_pSwapChain->GetBuffer(0, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(&pBackBuffer));
+    if (SUCCEEDED(hr) && pBackBuffer) {
+        g_pd3dDevice->CreateRenderTargetView(pBackBuffer, NULL, &g_mainRenderTargetView);
+        pBackBuffer->Release();
+    }
+}
+
+void CleanupRenderTarget()
+{
+    if (g_mainRenderTargetView) { g_mainRenderTargetView->Release(); g_mainRenderTargetView = NULL; }
+}
+
+LRESULT CALLBACK StatisticsWindowClass::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
+        return true;
+
+    switch (msg)
+    {
+    case WM_SIZE:
+        if (g_pd3dDevice != NULL && wParam != SIZE_MINIMIZED)
+        {
+            CleanupRenderTarget();
+            g_pSwapChain->ResizeBuffers(0, (UINT)LOWORD(lParam), (UINT)HIWORD(lParam), DXGI_FORMAT_UNKNOWN, 0);
+            CreateRenderTarget();
+        }
+        return 0;
+    case WM_SYSCOMMAND:
+        if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu
+            return 0;
+        break;
+    case WM_DESTROY:
+        ::PostQuitMessage(0);
+        return 0;
+    }
+    return ::DefWindowProc(hWnd, msg, wParam, lParam);
+}
+

--- a/sources/apps/webrtc-client/statistics-window-class.h
+++ b/sources/apps/webrtc-client/statistics-window-class.h
@@ -1,0 +1,199 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_STATISTICSWINDOWCLASS_H_
+#define GA_STATISTICSWINDOWCLASS_H_
+
+#include <Windows.h>
+#include <Windowsx.h>
+
+#include <atomic>
+#include <cmath>
+#include <string>
+
+#include "imgui.h"
+#include "imgui_impl_win32.h"
+#include "imgui_impl_dx11.h"
+#include "implot.h"
+
+#define WM_GA_CURSOR_VISIBLE (WM_USER + 1)
+#define GA_HIDE_CURSOR 0
+#define GA_SHOW_CURSOR 1
+
+extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+#define MAXSAMPLES 200
+
+struct StreamingStatistics
+{
+    std::atomic<bool> updated{ false };
+
+    // frame info
+    unsigned int captureFps = 0;
+
+    void CalcStatistics(double newTime, double* realTime, double* avgTime, double* minTime, double* maxTime, int* index, double* timesum, double* timelist)
+    {
+        *realTime = newTime;
+        if (newTime < *minTime || *minTime == 0)
+            *minTime = newTime;
+        if (newTime > *maxTime || *maxTime == 0)
+            *maxTime = newTime;
+
+        *timesum -= timelist[*index];
+        *timesum += newTime;
+        timelist[*index] = newTime;
+        if (++(*index) == MAXSAMPLES)
+            *index = 0;
+
+        /* get average */
+        if (frametimesum != 0) {
+            *avgTime = *timesum / (double)MAXSAMPLES;
+            double multiplier = std::pow(10.0, 6);
+            *avgTime = std::round(*avgTime * multiplier) / multiplier;
+        }
+    }
+
+    //Client Render Statistics
+    double crenrealtime = 0;
+    double crenavgtime = 0;
+    double crenmintime = 0;
+    double crenmaxtime = 0;
+    int crenindex = 0;
+    double crentimesum = 0;
+    double crentimelist[MAXSAMPLES];
+
+    //Server Render Statistics
+    double srenrealtime = 0;
+    double srenavgtime = 0;
+    double srenmintime = 0;
+    double srenmaxtime = 0;
+    int srenindex = 0;
+    double srentimesum = 0;
+    double srentimelist[MAXSAMPLES];
+
+    //Decode Statistics
+    double decrealtime = 0;
+    double decavgtime = 0;
+    double decmintime = 0;
+    double decmaxtime = 0;
+    int decindex = 0;
+    double dectimesum = 0;
+    double dectimelist[MAXSAMPLES];
+
+    //Encode Statistics
+    double encrealtime = 0;
+    double encavgtime = 0;
+    double encmintime = 0;
+    double encmaxtime = 0;
+    int    encindex = 0;
+    double enctimesum = 0;
+    double enctimelist[MAXSAMPLES];
+
+    //E2E Latency Statistics
+    double e2erealtime = 0;
+    double e2eavgtime = 0;
+    double e2emintime = 0;
+    double e2emaxtime = 0;
+    int    e2eindex = 0;
+    double e2etimesum = 0;
+    double e2etimelist[MAXSAMPLES];
+
+    //Frame Size Statistics
+    double framesizerealtime = 0;
+    double framesizeavgtime = 0;
+    double framesizemintime = 0;
+    double framesizemaxtime = 0;
+    int    framesizeindex = 0;
+    double framesizetimesum = 0;
+    double framesizetimelist[MAXSAMPLES];
+
+    //Frame Delay Statistics
+    double framedelayrealtime = 0;
+    double framedelayavgtime = 0;
+    double framedelaymintime = 0;
+    double framedelaymaxtime = 0;
+    int    framedelayindex = 0;
+    double framedelaytimesum = 0;
+    double framedelaytimelist[MAXSAMPLES];
+
+    //Packet Loss Statistics
+    double packetlossrealtime = 0;
+    double packetlossavgtime = 0;
+    double packetlossmintime = 0;
+    double packetlossmaxtime = 0;
+    int    packetlossindex = 0;
+    double packetlosstimesum = 0;
+    double packetlosstimelist[MAXSAMPLES];
+
+    unsigned int frametimeindex = 0;
+    unsigned int frametimesamples = 0;
+    double frametimesum = 0;
+    double frametimelist[MAXSAMPLES];
+
+    uint16_t framewidth = 0;
+    uint16_t frameheight = 0;
+
+    void init() {
+        memset(frametimelist     , 0, sizeof(frametimelist)     );
+        memset(crentimelist      , 0, sizeof(crentimelist)      );
+        memset(srentimelist      , 0, sizeof(srentimelist)      );
+        memset(dectimelist       , 0, sizeof(dectimelist)       );
+        memset(enctimelist       , 0, sizeof(enctimelist)       );
+        memset(e2etimelist       , 0, sizeof(e2etimelist)       );
+        memset(framesizetimelist , 0, sizeof(framesizetimelist) );
+        memset(framedelaytimelist, 0, sizeof(framedelaytimelist));
+        memset(packetlosstimelist, 0, sizeof(packetlosstimelist));
+    }
+
+    void CalcFPS(double newFrameTime)
+    {
+        frametimesum -= frametimelist[frametimeindex];
+        frametimesum += newFrameTime;
+        frametimelist[frametimeindex] = newFrameTime;
+        if (++frametimeindex == std::size(frametimelist)) {
+            frametimeindex = 0;
+        }
+        if (frametimesamples < std::size(frametimelist)) {
+            frametimesamples++;
+        }
+
+        /* return fps */
+        if (frametimesum != 0) {
+            captureFps = (unsigned int)(frametimesamples / frametimesum);
+        }
+    }
+};
+
+class StatisticsWindowClass {
+public:
+    HWND hwnd_;
+
+    StatisticsWindowClass(HINSTANCE h_instance, int n_cmd_show);
+    void Destroy(void);
+    void DrawStatistics();
+    void setStreamingStatistics(StreamingStatistics* streamingStatistics) { _streamingStatistics  = streamingStatistics;};
+private:
+    StreamingStatistics* _streamingStatistics;
+    static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    WNDCLASSEX wc_;
+
+};
+
+namespace ImPlot {
+    void ShowImplotWindow(StreamingStatistics* streamingStatistics);
+}
+
+#endif // GA_STATISTICSWINDOWCLASS_H_

--- a/sources/apps/webrtc-client/video-renderer.cc
+++ b/sources/apps/webrtc-client/video-renderer.cc
@@ -1,0 +1,506 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "video-renderer.h"
+#include <processthreadsapi.h>
+#include "game-session.h"
+#include "ga-option.h"
+// clang-format on
+
+extern std::unique_ptr<GameSession> g_remote_connection;
+
+using std::chrono::duration_cast;
+using std::chrono::high_resolution_clock;
+using std::chrono::system_clock;
+using std::chrono::microseconds;
+using std::chrono::milliseconds;
+
+static const UINT kBufferCountWithTearing = 3;
+static const UINT kBufferCountWithoutTearing = 2;
+
+bool DXRenderer::DXGIIsTearingSupported() {
+    IDXGIFactory4* dxgi_factory4 = NULL;
+    UINT allow_tearing = 0;
+
+    HRESULT hr = CreateDXGIFactory1(__uuidof(IDXGIFactory4), reinterpret_cast<void**>(&dxgi_factory4));
+    if (SUCCEEDED(hr) && dxgi_factory4) {
+        IDXGIFactory5* dxgi_factory5 = NULL;
+        hr = dxgi_factory4->QueryInterface(__uuidof(IDXGIFactory5), (void**)&dxgi_factory5);
+        if (SUCCEEDED(hr) && dxgi_factory5) {
+            hr = dxgi_factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING,
+                &allow_tearing, sizeof(allow_tearing));
+        }
+    }
+    return SUCCEEDED(hr) && allow_tearing;
+}
+
+void DXRenderer::FillSwapChainDesc(DXGI_SWAP_CHAIN_DESC1 &scd) {
+    scd.Width = scd.Height = 0; // automatic sizing.
+    scd.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+    scd.Stereo = false;
+    scd.SampleDesc.Count = 1; // no multi-sampling
+    scd.SampleDesc.Quality = 0;
+    scd.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    scd.BufferCount = kBufferCountWithoutTearing;
+    scd.Scaling = DXGI_SCALING_STRETCH;
+    scd.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
+    scd.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+}
+
+void DXRenderer::RenderFrame(std::unique_ptr<owt::base::VideoBuffer> buffer) {
+
+    render_frame_number++;
+
+    HRESULT hr = S_FALSE;
+    uint16_t width = 0;
+    uint16_t height = 0;
+
+    ID3D11Device *render_device = nullptr;
+    ID3D11VideoDevice *render_video_device = nullptr;
+    ID3D11Texture2D *texture = nullptr;
+    ID3D11VideoContext *render_context = nullptr;
+    ID3D11Texture2D *current_back_buffer = nullptr;
+    int array_slice = -1;
+
+    auto render_begin = high_resolution_clock::now();
+    
+    uint64_t client_received_timestamp_ms = duration_cast<milliseconds>(render_begin.time_since_epoch()).count();
+    uint64_t decode_duration = 0;
+
+    rapidjson::Document side_data_document;
+    bool has_side_data = false;
+
+    FILE* renderLogFile = ga::log::OpenFile("ClientStatsLog", "txt");
+    if (renderLogFile == NULL) {
+        hr = S_FALSE;
+        prev_back_buffer = current_back_buffer;
+        prev_texture = texture;
+        return;
+    }
+
+    // initialize currentFrameStats
+    bool has_frame_stats = false;
+    if (currentFrameStats == nullptr) {
+        currentFrameStats = new FrameStats;
+    }
+    currentFrameStats->ts = 0;
+    currentFrameStats->start_delay = 0;
+    currentFrameStats->delay = 0;
+    currentFrameStats->size = 0;
+    currentFrameStats->p_loss = 0;
+
+    if (!wnd_ || !dxgi_factory_ || !IsWindow(wnd_)) {
+        hr = S_FALSE;
+    } else {
+        owt::base::D3D11VAHandle *handle =
+            reinterpret_cast<owt::base::D3D11VAHandle *>(buffer->buffer);
+
+        if (handle) {
+            hr = S_OK;
+            width = buffer->resolution.width;
+            height = buffer->resolution.height;
+
+            if (width == 0 || height == 0) {
+                hr = S_FALSE;
+            } else {
+                render_device = handle->d3d11_device;
+                render_video_device = handle->d3d11_video_device;
+                texture = handle->texture;
+                render_context = handle->context;
+                array_slice = handle->array_index;
+
+                // populate currentFrameStats
+                currentFrameStats->delay = (int) (handle->last_duration - handle->start_duration);
+                currentFrameStats->size = handle->frame_size;
+                currentFrameStats->p_loss = handle->packet_loss; // percent
+                // This stat must use system_clock since its used for calculating a statistic across systems.
+                // high_resolution_clock does not account for time zone differences and so reports erroneous values.
+                // Other stats which are purely local should still use high_resolution_clock.
+                currentFrameStats->latencymsg_ = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+                has_frame_stats = true;
+
+                //send currentFrameStats
+                g_remote_connection->SendFrameStats(currentFrameStats);
+
+                D3D11_TEXTURE2D_DESC texture_desc;
+                if (texture) {
+                    texture->GetDesc(&texture_desc);
+                }
+                if (render_device == nullptr || render_video_device == nullptr ||
+                    texture == nullptr || render_context == nullptr) {
+                    hr = S_FALSE;
+                } else {
+                    if (render_device != d3d11_device_ ||
+                        render_video_device != d3d11_video_device_ ||
+                        render_context != d3d11_video_context_) {
+                        d3d11_device_ = render_device;
+                        d3d11_video_device_ = render_video_device;
+                        d3d11_video_context_ = render_context;
+                        need_swapchain_recreate = true;
+                    }
+                }
+
+                // handle E2ELatency message
+                if (FLAGS_verbose) {
+                    ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Side Data Size: %lu\n", render_frame_number, handle->side_data_size);
+                }
+                if (handle->side_data_size > 0) {
+                    std::string message;
+                    // get message pointer
+                    message.append((char*)handle->side_data, handle->side_data_size);
+
+                    decode_duration = (handle->decode_end - handle->decode_start); // decode times are already in ms
+
+                    if (ga::json::ParseMessage(side_data_document, message)) {
+                        // Check if side data is corrupted. Ignore if this is the case.
+                        has_side_data = true;
+                    }
+                }
+                // end handling E2ELatency message
+            }
+        }
+    }
+
+    if (hr == S_OK && need_swapchain_recreate) {
+
+        if (swap_chain_for_hwnd_) {
+            swap_chain_for_hwnd_->Release();
+        }
+        DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {0};
+        FillSwapChainDesc(swap_chain_desc);
+
+        hr = dxgi_factory_->CreateSwapChainForHwnd(d3d11_device_, wnd_,
+                                                   &swap_chain_desc, nullptr,
+                                                   nullptr, &swap_chain_for_hwnd_);
+
+        if (SUCCEEDED(hr)) {
+            D3D11_VIDEO_PROCESSOR_CONTENT_DESC content_desc;
+            memset(&content_desc, 0, sizeof(content_desc));
+
+            // Non-scaling
+            content_desc.InputFrameFormat = D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE;
+            content_desc.InputFrameRate.Numerator = 1000;
+            content_desc.InputFrameRate.Denominator = 1;
+            content_desc.InputWidth    = width;
+            content_desc.InputHeight = height;
+            content_desc.OutputWidth = width_;
+            content_desc.OutputHeight = height_;
+            content_desc.OutputFrameRate.Numerator = 1000;
+            content_desc.OutputFrameRate.Denominator = 1;
+            content_desc.Usage = D3D11_VIDEO_USAGE_OPTIMAL_SPEED;
+            if (FLAGS_verbose) {
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server Resolution: %lu x %lu\n", render_frame_number, width, height);
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Resolution: %lu x %lu\n", render_frame_number, width_, height_);
+                double wscale = width_ / (double) width;
+                double hscale = height_ / (double) height;
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server to Client Scaling: %.3f x %.3f = %.3f\n", render_frame_number, wscale, hscale, wscale * hscale);
+            }
+
+            HRESULT hr = d3d11_video_device_->CreateVideoProcessorEnumerator(
+                             &content_desc, &video_processors_enum_);
+
+            if (SUCCEEDED(hr)) {
+                if (video_processor_) {
+                    video_processor_->Release();
+                }
+                hr = d3d11_video_device_->CreateVideoProcessor(video_processors_enum_,
+                                                               0, &video_processor_);
+
+                if (SUCCEEDED(hr)) {
+                    RECT render_rect = {x_offset_, y_offset_, x_offset_ + width_,
+                                        y_offset_ + height_};
+                    d3d11_video_context_->VideoProcessorSetOutputTargetRect(
+                        video_processor_, TRUE, &render_rect);
+                } else {
+                }
+            } else {
+            }
+        } else {
+        }
+
+        need_swapchain_recreate = false;
+    }
+
+    if (SUCCEEDED(hr)) {
+        hr = swap_chain_for_hwnd_->GetBuffer(0, __uuidof(ID3D11Texture2D),
+                                             (void **)&current_back_buffer);
+
+        if (SUCCEEDED(hr)) {
+            if (prev_back_buffer != current_back_buffer) {
+
+                // Create output view and input view
+                D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC output_view_desc;
+                memset(&output_view_desc, 0, sizeof(output_view_desc));
+
+                output_view_desc.ViewDimension = D3D11_VPOV_DIMENSION_TEXTURE2D;
+                output_view_desc.Texture2D.MipSlice = 0;
+
+                hr = d3d11_video_device_->CreateVideoProcessorOutputView(
+                    current_back_buffer, video_processors_enum_, &output_view_desc,
+                    &output_view_);
+
+                if (FAILED(hr)) {
+                }
+            }
+
+            if (SUCCEEDED(hr)) {
+                prev_array_slice_ = array_slice;
+                D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC input_view_desc;
+                memset(&input_view_desc, 0, sizeof(input_view_desc));
+                input_view_desc.FourCC = 0;
+                input_view_desc.ViewDimension = D3D11_VPIV_DIMENSION_TEXTURE2D;
+                input_view_desc.Texture2D.MipSlice = 0;
+                input_view_desc.Texture2D.ArraySlice = array_slice;
+
+                hr = d3d11_video_device_->CreateVideoProcessorInputView(
+                    texture, video_processors_enum_, &input_view_desc, &input_view_);
+
+                if (SUCCEEDED(hr)) {
+                    // Blit NV12 surface to RGB back buffer here.
+                    RECT rect = {0, 0, width_, height_};
+                    // Make sure we are using the cropped rectangle within input texture.
+                    RECT src_rect = { 0, 0, width, height };
+                    memset(&stream_, 0, sizeof(stream_));
+                    stream_.Enable = true;
+                    stream_.OutputIndex = 0;
+                    stream_.InputFrameOrField = 0;
+                    stream_.PastFrames = 0;
+                    stream_.ppPastSurfaces = nullptr;
+                    stream_.ppFutureSurfaces = nullptr;
+                    stream_.pInputSurface = input_view_;
+                    stream_.ppPastSurfacesRight = nullptr;
+                    stream_.ppFutureSurfacesRight = nullptr;
+                    stream_.pInputSurfaceRight = nullptr;
+
+                    d3d11_video_context_->VideoProcessorSetStreamSourceRect(video_processor_, 0, true, &src_rect);
+                    d3d11_video_context_->VideoProcessorSetStreamDestRect(
+                        video_processor_, 0, true, &rect);
+                    d3d11_video_context_->VideoProcessorSetStreamFrameFormat(
+                        video_processor_, 0, D3D11_VIDEO_FRAME_FORMAT_PROGRESSIVE);
+
+                    D3D11_VIDEO_PROCESSOR_COLOR_SPACE stream_color_space;
+                    memset(&stream_color_space, 0, sizeof(stream_color_space));
+                    stream_color_space.Usage = 0;        // Used for playback
+                    stream_color_space.RGB_Range = 1;    // RGB limited range
+                    stream_color_space.YCbCr_Matrix = 1; // BT.709
+                    stream_color_space.YCbCr_xvYCC = 0;  // Conventional YCbCr
+                    stream_color_space.Nominal_Range = D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_16_235;
+                    d3d11_video_context_->VideoProcessorSetStreamColorSpace(video_processor_, 0, &stream_color_space);
+
+                    D3D11_VIDEO_PROCESSOR_COLOR_SPACE output_color_space;
+                    memset(&output_color_space, 0, sizeof(output_color_space));
+                    output_color_space.Usage = 0;        // Used for playback
+                    output_color_space.RGB_Range = 0;    // RGB full range
+                    output_color_space.YCbCr_Matrix = 1; // BT.709
+                    output_color_space.YCbCr_xvYCC = 0;  // Conventional YCbCr
+                    output_color_space.Nominal_Range = D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_0_255;
+                    d3d11_video_context_->VideoProcessorSetOutputColorSpace(video_processor_, &output_color_space);
+                } else {
+                }
+            }
+        } else {
+        }
+    }
+
+    if (SUCCEEDED(hr)) {
+        hr = d3d11_video_context_->VideoProcessorBlt(video_processor_, output_view_,
+                                                     0, 1, &stream_);
+        if (FAILED(hr)) {
+        }
+    }
+
+    prev_back_buffer = current_back_buffer;
+    prev_texture = texture;
+
+    if (SUCCEEDED(hr)) {
+        DXGI_PRESENT_PARAMETERS parameters = {0};
+        hr = swap_chain_for_hwnd_->Present1(0, 0, &parameters);
+    }
+
+    //E2ELatency
+    auto render_end = high_resolution_clock::now();
+    auto client_render_time = duration_cast<milliseconds>(render_end - render_begin).count();
+
+    if (has_frame_stats && currentFrameStats) {
+        if (_streamingStatistics && render_frame_number > 1) {
+            _streamingStatistics->CalcStatistics((double)currentFrameStats->size,
+                &(_streamingStatistics->framesizerealtime), &(_streamingStatistics->framesizeavgtime),
+                &(_streamingStatistics->framesizemintime), &(_streamingStatistics->framesizemaxtime),
+                &(_streamingStatistics->framesizeindex), &(_streamingStatistics->framesizetimesum),
+                _streamingStatistics->framesizetimelist);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Size: Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->framesizerealtime,
+                _streamingStatistics->framesizeavgtime,
+                _streamingStatistics->framesizemintime,
+                _streamingStatistics->framesizemaxtime);
+            
+            _streamingStatistics->CalcStatistics((double)currentFrameStats->delay,
+                &(_streamingStatistics->framedelayrealtime), &(_streamingStatistics->framedelayavgtime),
+                &(_streamingStatistics->framedelaymintime), &(_streamingStatistics->framedelaymaxtime),
+                &(_streamingStatistics->framedelayindex), &(_streamingStatistics->framedelaytimesum),
+                _streamingStatistics->framedelaytimelist);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Delay: Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->framedelayrealtime,
+                _streamingStatistics->framedelayavgtime,
+                _streamingStatistics->framedelaymintime,
+                _streamingStatistics->framedelaymaxtime);
+            
+            _streamingStatistics->CalcStatistics((double)currentFrameStats->p_loss,
+                &(_streamingStatistics->packetlossrealtime), &(_streamingStatistics->packetlossavgtime),
+                &(_streamingStatistics->packetlossmintime), &(_streamingStatistics->packetlossmaxtime),
+                &(_streamingStatistics->packetlossindex), &(_streamingStatistics->packetlosstimesum),
+                _streamingStatistics->packetlosstimelist);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Loss (%%): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->packetlossrealtime,
+                _streamingStatistics->packetlossavgtime,
+                _streamingStatistics->packetlossmintime,
+                _streamingStatistics->packetlossmaxtime);
+        } else {
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Size: %ld\n", render_frame_number, currentFrameStats->size);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Delay: %d\n", render_frame_number, currentFrameStats->delay);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Frame Loss (%%): %ld\n", render_frame_number, currentFrameStats->p_loss);
+        }
+    }
+
+    if (has_side_data) {
+        uint64_t client_send_timestamp_ms = ga::json::FromUint64(side_data_document, "clientSendLatencyTime");
+        uint64_t server_received_timestamp_ms = ga::json::FromUint64(side_data_document, "serverReceivedLatencyTime");
+
+        uint64_t e2e_latency = (uint64_t)(server_received_timestamp_ms - client_send_timestamp_ms);
+        int client_decode_duration = (int)decode_duration;
+
+        if (client_send_timestamp_ms == 0 || server_received_timestamp_ms == 0) {
+            e2e_latency = 0;
+        } else {
+            if (FLAGS_verbose) {
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Input Timestamp (ms): %llu\n", render_frame_number, client_send_timestamp_ms);
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Received Timestamp (ms): %llu\n", render_frame_number, client_received_timestamp_ms);
+            }
+
+            if (_streamingStatistics && render_frame_number > 1) {
+                _streamingStatistics->CalcStatistics((double)e2e_latency,
+                &(_streamingStatistics->e2erealtime), &(_streamingStatistics->e2eavgtime),
+                &(_streamingStatistics->e2emintime), &(_streamingStatistics->e2emaxtime),
+                &(_streamingStatistics->e2eindex), &(_streamingStatistics->e2etimesum),
+                _streamingStatistics->e2etimelist);
+
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, E2E Latency (ms): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                    render_frame_number,
+                    _streamingStatistics->e2erealtime,
+                    _streamingStatistics->e2eavgtime,
+                    _streamingStatistics->e2emintime,
+                    _streamingStatistics->e2emaxtime);
+            } else {
+                ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, E2E Latency (ms): %llu\n", render_frame_number, e2e_latency);
+            }
+        }
+
+        if (_streamingStatistics) {
+            _streamingStatistics->framewidth = width;
+            _streamingStatistics->frameheight = height;
+        }
+        
+        if (_streamingStatistics && render_frame_number > 1) {
+            _streamingStatistics->CalcStatistics((double)client_decode_duration,
+                &(_streamingStatistics->decrealtime), &(_streamingStatistics->decavgtime),
+                &(_streamingStatistics->decmintime), &(_streamingStatistics->decmaxtime),
+                &(_streamingStatistics->decindex), &(_streamingStatistics->dectimesum),
+                _streamingStatistics->dectimelist);
+            _streamingStatistics->CalcStatistics((double)client_render_time,
+                &(_streamingStatistics->crenrealtime), &(_streamingStatistics->crenavgtime),
+                &(_streamingStatistics->crenmintime), &(_streamingStatistics->crenmaxtime),
+                &(_streamingStatistics->crenindex), &(_streamingStatistics->crentimesum),
+                _streamingStatistics->crentimelist);
+            uint64_t server_encode_duration = ga::json::FromUint64(side_data_document, "serverEncodeFrameTime");
+            _streamingStatistics->CalcStatistics((double)server_encode_duration,
+                &(_streamingStatistics->encrealtime), &(_streamingStatistics->encavgtime),
+                &(_streamingStatistics->encmintime), &(_streamingStatistics->encmaxtime),
+                &(_streamingStatistics->encindex), &(_streamingStatistics->enctimesum),
+                _streamingStatistics->enctimelist);
+            uint64_t server_render_time = ga::json::FromUint64(side_data_document, "serverRenderClientInputTime");
+            _streamingStatistics->CalcStatistics((double)server_render_time,
+                &(_streamingStatistics->srenrealtime), &(_streamingStatistics->srenavgtime),
+                &(_streamingStatistics->srenmintime), &(_streamingStatistics->srenmaxtime),
+                &(_streamingStatistics->srenindex), &(_streamingStatistics->srentimesum),
+                _streamingStatistics->srentimelist);
+
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Decode Duration (ms): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->decrealtime,
+                _streamingStatistics->decavgtime,
+                _streamingStatistics->decmintime,
+                _streamingStatistics->decmaxtime);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Render Duration (ms): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->crenrealtime,
+                _streamingStatistics->crenavgtime,
+                _streamingStatistics->crenmintime,
+                _streamingStatistics->crenmaxtime);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server Encode Duration (ms): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->encrealtime,
+                _streamingStatistics->encavgtime,
+                _streamingStatistics->encmintime,
+                _streamingStatistics->encmaxtime);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server Render Client Input Duration (ms): Real=%.3f, Avg=%.3f, Min=%.3f, Max=%.3f\n",
+                render_frame_number,
+                _streamingStatistics->srenrealtime,
+                _streamingStatistics->srenavgtime,
+                _streamingStatistics->srenmintime,
+                _streamingStatistics->srenmaxtime);
+        } else {
+            // We aren't tracking stats or verbosity is not enabled so just display current values.
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Decode Duration (ms): %d\n", render_frame_number, client_decode_duration);
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Render Duration (ms): %d\n", render_frame_number, client_render_time);
+            uint64_t server_encode_duration = ga::json::FromUint64(side_data_document, "serverEncodeFrameTime");
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server Encode Duration (ms): %d\n", render_frame_number, server_encode_duration);
+            uint64_t server_render_time = ga::json::FromUint64(side_data_document, "serverRenderClientInputTime");
+            ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Server Render Client Input Duration (ms): %d\n", render_frame_number, server_render_time);
+        }
+    } else if (FLAGS_verbose) {
+        ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, No message from Latency Client Instance: %d\n", render_frame_number);
+    }
+    
+    double frame_to_frame = (double)(duration_cast<milliseconds>(render_end - render_prev).count()) / 1000.0;
+    ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Frame Time (s): %.6f\n", render_frame_number, frame_to_frame);
+
+    if (_streamingStatistics && render_frame_number > 1) {
+        _streamingStatistics->CalcFPS(frame_to_frame);
+        ga::log::WriteToMsg(render_stats_log_msg, "Frame Number: %u, Client Capture FPS: %lu\n", render_frame_number, _streamingStatistics->captureFps);
+        _streamingStatistics->updated = true;
+    }
+
+    render_prev = render_end;
+
+    ga::log::FlushMsgToFile(renderLogFile, render_stats_log_msg);
+    ga::log::CloseFile(renderLogFile);
+
+    return;
+}
+
+void DXRenderer::Cleanup() {
+    if (swap_chain_for_hwnd_) {
+        swap_chain_for_hwnd_->Release();
+    }
+    if (currentFrameStats) {
+        delete currentFrameStats;
+    }
+}
+

--- a/sources/apps/webrtc-client/video-renderer.h
+++ b/sources/apps/webrtc-client/video-renderer.h
@@ -1,0 +1,95 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_DXRENDERER_H_
+#define GA_DXRENDERER_H_
+
+#include "owt/base/videorendererinterface.h"
+
+#include <chrono>
+#include <d3d11.h>
+#include <dxgi1_2.h>
+#include <dxgi1_4.h>
+#include <dxgi1_5.h>
+
+#include "control-handler.h"
+#include "statistics-window-class.h"
+
+// The video renderer implementation that accepts decoded video frame from WebRTC stack.
+// Operation process:
+//   1. Client subscribe the gaming stream add attach an instance of this renderer, passing the HWND
+// handle used for video rendering.
+//   2. On each decoded frame, WebRTC stack will pass decoded frame(ID3D11Texture2D instance. FourCC: NV12),
+// and the D3D11Device instance associated with that texture frame in the overrided RenderFrame() callback.
+//   3. Use D3D11VideoProcessor to do color space conversion from NV12 to ARGB, and render it.
+class DXRenderer : public owt::base::VideoRendererInterface {
+public:
+  DXRenderer() : wnd_(NULL) {
+    CreateDXGIFactory(__uuidof(IDXGIFactory2), (void **)(&dxgi_factory_));
+    dxgi_allow_tearing_ = DXGIIsTearingSupported();
+  }
+  void SetWindow(HWND handle) { wnd_ = handle; }
+  void setStreamingStatistics(StreamingStatistics* streamingStatistics) { _streamingStatistics = streamingStatistics; };
+  void RenderFrame(std::unique_ptr<owt::base::VideoBuffer> buffer);
+  owt::base::VideoRendererType Type() {
+    return owt::base::VideoRendererType::kD3D11;
+  }
+  void SetWindowSize(UINT x, UINT y, UINT w, UINT h) {
+    x_offset_ = x;
+    y_offset_ = y;
+    width_ = w;
+    height_ = h;
+    need_swapchain_recreate = true;
+  }
+  void Cleanup();
+
+private:
+  void FillSwapChainDesc(DXGI_SWAP_CHAIN_DESC1 &scd);
+  bool DXGIIsTearingSupported();
+
+  HWND wnd_ = nullptr;
+  uint16_t x_offset_ = 0;
+  uint16_t y_offset_ = 0;
+
+  uint16_t width_ = 0;
+  uint16_t height_ = 0;
+  bool need_swapchain_recreate = true;
+  bool dxgi_allow_tearing_ = false;
+  StreamingStatistics* _streamingStatistics = nullptr;
+
+  UINT render_frame_number = 0;
+  std::string render_stats_log_msg = "";
+
+  // Owner of the d3d11 device/context is decoder.
+  ID3D11Device *d3d11_device_ = nullptr;
+  ID3D11VideoDevice *d3d11_video_device_ = nullptr;
+  ID3D11VideoContext *d3d11_video_context_ = nullptr;
+  IDXGIFactory2 *dxgi_factory_ = nullptr;
+  ID3D11VideoProcessorEnumerator *video_processors_enum_ = nullptr;
+  ID3D11VideoProcessor *video_processor_ = nullptr;
+  ID3D11VideoProcessorInputView *input_view_ = nullptr;
+  ID3D11VideoProcessorOutputView *output_view_ = nullptr;
+  IDXGISwapChain1 *swap_chain_for_hwnd_ = nullptr;
+  D3D11_VIDEO_PROCESSOR_STREAM stream_;
+  ID3D11Texture2D *prev_back_buffer = nullptr;
+  ID3D11Texture2D *prev_texture = nullptr;
+  int prev_array_slice_ = -1;
+  std::chrono::high_resolution_clock::time_point last_present_ts_;
+  std::chrono::high_resolution_clock::time_point render_prev;
+  FrameStats* currentFrameStats = nullptr;
+};
+
+#endif // GA_DXRENDERER_H_

--- a/sources/apps/webrtc-client/webrtc-client.cc
+++ b/sources/apps/webrtc-client/webrtc-client.cc
@@ -1,0 +1,151 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <iostream>
+#include <windows.h>
+#include <stdint.h>
+#include "window-handler.h"
+#include "ga-option.h"
+#include <map>
+#include "statistics-window-class.h"
+
+std::string FLAGS_peer_server_url = "";
+std::string FLAGS_sessionid = "ga";
+std::string FLAGS_clientid = "client";
+bool FLAGS_show_statistics = false;
+bool FLAGS_logging = false;
+bool FLAGS_streamdump = false;
+bool FLAGS_verbose = false;
+std::string FLAGS_stunsvr = "stun:stun.l.google.com:19302";
+
+void Usage(std::string cmd)
+{
+  MessageBox(
+    NULL,
+    L"See client section in WCG README for full list of options",
+    L"Usage",
+    MB_OK
+  );
+}
+
+void ParseCommandLineFlags(int argc, char** argv)
+{
+  for (int idx = 1; idx < argc; ++idx) {
+    if (std::string("-h") == argv[idx] ||
+      std::string("--help") == argv[idx]) {
+      Usage(argv[0]);
+      exit(0);
+    } else if (std::string("--peer_server_url") == argv[idx]) {
+      if (++idx >= argc) break;
+      FLAGS_peer_server_url = argv[idx];
+    } else if (std::string("--sessionid") == argv[idx]) {
+      if (++idx >= argc) break;
+      FLAGS_sessionid = argv[idx];
+    } else if (std::string("--clientid") == argv[idx]) {
+      if (++idx >= argc) break;
+      FLAGS_clientid = argv[idx];
+    } else if (std::string("--show_statistics") == argv[idx]) {
+      FLAGS_show_statistics = true;
+    } else if (std::string("--logging") == argv[idx]) {
+      FLAGS_logging = true;
+    } else if (std::string("--streamdump") == argv[idx]) {
+      FLAGS_streamdump = true;
+    } else if (std::string("--verbose") == argv[idx]) {
+      FLAGS_verbose = true;
+    } else if (std::string("--stunsvr") == argv[idx]) {
+      if (++idx >= argc) break;
+      FLAGS_stunsvr = argv[idx];
+    } else {
+      break;
+    }
+  }
+}
+
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+  LPSTR lpCmdLine, int nCmdShow) {
+  MSG Msg;
+  ga::remote::SessionMetaData session_info;
+  ga::remote::ClientSettings client_settings;
+  WindowHandler *window_handler = nullptr;
+  bool is_done = false;
+  std::unique_ptr<StatisticsWindowClass> swc_ = nullptr;
+  StreamingStatistics streamingStatistics;
+
+  ParseCommandLineFlags(__argc, __argv);
+  if (FLAGS_show_statistics) {
+    FLAGS_verbose = true;
+  }
+  session_info.peer_server_url_ = FLAGS_peer_server_url;
+  session_info.session_id_ = FLAGS_sessionid;
+  session_info.client_id_ = FLAGS_clientid;
+
+  client_settings.mousestate_callback_ = WindowHandler::OnMouseStateChange;
+  client_settings.connection_callback_ = WindowHandler::OnGameServerConnected;
+
+  if ((window_handler = WindowHandler::GetInstance()) == nullptr) {
+    goto Done;
+  }
+
+  if (window_handler->InitializeGameWindow(hInstance, nCmdShow,"GaWebRTCClient") != 0) {
+    goto Done;
+  }
+
+  client_settings.hwnd_ = window_handler->GetWindowHandle();
+  if (FLAGS_show_statistics) {
+    swc_.reset(new StatisticsWindowClass(hInstance, nCmdShow));
+    streamingStatistics.init();
+    swc_->setStreamingStatistics(&streamingStatistics);
+    ga::remote::StartGame(session_info, client_settings, &streamingStatistics);
+  } else if (FLAGS_verbose) {
+    streamingStatistics.init();
+    ga::remote::StartGame(session_info, client_settings, &streamingStatistics);
+  } else {
+    ga::remote::StartGame(session_info, client_settings, nullptr);
+  }
+
+  /*while (GetMessage(&Msg, NULL, 0, 0) > 0) {
+    TranslateMessage(&Msg);
+    DispatchMessage(&Msg);
+  }*/
+  while (!is_done) {
+    if (PeekMessage(&Msg, NULL, 0, 0, PM_REMOVE) > 0)
+    {
+        TranslateMessage(&Msg);
+        DispatchMessage(&Msg);
+    }
+
+    if (WM_QUIT == Msg.message) {
+        is_done = true;
+    }
+
+    if (FLAGS_show_statistics && swc_ && streamingStatistics.updated) {
+        streamingStatistics.updated = false;
+        swc_->DrawStatistics();
+    }
+  }
+
+Done:
+  if (window_handler) {
+    window_handler->Destroy();
+  }
+
+  if (FLAGS_show_statistics && swc_) {
+      swc_->Destroy();
+      swc_ = NULL;
+  }
+
+  return Msg.wParam;
+}

--- a/sources/apps/webrtc-client/window-class.cc
+++ b/sources/apps/webrtc-client/window-class.cc
@@ -1,0 +1,319 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "window-class.h"
+#include "ga-option.h"
+#include "Shellscalingapi.h"
+// clang format on
+
+#pragma comment(lib, "Shcore.lib")
+
+#define WM_MOUSE_MOVE_SHIFT_H 16
+
+float screen_scale_factor_ = 1.0f;
+
+void WindowClass::Destroy(void) {
+  if (this->hwnd_) {
+    DestroyWindow(this->hwnd_);
+  }
+  delete this;
+}
+
+WindowClass::WindowClass(HINSTANCE h_instance, int n_cmd_show, const char* window_title) {
+  LONG l_ex_window_style;
+  RECT client_rect;
+  int width_delta = 0; 
+  int height_delta = 0;
+
+  wc_.cbSize = sizeof(WNDCLASSEX);
+  wc_.style = 0;
+  wc_.lpfnWndProc = WindowClass::PreInitWndProc;
+  wc_.cbClsExtra = 0;
+  wc_.cbWndExtra = 0;
+  wc_.hInstance = h_instance;
+  wc_.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+  wc_.hCursor = LoadCursor(NULL, IDC_ARROW);
+  wc_.hbrBackground = (HBRUSH)(CTLCOLOR_EDIT + 1);
+  wc_.lpszMenuName = NULL;
+  wc_.lpszClassName = L"GaWebRTCClient";
+  wc_.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
+
+  if (!RegisterClassEx(&wc_)) {
+    MessageBox(NULL, L"Window Registration Failed!", L"Error!",
+               MB_ICONEXCLAMATION | MB_OK);
+  }
+
+  initial_window_height_ = GetSystemMetrics(SM_CYSCREEN);
+  initial_window_width_ = GetSystemMetrics(SM_CXSCREEN);
+  client_window_height_ = initial_window_height_;
+  client_window_width_ = initial_window_width_;
+  scale_ratio_w_ = 1.0;
+  scale_ratio_h_ = 1.0;
+
+  hwnd_ = CreateWindowEx(WS_EX_APPWINDOW,
+                          L"GaWebRTCClient", L"GameWindow",
+                          WS_POPUP,
+                          CW_USEDEFAULT, CW_USEDEFAULT, client_window_width_, client_window_height_, NULL,
+                          NULL, h_instance, this);
+  
+  if (hwnd_ == NULL) {
+      MessageBox(NULL, L"CreateWindowEx Failed!", L"Error!",
+          MB_ICONEXCLAMATION | MB_OK);
+      exit(-1);
+  }
+
+  l_ex_window_style = GetWindowLong(hwnd_, GWL_EXSTYLE);
+  l_ex_window_style &= ~(WS_EX_DLGMODALFRAME | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE);
+  SetWindowLong(hwnd_, GWL_EXSTYLE, l_ex_window_style);
+
+  GetWindowRect(hwnd_, &window_rect_);
+  GetClientRect(hwnd_, &client_rect);
+
+  if ((client_rect.right - client_rect.left) != initial_window_width_) {
+    width_delta = initial_window_width_ - (client_rect.right - client_rect.left);
+  }
+  if ((client_rect.bottom - client_rect.top) != initial_window_height_) {
+    height_delta = initial_window_height_ - (client_rect.bottom - client_rect.top);
+  }
+
+  window_rect_.right += width_delta-2* GetSystemMetrics(SM_CXEDGE);
+  window_rect_.bottom += height_delta-2* GetSystemMetrics(SM_CYEDGE);
+
+  SetWindowPos(hwnd_, 0, window_rect_.left, window_rect_.top,
+               GetSystemMetrics(SM_CXSCREEN),
+               GetSystemMetrics(SM_CYSCREEN),
+               SWP_NOZORDER | SWP_NOACTIVATE);
+
+  GetClientRect(hwnd_, &client_rect);
+  GetWindowRect(hwnd_, &window_rect_);
+
+  ShowWindow(hwnd_, n_cmd_show);
+  UpdateWindow(hwnd_);
+  game_mode_toggle_ = true;
+  full_screen_toggle_ = false;
+  in_sys_key_down_ = false;
+
+  HMONITOR monitor = MonitorFromWindow(hwnd_, MONITOR_DEFAULTTONEAREST);
+  if (monitor != NULL) {
+      MONITORINFOEX miex;
+      miex.cbSize = sizeof(miex);
+      GetMonitorInfo(monitor, &miex);
+      int cxLogical = (miex.rcMonitor.right - miex.rcMonitor.left);
+      int cyLogical = (miex.rcMonitor.bottom - miex.rcMonitor.top);
+
+      // Get the physical width and height of the monitor.
+      DEVMODE dm;
+      dm.dmSize = sizeof(dm);
+      dm.dmDriverExtra = 0;
+      EnumDisplaySettings(miex.szDevice, ENUM_CURRENT_SETTINGS, &dm);
+      int cxPhysical = dm.dmPelsWidth;
+      int cyPhysical = dm.dmPelsHeight;
+
+      // Calculate the scaling factor.
+      double horzScale = ((double)cxPhysical / (double)cxLogical);
+      double vertScale = ((double)cyPhysical / (double)cyLogical);
+
+      screen_scale_factor_ = horzScale;
+  }
+
+  this->RegisterRawInput(hwnd_);
+}
+
+LRESULT CALLBACK WindowClass::PreInitWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param){
+    LRESULT ret_val;
+  if( msg == WM_NCCREATE ) {
+    CREATESTRUCTW* p_create_struct = reinterpret_cast<CREATESTRUCTW*>(l_param);
+    WindowClass* const p_window_class = static_cast<WindowClass*>(p_create_struct->lpCreateParams);
+    SetWindowLongPtr( h_wnd,GWLP_WNDPROC,reinterpret_cast<LONG_PTR>(&WindowClass::PostInitWndProc) );
+    SetWindowLongPtr( h_wnd,GWLP_USERDATA,reinterpret_cast<LONG_PTR>(p_window_class) );
+    ret_val = p_window_class->InternalWndProc( h_wnd,msg,w_param,l_param );
+  } else {
+    ret_val = DefWindowProc( h_wnd,msg,w_param,l_param);
+  }
+  return ret_val;
+}
+
+LRESULT CALLBACK WindowClass::PostInitWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param) {
+  WindowClass* const p_window_class = reinterpret_cast<WindowClass*>(GetWindowLongPtr(h_wnd,GWLP_USERDATA));
+  return p_window_class->InternalWndProc(h_wnd,msg,w_param,l_param);
+}
+
+LRESULT CALLBACK WindowClass::InternalWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param) {
+  LPARAM mouse_x;
+  LPARAM mouse_y;
+  LPARAM scaled_lparam;
+  LRESULT result = 0;
+
+  switch (msg) {
+  case WM_MOUSEMOVE:
+  case WM_LBUTTONUP:
+  case WM_LBUTTONDOWN:
+  case WM_MBUTTONUP:
+  case WM_MBUTTONDOWN:
+  case WM_RBUTTONUP:
+  case WM_RBUTTONDOWN:
+    mouse_x = (float)GET_X_LPARAM(l_param);
+    mouse_x -= x_render_offset_;
+
+    mouse_y = (float)GET_Y_LPARAM(l_param);
+    mouse_y -= y_render_offset_;
+    scaled_lparam = (LPARAM)(ceil(this->scale_ratio_h_ * mouse_y));
+    scaled_lparam <<= WM_MOUSE_MOVE_SHIFT_H;
+    scaled_lparam = scaled_lparam | (LPARAM)(ceil(this->scale_ratio_w_ * mouse_x));
+
+
+    ga::remote::SendInput(msg, w_param, scaled_lparam);
+    break;
+  case WM_KEYDOWN:
+  case WM_KEYUP:
+  case WM_INPUT:
+    ga::remote::SendInput(msg, w_param, l_param);
+    break;
+  case WM_SYSKEYDOWN:
+    if ((w_param == VK_UP) && (HIWORD(l_param) & KF_ALTDOWN) &&
+        !this->in_sys_key_down_) {
+      this->in_sys_key_down_ = true;
+      if (this->full_screen_toggle_) {
+        this->ChangeWindowedMode(h_wnd, false);
+        this->full_screen_toggle_ = false;
+        this->ChangeGameMode(NULL, false);
+      } else {
+        this->ChangeWindowedMode(h_wnd,true);
+        this->full_screen_toggle_ = true;
+        this->ChangeGameMode(NULL, false);
+        this->ChangeGameMode(h_wnd, true);
+      }
+    }
+    else if ((w_param == VK_OEM_PLUS) && (HIWORD(l_param) & KF_ALTDOWN) && !this->in_sys_key_down_) {
+      this->in_sys_key_down_ = true;
+      if (this->game_mode_toggle_) {
+        this->ChangeGameMode(h_wnd, true);
+        this->game_mode_toggle_ = false;
+      }
+      else{
+       this->ChangeGameMode(NULL, false);
+       this->game_mode_toggle_ = true;
+      }
+    }
+    break;
+  
+  case WM_SYSKEYUP:
+    this->in_sys_key_down_ = false;
+    break;
+  case WM_CLOSE:
+    this->Destroy();
+    break;
+  case WM_DESTROY:
+    PostQuitMessage(0);
+    break;
+  case WM_GA_CURSOR_VISIBLE:
+    int disp_count;
+    if (l_param == GA_SHOW_CURSOR) {
+      disp_count = ShowCursor(TRUE);
+      while (disp_count <= 0) {
+        disp_count = ShowCursor(TRUE);
+      }
+      this->ChangeGameMode(h_wnd, false);
+    ga::remote::ChangeCursorReportMode(false);
+    }
+    else {
+      disp_count = ShowCursor(FALSE);
+      while (disp_count >= 0) {
+        disp_count = ShowCursor(FALSE);
+      }
+      if (!this->game_mode_toggle_) {
+        this->ChangeGameMode(h_wnd, true);
+      }
+    ga::remote::ChangeCursorReportMode(true);
+    }
+  default:
+    result = DefWindowProc(h_wnd, msg, w_param, l_param);
+  }
+  return result;
+}
+
+void WindowClass::ChangeWindowedMode(HWND hwnd, bool enable_fullscreen) {
+  if (enable_fullscreen) {
+    GetWindowRect(hwnd, &this->window_rect_);
+
+    UINT w = GetSystemMetrics(SM_CXSCREEN);
+    UINT h = GetSystemMetrics(SM_CYSCREEN);
+    SetWindowLongPtr(hwnd, GWL_STYLE, WS_VISIBLE | WS_POPUP);
+    SetWindowPos(hwnd, HWND_TOP, 0, 0, w, h, SWP_FRAMECHANGED);
+    RECT rect;
+    GetClientRect(hwnd, &rect);
+    this->client_window_width_ = rect.right - rect.left;
+    this->client_window_height_ = rect.bottom - rect.top;
+  }
+  else{
+    UINT w;
+    UINT h;
+
+    this->client_window_width_ = this->initial_window_width_;
+    this->client_window_height_ = this->initial_window_height_;
+    SetWindowLongPtr(hwnd, GWL_STYLE, WS_VISIBLE | WS_OVERLAPPEDWINDOW & ~(WS_SIZEBOX | WS_MAXIMIZEBOX));
+    w = this->window_rect_.right - this->window_rect_.left;
+    h = this->window_rect_.bottom - this->window_rect_.top;
+    SetWindowPos(hwnd, NULL, this->window_rect_.left, this->window_rect_.top, w, h,
+                     SWP_FRAMECHANGED);
+  }
+  int new_height = (this->client_window_width_ * this->initial_window_height_) / this->initial_window_width_;
+
+  this->scale_ratio_w_ = (float)(this->initial_window_width_) / (float)(this->client_window_width_);
+  this->scale_ratio_h_ = (float)(this->initial_window_height_) / (float)(new_height);
+  x_render_offset_ = 0;
+  y_render_offset_ = (this->client_window_height_ - new_height)/2;
+  ga::remote::SetWindowSize(x_render_offset_, y_render_offset_, this->client_window_width_, new_height);
+}
+
+void WindowClass::ChangeGameMode(HWND hwnd, bool enable) {
+  RECT window_rect;
+  if (enable) { // true = releative mode.
+    GetWindowRect(hwnd, &window_rect);
+    ClipCursor(&window_rect);
+    SetCapture(hwnd);
+  }
+  else{
+    ClipCursor(NULL);
+    ReleaseCapture();
+  }
+}
+
+void WindowClass::RegisterRawInput(HWND hwnd) {
+  RAWINPUTDEVICE Rid[1] = {0};
+
+  Rid[0].usUsagePage = 0x01;
+  Rid[0].usUsage = 0x02;
+  Rid[0].dwFlags = 0;
+  Rid[0].hwndTarget = hwnd;
+
+  if (RegisterRawInputDevices(Rid, 1, sizeof(Rid[0])) == FALSE) {
+  }
+}
+
+void WindowClass::UnregisterRawInput(void) {
+  RAWINPUTDEVICE Rid[1] = {0};
+
+  Rid[0].usUsagePage = 0x01;
+  Rid[0].usUsage = 0x02;
+  Rid[0].dwFlags = RIDEV_REMOVE;
+  Rid[0].hwndTarget = NULL;
+
+  if (RegisterRawInputDevices(Rid, 1, sizeof(Rid[0])) == FALSE) {
+  }
+}
+

--- a/sources/apps/webrtc-client/window-class.h
+++ b/sources/apps/webrtc-client/window-class.h
@@ -1,0 +1,58 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_WINDOWCLASS_H_
+#define GA_WINDOWCLASS_H_
+
+#include <Windows.h>
+#include <Windowsx.h>
+#include <string>
+
+#define WM_GA_CURSOR_VISIBLE (WM_USER + 1)
+#define GA_HIDE_CURSOR 0
+#define GA_SHOW_CURSOR 1
+
+class WindowClass {
+public:
+  HWND hwnd_;
+  UINT client_window_width_;
+  UINT client_window_height_;
+
+  WindowClass(HINSTANCE h_instance, int n_cmd_show, const char *window_title);
+  void Destroy(void);
+private:
+  static LRESULT CALLBACK PreInitWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param);
+  static LRESULT CALLBACK PostInitWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param);
+  LRESULT CALLBACK InternalWndProc(HWND h_wnd, UINT msg, WPARAM w_param, LPARAM l_param);
+  void RegisterRawInput(HWND hwnd);
+  void UnregisterRawInput(void);
+  void ChangeGameMode(HWND hwnd, bool enable);
+  void ChangeWindowedMode(HWND hwnd, bool enable_fullscreen);
+  WNDCLASSEX wc_;
+  float scale_ratio_w_;
+  float scale_ratio_h_;
+  bool full_screen_toggle_;
+  bool game_mode_toggle_;
+  bool in_sys_key_down_;
+  UINT initial_window_width_;
+  UINT initial_window_height_;
+  RECT window_rect_;
+  UINT x_render_offset_ = 0;
+  UINT y_render_offset_ = 0;
+
+};
+#endif // GA_WINDOWCLASS_H_
+

--- a/sources/apps/webrtc-client/window-handler.cc
+++ b/sources/apps/webrtc-client/window-handler.cc
@@ -1,0 +1,86 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+#include "ga-option.h"
+#include "window-class.h"
+#include "control-handler.h"
+#include "window-handler.h"
+// clang-format on
+
+WindowHandler *WindowHandler::window_handler_ = nullptr;
+
+WindowHandler *WindowHandler::GetInstance(void) {
+  if (!window_handler_) {
+    window_handler_ = new WindowHandler();
+  }
+  return window_handler_;
+}
+
+void WindowHandler::OnMouseStateChange(struct ga::remote::CursorInfo &cursorInfo) {
+  HWND hwnd;
+
+  hwnd = WindowHandler::GetInstance()->wc_->hwnd_;
+  if (!cursorInfo.isVisible) {
+    SendMessage(hwnd, WM_GA_CURSOR_VISIBLE, 0, GA_HIDE_CURSOR);
+  } else {
+    SendMessage(hwnd, WM_GA_CURSOR_VISIBLE, 0, GA_SHOW_CURSOR);
+  }
+}
+
+int WindowHandler::OnGameServerConnected(std::string &session_id) {
+  if (!session_id.empty()) {
+    WindowHandler* window_handler = WindowHandler::GetInstance();
+    window_handler->session_id_ = session_id;
+    window_handler->connected_ = true;
+  }
+  return 0;
+}
+
+int WindowHandler::InitializeGameWindow(HINSTANCE h_instance, int n_cmd_show,
+                                       const char *window_title) {
+  int ret_value = 0;
+  wc_.reset(
+      new WindowClass(h_instance, n_cmd_show, window_title));
+  return ret_value;
+}
+
+HWND WindowHandler::GetWindowHandle(void) {
+  HWND h_wnd = nullptr;
+  if (wc_) {
+    h_wnd = wc_->hwnd_;
+  }
+  return h_wnd;
+}
+
+void WindowHandler::GetWindowSize(int& width, int& height) {
+  width = wc_->client_window_width_;
+  height = wc_->client_window_height_;
+}
+
+void WindowHandler::Destroy(void) {
+  if (!session_id_.empty()) {
+    ga::remote::ExitGame(session_id_);
+  }
+  if (wc_) {
+    wc_->Destroy();
+  }
+  if (window_handler_) {
+    delete window_handler_;
+    window_handler_ = nullptr;
+  }
+}
+

--- a/sources/apps/webrtc-client/window-handler.h
+++ b/sources/apps/webrtc-client/window-handler.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2020-2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef GA_WINDOW_HANDLER_H_
+#define GA_WINDOW_HANDLER_H_
+
+// clang-format off
+#include <string>
+#include <thread>
+#include <windows.h>
+#include "window-class.h"
+#include "ga-option.h"
+// clang-format on
+
+class WindowHandler {
+public:
+  static void OnMouseStateChange(struct ga::remote::CursorInfo &cursorInfo);
+  static int OnGameServerConnected(std::string &session_id);
+  static WindowHandler *GetInstance(void);
+  void GetWindowSize(int& width, int& height);
+  int InitializeGameWindow(HINSTANCE h_instance, int n_cmd_show, const char *window_title);
+  HWND GetWindowHandle();
+  void Destroy();
+private:
+  static WindowHandler* window_handler_;
+  bool connected_;
+  std::unique_ptr<WindowClass> wc_;
+  std::string session_id_;
+
+  WindowHandler() {}
+  ~WindowHandler() {}
+};
+
+#endif // GA_WINDOW_HANDLER_H_
+

--- a/subprojects/imgui.wrap
+++ b/subprojects/imgui.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = imgui-1.89.9
+source_url = https://github.com/ocornut/imgui/archive/refs/tags/v1.89.9.tar.gz
+source_filename = imgui-1.89.9.tar.gz
+source_hash = 1acc27a778b71d859878121a3f7b287cd81c29d720893d2b2bf74455bf9d52d6
+patch_filename = imgui_1.89.9-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/imgui_1.89.9-1/get_patch
+patch_hash = 9b21290c597d76bf8d4eeb3f9ffa024b11d9ea6c61e91d648ccc90b42843d584
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/imgui_1.89.9-1/imgui-1.89.9.tar.gz
+wrapdb_version = 1.89.9-1
+
+[provide]
+imgui = imgui_dep

--- a/subprojects/implot.wrap
+++ b/subprojects/implot.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = implot-0.16
+source_url = https://github.com/epezent/implot/archive/refs/tags/v0.16.zip
+source_filename = implot-0.16.zip
+source_hash = 24f772c688f6b8a6e19d7efc10e4923a04a915f13d487b08b83553aa62ae1708
+patch_filename = implot_0.16-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/implot_0.16-1/get_patch
+patch_hash = 1c6b1462066a5452fa50c1da1dd47fed841f28232972c82d778f2962936568c7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/implot_0.16-1/implot-0.16.zip
+wrapdb_version = 0.16-1
+
+[provide]
+implot = implot_dep

--- a/subprojects/sdl2.wrap
+++ b/subprojects/sdl2.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = SDL2-2.26.5
+source_url = https://github.com/libsdl-org/SDL/releases/download/release-2.26.5/SDL2-2.26.5.tar.gz
+source_filename = SDL2-2.26.5.tar.gz
+source_hash = ad8fea3da1be64c83c45b1d363a6b4ba8fd60f5bde3b23ec73855709ec5eabf7
+patch_filename = sdl2_2.26.5-5_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sdl2_2.26.5-5/get_patch
+patch_hash = 4d8d3ae534c326f27b2d97616fdfa7cce41bd0333c7d9683dd8ae39d4ad70e6a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sdl2_2.26.5-5/SDL2-2.26.5.tar.gz
+wrapdb_version = 2.26.5-5
+
+[provide]
+sdl2 = sdl2_dep
+sdl2main = sdl2main_dep
+sdl2_test = sdl2_test_dep


### PR DESCRIPTION
This commit adds Windows webrtc (owt) client application. It requires a set of dependencies to be built first (in earlier commit we've provided docker containers showing how to build them):

* ffmpeg w/ enabled DX11 decoders
* openssl
* owt (client build configuration)

Once dependencies are built, configure client as follows:
```
  meson setup _build --vsenv \
    --wrap-mode=forcefallback
    -Dprebuilt-path=/path/to/prebuilt/components \
    -Dstreamer=disabled
```
Note that --wrap-mode=forcefallback is required to fetch dependencies defined on meson level. -Dstreamer=disabled is a current limitation for the project build on Windows (streaming component is not yet upstreamed).

This client can be used as a sample Windows client for Android CG. It supports H.264, H265 and AV1 streaming.