### PR TITLE
server: fix mangled json messages

### DIFF
--- a/sources/streamer/module/server-webrtc/aic-vhal-client/CameraClientHandler.h
+++ b/sources/streamer/module/server-webrtc/aic-vhal-client/CameraClientHandler.h
@@ -35,7 +35,7 @@ public:
   std::string startPreviewStreamMsg =
     "{ \"key\" : \"start-camera-preview\", \
        \"cameraRes\" : \"0\", \
-       \"cameraId\" : \"0\" \" \
+       \"cameraId\" : \"0\" \
      }";
   static const std::string stopPreviewStreamMsg;
 

--- a/sources/streamer/module/server-webrtc/aic-vhal-client/SensorHandler.cpp
+++ b/sources/streamer/module/server-webrtc/aic-vhal-client/SensorHandler.cpp
@@ -31,9 +31,9 @@ using json = nlohmann::json;
 
 // Proto-type for command to be send to client app
 std::string SensorHandler::sensorStartMsg =
-    "{ \"key\" : \"sensor-start\" , \"type\" : \"0\" \"}";
+    "{ \"key\" : \"sensor-start\" , \"type\" : \"0\"}";
 std::string SensorHandler::sensorStopMsg =
-    "{ \"key\" : \"sensor-stop\" , \"type\" : \"0\" \"}";
+    "{ \"key\" : \"sensor-stop\" , \"type\" : \"0\"}";
 
 SensorHandler::SensorHandler(int instanceId, CommandHandler cmdHandler)
 {

--- a/sources/streamer/module/server-webrtc/ics-p2p-client.cpp
+++ b/sources/streamer/module/server-webrtc/ics-p2p-client.cpp
@@ -190,7 +190,7 @@ void ICSP2PClient::RegisterCallbacks() {
     if (type == vhal::client::MsgType::kActivityMonitor) {
       msg_json = "{\"key\":\"activity-switch\",\"val\":\"" + msg + "\"}";
     } else if (type == vhal::client::MsgType::kAicCommand) {
-      msg_json = "{\"key\":\"cmd-output\",\"val\":" + msg + "}";
+      msg_json = "{\"key\":\"cmd-output\",\"val\":\"" + msg + "\"}";
     }
     p2pclient_->Send(remote_user_id_, msg_json.c_str(),
                      nullptr, nullptr);


### PR DESCRIPTION
This was noted testing recently upstreamed windows webrtc (owt) client. Client might throw assertions parsing some json messages sent by the server. This commit fixes malformed json messages.