### PR TITLE
ics3a & wincg: update to ffmpeg-n6.1 

### DIFF
--- a/docker/deps/windows/Dockerfile
+++ b/docker/deps/windows/Dockerfile
@@ -33,8 +33,8 @@ RUN cd /opt/build && \
 
 # d3d11va AV1 decoder requires mingw >= 10.x (Ubuntu 22.10 and later)
 RUN cd /opt/build && \
-  wget -O FFmpeg-n6.0.zip https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.0.zip && \
-  unzip FFmpeg-n6.0.zip && cd FFmpeg-n6.0 && \
+  wget -O FFmpeg-n6.1.zip https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.1.zip && \
+  unzip FFmpeg-n6.1.zip && cd FFmpeg-n6.1 && \
   ./configure \
     --enable-cross-compile \
     --arch=x86_64 \

--- a/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/encoder/ubuntu22.04/intel-gfx/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout 57afccc
+  git checkout n6.1
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/encoder/ubuntu22.04/selfbuild-prodkmd/Dockerfile
@@ -219,7 +219,7 @@ RUN apt-get update && \
 ARG FFMPEG_REPO=https://github.com/FFmpeg/FFmpeg.git
 RUN git clone $FFMPEG_REPO /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout 57afccc
+  git checkout n6.1
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`FFMPEG_VER',`57afccc') dnl tracking master
+DECLARE(`FFMPEG_VER',`n6.1') dnl tracking master
 dnl Using github mirror to avoid pulling from different locations which minimizes
 dnl dnl impact on the CI in case of outages.
 DECLARE(`FFMPEG_REPO_URL',https://github.com/FFmpeg/FFmpeg.git)


### PR DESCRIPTION
This aligns ffmpeg version used by 2 reference stacks at n6.1.