### PR TITLE
drivers/idd: switch to EDID-less monitors

### DIFF
--- a/sources/drivers/idd/Driver.cpp
+++ b/sources/drivers/idd/Driver.cpp
@@ -35,85 +35,59 @@ const GUID GUID_DEVINTERFACE_IDD_DEVICE = \
 static constexpr DWORD IDD_SAMPLE_MONITOR_COUNT = 2;
 
 ULONG MonitorNumberRegistryValue = 0; // Will be used to get the number of monitors
-ULONG MonitorTypeRegistryValue   = 0; // Will be used to get the type of monitor 1080p,1440p,2160p
 ULONG MonitorCursorRegistryValue = 0; // Will be used to set software or hardware cursor.
 ULONG AdapterLUIDLowPart         = 0; // Will be used to set the preferred render adapter.
 WDFDEVICE g_Device               = nullptr;
 
-// Default modes reported for edid-less monitors. The first mode is set as preferred
-static const struct IndirectSampleMonitor::SampleMonitorMode s_SampleDefaultModes[] =
-{
-    { 1920, 1080, 60 },
-    { 1600,  900, 60 },
-    { 1024,  768, 75 },
+struct MonitorMode {
+    DWORD width;
+    DWORD height;
+    DWORD vsync;
 };
 
-// FOR SAMPLE PURPOSES ONLY, Static info about monitors that will be reported to OS
-static const struct IndirectSampleMonitor s_SampleMonitors[] =
+// List of modes supported by this driver. Note that since there is no physical
+// monitor attached we don't need EDID, so driver works in EDID-less mode.
+static const MonitorMode g_modes[] =
 {
-    // 1080p EDID
-    {
-        {
-            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0x03,0x42,0x01,0x01,0x01,0x01,
-            0x01,0x18,0x01,0x03,0x80,0x7A,0x44,0x78,0x0A,0x0D,0xC9,0xA0,0x57,0x47,0x98,0x27,
-            0x12,0x48,0x4C,0x21,0x08,0x00,0x81,0x80,0xA9,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,
-            0x01,0x01,0x01,0x01,0x01,0x01,0x02,0x3A,0x80,0x18,0x71,0x38,0x2D,0x40,0x58,0x2C,
-            0x45,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x01,0x1D,0x00,0x72,0x51,0xD0,0x1E,0x20,
-            0x6E,0x28,0x55,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x00,0x00,0x00,0xFC,0x00,0x31,
-            0x30,0x38,0x30,0x70,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x00,0x00,0x00,0xFD,
-            0x00,0x30,0x3E,0x0E,0x46,0x0F,0x00,0x0A,0x20,0x20,0x20,0x20,0x20,0x20,0x00,0x36
-        },
-        // SampleMonitorMode
-        {
-            { 1920, 1080,  60 },
-            { 1600,  900,  60 },
-            { 1024,  768,  60 },
-        },
-        0
-    },
-    // 1440p EDID
-    {
-        {
-            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0x01,0x00,0x01,0x00,0x00,0x00,
-            0x24,0x1D,0x01,0x04,0xA5,0x3C,0x22,0x78,0xFB,0x6C,0xE5,0xA5,0x55,0x50,0xA0,0x23,
-            0x0B,0x50,0x54,0x00,0x02,0x00,0xD1,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,
-            0x01,0x01,0x01,0x01,0x01,0x01,0x6A,0x5E,0x00,0xA0,0xA0,0xA0,0x29,0x50,0x30,0x20,
-            0x35,0x00,0x55,0x50,0x21,0x00,0x00,0x1A,0x00,0x00,0x00,0xFF,0x00,0x37,0x4A,0x51,
-            0x58,0x42,0x59,0x32,0x0A,0x20,0x20,0x20,0x20,0x20,0x00,0x00,0x00,0xFC,0x00,0x31,
-            0x34,0x34,0x30,0x70,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x00,0x00,0x00,0xFD,
-            0x00,0x28,0x9B,0xFA,0xFA,0x40,0x01,0x0A,0x20,0x20,0x20,0x20,0x20,0x20,0x00,0xE6
-        },
-        // SampleMonitorMode
-        {
-            { 2560, 1440,  60 },
-            { 2048, 1536,  60 },
-            { 1920, 1080,  60 },
-            { 1024,  768,  60 },
-        },
-        0
-    },
-    // 2160p EDID
-    {
-        {
-            0x00,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0x00,0x24,0x84,0xBF,0x65,0x01,0x01,0x01,0x01,
-            0x20,0x1A,0x01,0x04,0xA5,0x3C,0x22,0x78,0x3B,0xEE,0xD1,0xA5,0x55,0x48,0x9B,0x26,
-            0x12,0x50,0x54,0x00,0x08,0x00,0xA9,0xC0,0x01,0x01,0x01,0x01,0x01,0x01,0x01,0x01,
-            0x01,0x01,0x01,0x01,0x01,0x01,0x68,0xD8,0x00,0x18,0xF1,0x70,0x2D,0x80,0x58,0x2C,
-            0x45,0x00,0x53,0x50,0x21,0x00,0x00,0x1E,0x02,0x3A,0x80,0x18,0x71,0x38,0x2D,0x40,
-            0x58,0x2C,0x45,0x00,0xC2,0xAD,0x42,0x00,0x00,0x1E,0x6A,0x5E,0x00,0xA0,0xA0,0xA0,
-            0x29,0x50,0x30,0x20,0x35,0x00,0x55,0x50,0x21,0x00,0x00,0x1A,0x00,0x00,0x00,0xFC,
-            0x00,0x32,0x31,0x36,0x30,0x4D,0x6F,0x6E,0x69,0x74,0x6F,0x72,0x0A,0x20,0x00,0x5A
-        },
-        // SampleMonitorMode
-        {
-            { 1920, 1080,  60 },
-            { 3840, 2160,  60 },
-            { 2048, 1536,  60 },
-            { 1024,  768,  60 },
-        },
-        0
-    }
+    { 3840, 2160, 60 },
+    { 3200, 2400, 60 },
+    { 3200, 1800, 60 },
+    { 3008, 1692, 60 },
+    { 2880, 1800, 60 },
+    { 2880, 1620, 60 },
+    { 2560, 1440, 144 },
+    { 2560, 1440, 90 },
+    { 2048, 1536, 60 },
+    { 2560, 1440, 60 },
+    { 2560, 1600, 60 },
+    { 2048, 1536, 60 },
+    { 1920, 1440, 60 },
+    { 1920, 1200, 60 },
+    { 1920, 1080, 144 },
+    { 1920, 1080, 90 },
+    { 1920, 1080, 60 },
+    { 1680, 1050, 60 },
+    { 1600, 1024, 60 },
+    { 1600, 900, 60 },
+    { 1400, 1050,60 },
+    { 1440, 900, 60 },
+    { 1366, 768, 60 },
+    { 1360, 768, 60 },
+    { 1280, 1024, 60 },
+    { 1280, 960, 60 },
+    { 1280, 800, 60 },
+    { 1024, 768, 75 },
+    { 1280, 768, 60 },
+    { 1280, 720, 60 },
+    { 1280, 600, 60 },
+    { 1152, 864, 60 },
+    { 800, 600, 60 },
+    { 640, 480, 60 },
 };
+// That's default mode for the driver. While we can expose any mode here as
+// default, we don't want to set too high default resolution to ease initial
+// system configuration.
+static const MonitorMode g_default_mode = { 1920, 1080, 60 };
 
 #pragma endregion
 
@@ -133,18 +107,6 @@ static inline void FillSignalInfo(DISPLAYCONFIG_VIDEO_SIGNAL_INFO& Mode, DWORD W
     Mode.hSyncFreq.Denominator                 = 1;
     Mode.scanLineOrdering                      = DISPLAYCONFIG_SCANLINE_ORDERING_PROGRESSIVE;
     Mode.pixelRate                             = ((UINT64)VSync) * ((UINT64)Width) * ((UINT64)Height);
-}
-
-static IDDCX_MONITOR_MODE CreateIddCxMonitorMode(DWORD Width, DWORD Height, DWORD VSync, IDDCX_MONITOR_MODE_ORIGIN Origin = IDDCX_MONITOR_MODE_ORIGIN_DRIVER)
-{
-    IDDCX_MONITOR_MODE Mode = {};
-
-    Mode.Size   = sizeof(Mode);
-    Mode.Origin = Origin;
-
-    FillSignalInfo(Mode.MonitorVideoSignalInfo, Width, Height, VSync, true);
-
-    return Mode;
 }
 
 static IDDCX_TARGET_MODE CreateIddCxTargetMode(DWORD Width, DWORD Height, DWORD VSync)
@@ -244,33 +206,10 @@ extern "C" BOOL WINAPI DllMain(
 
 #define DBG_PRINTF(...) {char msg[512]; sprintf_s(msg, 512, __VA_ARGS__);  OutputDebugStringA(msg);}
 
-#define MONITOR_1080p 1
-#define MONITOR_1440p 2
-#define MONITOR_2160p 4
-
 #define CURSOR_SOFTWARE 0
 #define CURSOR_HARDWARE 1
 
 #define REMOTE_SESSION 0x01000000
-
-ULONG GetMonitorIdx()
-{
-    // TBD : Need to check if this () is required, can be replaced with macro
-    if (MonitorTypeRegistryValue & MONITOR_1080p)
-    {
-        return 2;
-    }
-    else if (MonitorTypeRegistryValue & MONITOR_1440p)
-    {
-        return 2;
-    }
-    else if (MonitorTypeRegistryValue & MONITOR_2160p)
-    {
-       return 2;
-    }
-
-    return 2;
-}
 
 ULONG GetMonitorNumber()
 {
@@ -318,7 +257,6 @@ NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     WDF_PNPPOWER_EVENT_CALLBACKS PnpPowerCallbacks;
-    DECLARE_CONST_UNICODE_STRING(MonitorTypeName, L"IddCustomControl");
     DECLARE_CONST_UNICODE_STRING(MonitorNumber, L"IddMonitorNumber");
     DECLARE_CONST_UNICODE_STRING(MonitorCursor, L"IddCursorControl");
     UNREFERENCED_PARAMETER(Driver);
@@ -369,7 +307,6 @@ NTSTATUS IddSampleDeviceAdd(WDFDRIVER Driver, PWDFDEVICE_INIT pDeviceInit)
         return Status;
     }
 
-    MonitorTypeRegistryValue   = IddReadRegistryDword(Device, &MonitorTypeName);
     MonitorNumberRegistryValue = IddReadRegistryDword(Device, &MonitorNumber);
     MonitorCursorRegistryValue = IddReadRegistryDword(Device, &MonitorCursor);
 
@@ -688,24 +625,11 @@ void IndirectDeviceContext::FinishInit(UINT ConnectorIndex)
     // In the sample driver, we report a monitor right away but a real driver would do this when a monitor connection event occurs
     IDDCX_MONITOR_INFO MonitorInfo      = {};
     MonitorInfo.Size                    = sizeof(MonitorInfo);
-    // Reporting as INDIRECT_WIRED for detecting IDD displays in QDC.
+    // Reporting as INDIRECT_WIRED for detecting IDD displays in QueryDisplayConfig Win API.
     MonitorInfo.MonitorType             = DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INDIRECT_WIRED;
     MonitorInfo.ConnectorIndex          = ConnectorIndex;
     MonitorInfo.MonitorDescription.Size = sizeof(MonitorInfo.MonitorDescription);
     MonitorInfo.MonitorDescription.Type = IDDCX_MONITOR_DESCRIPTION_TYPE_EDID;
-
-    if (ConnectorIndex >= ARRAYSIZE(s_SampleMonitors))
-    {
-        MonitorInfo.MonitorDescription.DataSize = 0;
-        MonitorInfo.MonitorDescription.pData = nullptr;
-    }
-    else
-    {
-        MonitorInfo.MonitorDescription.DataSize = IndirectSampleMonitor::szEdidBlock;
-        // MonitorInfo.MonitorDescription.pData = const_cast<BYTE*>(s_SampleMonitors[ConnectorIndex].pEdidBlock);
-        MonitorInfo.MonitorDescription.pData    = const_cast<BYTE*>(s_SampleMonitors[GetMonitorIdx()].pEdidBlock);
-
-    }
 
     // ==============================
     // TODO: The monitor's container ID should be distinct from "this" device's container ID if the monitor is not
@@ -889,88 +813,54 @@ NTSTATUS IddSampleAdapterCommitModes(IDDCX_ADAPTER AdapterObject, const IDARG_IN
 _Use_decl_annotations_
 NTSTATUS IddSampleParseMonitorDescription(const IDARG_IN_PARSEMONITORDESCRIPTION* pInArgs, IDARG_OUT_PARSEMONITORDESCRIPTION* pOutArgs)
 {
-    // ==============================
-    // TODO: In a real driver, this function would be called to generate monitor modes for an EDID by parsing it. In
-    // this sample driver, we hard-code the EDID, so this function can generate known modes.
-    // ==============================
-
-    pOutArgs->MonitorModeBufferOutputCount = IndirectSampleMonitor::szModeList;
-
-    if (pInArgs->MonitorModeBufferInputCount < IndirectSampleMonitor::szModeList)
-    {
-        // Return success if there was no buffer, since the caller was only asking for a count of modes
-        return (pInArgs->MonitorModeBufferInputCount > 0) ? STATUS_BUFFER_TOO_SMALL : STATUS_SUCCESS;
-    }
-    else
-    {
-        // In the sample driver, we have reported some static information about connected monitors
-        // Check which of the reported monitors this call is for by comparing it to the pointer of
-        // our known EDID blocks.
-
-        if (pInArgs->MonitorDescription.DataSize != IndirectSampleMonitor::szEdidBlock)
-        {
-            return STATUS_INVALID_PARAMETER;
-        }
-
-        DWORD SampleMonitorIdx = 0;
-        for (; SampleMonitorIdx < ARRAYSIZE(s_SampleMonitors); SampleMonitorIdx++)
-        {
-            if (memcmp(pInArgs->MonitorDescription.pData, s_SampleMonitors[SampleMonitorIdx].pEdidBlock, IndirectSampleMonitor::szEdidBlock) == 0)
-            {
-                // Copy the known modes to the output buffer
-                for (DWORD ModeIndex = 0; ModeIndex < IndirectSampleMonitor::szModeList; ModeIndex++)
-                {
-                    pInArgs->pMonitorModes[ModeIndex] = CreateIddCxMonitorMode(
-                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].Width,
-                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].Height,
-                        s_SampleMonitors[SampleMonitorIdx].pModeList[ModeIndex].VSync,
-                        IDDCX_MONITOR_MODE_ORIGIN_MONITORDESCRIPTOR
-                    );
-                }
-
-                // Set the preferred mode as represented in the EDID
-                pOutArgs->PreferredMonitorModeIdx = s_SampleMonitors[SampleMonitorIdx].ulPreferredModeIdx;
-
-                return STATUS_SUCCESS;
-            }
-        }
-
-        // This EDID block does not belong to the monitors we reported earlier
-        return STATUS_INVALID_PARAMETER;
-    }
+    // This function is called to parse monitor EDID. We configured EDID-less
+    // monitor so we should not get it called. However, Windows does seem to
+    // expect that we will provide valid function callback to parse EDIDs.
+    (void)pInArgs;
+    (void)pOutArgs;
+    return STATUS_INVALID_PARAMETER;
 }
 
 _Use_decl_annotations_
 NTSTATUS IddSampleMonitorGetDefaultModes(IDDCX_MONITOR MonitorObject, const IDARG_IN_GETDEFAULTDESCRIPTIONMODES* pInArgs, IDARG_OUT_GETDEFAULTDESCRIPTIONMODES* pOutArgs)
 {
+    // This function is called to generate monitor modes for monitors without EDID
+    // which is exactly our case. In case we will need to support EDIDs for any
+    // reason, here we can report additional modes not listed in EDID.
     UNREFERENCED_PARAMETER(MonitorObject);
-
-    // ==============================
-    // TODO: In a real driver, this function would be called to generate monitor modes for a monitor with no EDID.
-    // Drivers should report modes that are guaranteed to be supported by the transport protocol and by nearly all
-    // monitors (such 640x480, 800x600, or 1024x768). If the driver has access to monitor modes from a descriptor other
-    // than an EDID, those modes would also be reported here.
-    // ==============================
 
     if (pInArgs->DefaultMonitorModeBufferInputCount == 0)
     {
-        pOutArgs->DefaultMonitorModeBufferOutputCount = ARRAYSIZE(s_SampleDefaultModes);
+        pOutArgs->DefaultMonitorModeBufferOutputCount = ARRAYSIZE(g_modes);
+        return STATUS_SUCCESS;
     }
-    else
+    if (pInArgs->DefaultMonitorModeBufferInputCount < ARRAYSIZE(g_modes))
     {
-        for (DWORD ModeIndex = 0; ModeIndex < ARRAYSIZE(s_SampleDefaultModes); ModeIndex++)
-        {
-            pInArgs->pDefaultMonitorModes[ModeIndex] = CreateIddCxMonitorMode(
-                s_SampleDefaultModes[ModeIndex].Width,
-                s_SampleDefaultModes[ModeIndex].Height,
-                s_SampleDefaultModes[ModeIndex].VSync,
-                IDDCX_MONITOR_MODE_ORIGIN_DRIVER
-            );
-        }
-
-        pOutArgs->DefaultMonitorModeBufferOutputCount = ARRAYSIZE(s_SampleDefaultModes);
-        pOutArgs->PreferredMonitorModeIdx = 0;
+        return STATUS_INVALID_PARAMETER;
     }
+
+    UINT def_idx = 0;
+    for (DWORD idx = 0; idx < ARRAYSIZE(g_modes); ++idx)
+    {
+        pInArgs->pDefaultMonitorModes[idx] = {};
+        pInArgs->pDefaultMonitorModes[idx].Size = sizeof(pInArgs->pDefaultMonitorModes[idx]);
+        pInArgs->pDefaultMonitorModes[idx].Origin = IDDCX_MONITOR_MODE_ORIGIN_DRIVER;
+
+        FillSignalInfo(
+            pInArgs->pDefaultMonitorModes[idx].MonitorVideoSignalInfo,
+            g_modes[idx].width,
+            g_modes[idx].height,
+            g_modes[idx].vsync, true);
+
+        if (g_modes[idx].width == g_default_mode.width &&
+            g_modes[idx].height == g_default_mode.height &&
+            g_modes[idx].vsync == g_default_mode.vsync)
+        {
+            def_idx = idx;
+        }
+    }
+
+    pOutArgs->PreferredMonitorModeIdx = def_idx;
 
     return STATUS_SUCCESS;
 }
@@ -982,50 +872,19 @@ NTSTATUS IddSampleMonitorQueryModes(IDDCX_MONITOR MonitorObject, const IDARG_IN_
 
     vector<IDDCX_TARGET_MODE> TargetModes;
 
-    // Create a set of modes supported for frame processing and scan-out. These are typically not based on the
-    // monitor's descriptor and instead are based on the static processing capability of the device. The OS will
-    // report the available set of modes for a given output as the intersection of monitor modes with target modes.
+    for (DWORD idx = 0; idx < ARRAYSIZE(g_modes); ++idx)
+    {
+        IDDCX_TARGET_MODE mode{};
 
-    TargetModes.push_back(CreateIddCxTargetMode(3840, 2160, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(3200, 2400, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(3200, 1800, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(3008, 1692, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(2880, 1800, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(2880, 1620, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 144));
-    TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 90));
-    TargetModes.push_back(CreateIddCxTargetMode(2560, 1600, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(2560, 1440, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(2048, 1536, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1920, 1440, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1920, 1200, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 144));
-    TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 90));
-    TargetModes.push_back(CreateIddCxTargetMode(1920, 1080, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(1600, 1024, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1680, 1050, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1600, 900, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1440, 900, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1400, 1050,60));
-    TargetModes.push_back(CreateIddCxTargetMode(1366, 768, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1360, 768, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 1024, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 960, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 800, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 768, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 720, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1280, 600, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(1152, 864, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(1024, 768, 75));
-    TargetModes.push_back(CreateIddCxTargetMode(1024, 768, 60));
-
-    TargetModes.push_back(CreateIddCxTargetMode(800, 600, 60));
-    TargetModes.push_back(CreateIddCxTargetMode(640, 480, 60));
+        mode.Size = sizeof(mode);
+        FillSignalInfo(
+            mode.TargetVideoSignalInfo.targetVideoSignalInfo,
+            g_modes[idx].width,
+            g_modes[idx].height,
+            g_modes[idx].vsync,
+            false);
+        TargetModes.push_back(mode);
+    }
 
     pOutArgs->TargetModeBufferOutputCount = (UINT)TargetModes.size();
 

--- a/sources/drivers/idd/Driver.h
+++ b/sources/drivers/idd/Driver.h
@@ -38,23 +38,6 @@ namespace Microsoft
         /// <summary>
         /// Manages the creation and lifetime of a Direct3D render device.
         /// </summary>
-        struct IndirectSampleMonitor
-        {
-            static constexpr size_t szEdidBlock = 128;
-            static constexpr size_t szModeList = 4;
-
-            const BYTE pEdidBlock[szEdidBlock];
-            const struct SampleMonitorMode {
-                DWORD Width;
-                DWORD Height;
-                DWORD VSync;
-            } pModeList[szModeList];
-            const DWORD ulPreferredModeIdx;
-        };
-
-        /// <summary>
-        /// Manages the creation and lifetime of a Direct3D render device.
-        /// </summary>
         struct Direct3DDevice
         {
             Direct3DDevice(LUID AdapterLuid);

--- a/sources/drivers/idd/IddSampleDriver.inf
+++ b/sources/drivers/idd/IddSampleDriver.inf
@@ -36,7 +36,6 @@ AddReg = IddDevice_HardwareDeviceSettings
 [IddDevice_HardwareDeviceSettings]
 HKR,, "UpperFilters",  %REG_MULTI_SZ%, "IndirectKmd"
 HKR, "WUDF", "DeviceGroupId", %REG_SZ%, "IddSampleDriverGroup" ; TODO: edit driver group name, see README.md for more info
-HKR,,"IddCustomControl",0x00010001,1 ; 1 - 1080p Monitor, 2 - 1440p Monitor, 4 - 2160p Monitor
 HKR,,"IddMonitorNumber",0x00010001,1 ; 1 - 1 monitor, 2 - 2 monitors
 HKR,,"IddCursorControl",0x00010001,0 ; 0 - Software Cursor, 1 - Hardware Cursor
 HKR,,Security,,"D:P(A;;GA;;;BA)(A;;GA;;;SY)(A;;GA;;;UD)(A;;GA;;;AU)"

--- a/sources/drivers/idd/IddSampleDriver.rc
+++ b/sources/drivers/idd/IddSampleDriver.rc
@@ -13,7 +13,7 @@
 #define VER_LEGALCOPYRIGHT_STR      "Copyright (C) 2022-2023 Intel Corporation"
 #define VER_PRODUCTNAME_STR         "Cloud Streaming Reference Stack"
 #define VER_COMPANYNAME_STR         "Intel Corporation"
-#define VER_PRODUCTVERSION          0,5,0,0
-#define VER_PRODUCTVERSION_STR      "0.5.0.0"
+#define VER_PRODUCTVERSION          0,5,0,1
+#define VER_PRODUCTVERSION_STR      "0.5.0.1"
 
 #include "common.ver"

--- a/sources/drivers/idd/IddSampleDriver.vcxproj
+++ b/sources/drivers/idd/IddSampleDriver.vcxproj
@@ -266,7 +266,7 @@
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Inf>
-      <TimeStamp>0.5.0.0</TimeStamp>
+      <TimeStamp>0.5.0.1</TimeStamp>
       <SpecifyDriverVerDirectiveVersion>true</SpecifyDriverVerDirectiveVersion>
     </Inf>
   </ItemDefinitionGroup>

--- a/sources/drivers/idd/readme.rst
+++ b/sources/drivers/idd/readme.rst
@@ -97,10 +97,6 @@ IDD driver support the following registry keys which control its behavior:
 +------------------+-----------+---------------+---------------------------+-------------------------------------+
 | Key              | Type      | Default value | Supported values          | Description                         |
 +==================+===========+===============+===========================+=====================================+
-| IddCustomControl | REG_DWORD | 1             | * ``1`` : 1080p Monitor   | Controls maximum resolution         |
-|                  |           |               | * ``2`` : 1440p Monitor   | available on IDD device             |
-|                  |           |               | * ``4`` : 2160p Monitor   |                                     |
-+------------------+-----------+---------------+---------------------------+-------------------------------------+
 | IddMonitorNumber | REG_DWORD | 1             | * ``1`` : 1 monitor       | Controls number of exposed monitors |
 |                  |           |               | * ``2`` : 2 monitors      |                                     |
 +------------------+-----------+---------------+---------------------------+-------------------------------------+
@@ -119,16 +115,97 @@ location in the registry:
 You can change registry settings from the command shell::
 
   reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\ROOT\DISPLAY\0000\Device Parameters" ^
-    /v IddCustomControl /t REG_DWORD /d 2 /f
+    /v IddMonitorNumber /t REG_DWORD /d 2 /f
 
-Above example will change maximum resolution available on IDD device ``0000``
-to 1440p. In order for the change to take effect you need to disable and
-enable back this device to trigger IDD driver reload. You can do that either
-from the Windows Device Manager (targeting specific device) or from command
-line using `devcon`_ (targeting all IDD devices)::
+Above example will change number of exposed monitors on IDD device ``0000``.
+In order for the change to take effect you need to disable and enable back this
+device to trigger IDD driver reload. You can do that either from the Windows
+Device Manager (targeting specific device) or from command line using
+`devcon`_ (targeting all IDD devices)::
 
   devcon.exe disable "root\iddsampledriver"
   devcon.exe enable "root\iddsampledriver"
+
+Supported modes
+---------------
+
+Current implementation of IDD driver supports following modes:
+
++-------+--------+--------------+
+| Width | Height | Refresh Rate |
++=======+========+==============+
+| 3840  |  2160  |  60          |
++-------+--------+--------------+
+| 3200  |  2400  |  60          |
++-------+--------+--------------+
+| 3200  |  1800  |  60          |
++-------+--------+--------------+
+| 3008  |  1692  |  60          |
++-------+--------+--------------+
+| 2880  |  1800  |  60          |
++-------+--------+--------------+
+| 2880  |  1620  |  60          |
++-------+--------+--------------+
+| 2560  |  1440  |  144         |
++-------+--------+--------------+
+| 2560  |  1440  |  90          |
++-------+--------+--------------+
+| 2048  |  1536  |  60          |
++-------+--------+--------------+
+| 2560  |  1440  |  60          |
++-------+--------+--------------+
+| 2560  |  1600  |  60          |
++-------+--------+--------------+
+| 2048  |  1536  |  60          |
++-------+--------+--------------+
+| 1920  |  1440  |  60          |
++-------+--------+--------------+
+| 1920  |  1200  |  60          |
++-------+--------+--------------+
+| 1920  |  1080  |  144         |
++-------+--------+--------------+
+| 1920  |  1080  |  90          |
++-------+--------+--------------+
+| 1920  |  1080  |  60          |
++-------+--------+--------------+
+| 1680  |  1050  |  60          |
++-------+--------+--------------+
+| 1600  |  1024  |  60          |
++-------+--------+--------------+
+| 1600  |  900   |  60          |
++-------+--------+--------------+
+| 1400  |  1050  |  60          |
++-------+--------+--------------+
+| 1440  |  900   |  60          |
++-------+--------+--------------+
+| 1366  |  768   |  60          |
++-------+--------+--------------+
+| 1360  |  768   |  60          |
++-------+--------+--------------+
+| 1280  |  1024  |  60          |
++-------+--------+--------------+
+| 1280  |  960   |  60          |
++-------+--------+--------------+
+| 1280  |  800   |  60          |
++-------+--------+--------------+
+| 1024  |  768   |  75          |
++-------+--------+--------------+
+| 1280  |  768   |  60          |
++-------+--------+--------------+
+| 1280  |  720   |  60          |
++-------+--------+--------------+
+| 1280  |  600   |  60          |
++-------+--------+--------------+
+| 1152  |  864   |  60          |
++-------+--------+--------------+
+| 800   |  600   |  60          |
++-------+--------+--------------+
+| 640   |  480   |  60          |
++-------+--------+--------------+
+
+Technically IDD driver can support other modes limited by maximum resolution
+supported by adapter it's paired with. If you miss a mode, please, open an
+issue on our Github projec or Pull Request adding required mode.
 
 Known issues
 ------------


### PR DESCRIPTION
Issue: ACEABAI-23

EDID lists supported modes and imply limitations over supported resolutions. Our IDD driver is fully headless and these limitations don't make sense for us. So, we can use EDID-less monitors and just list modes we want to support.