### PR TITLE
wincg: add desktop target capture library and sample app

### DIFF
--- a/.github/workflows/wincg.yml
+++ b/.github/workflows/wincg.yml
@@ -33,7 +33,14 @@ jobs:
         docker run --rm -u $(id -u):$(id -g) -v $(pwd):/opt/dist2 build-deps-linux \
           cp -rd /opt/dist/build-deps /opt/dist2/
 
-  meson-ninja:
+  # minimal-* builds correspond to project configuration with minimal
+  # dependencies. Only few tools will actually be built which depend only
+  # on Windows API (enum-adapters, idd-setup-tool).
+
+  minimal-meson:
+    strategy:
+      matrix:
+        backend: [ninja, vs]
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
@@ -44,16 +51,73 @@ jobs:
     - run: '.github\workflows\EnterDevShell.ps1 amd64'
       shell: pwsh
     - name: 'Configure'
-      run: meson setup _build --wrap-mode=forcefallback
+      run: meson setup _build --backend=${{ matrix.backend }}
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'
       run: meson install -C _build
 
-  meson-msbuild:
+  # samples-* builds correspond to project configuration which exposes key project
+  # features covered by samples. This configuration requires dependencies which
+  # needs to be built or installed beforehand.
+
+  samples-meson:
+    strategy:
+      matrix:
+        backend: [ninja, vs]
     runs-on: windows-2022
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+        repository: intel/libvpl
+        ref: v2023.3.1
+        path: libvpl
+    - uses: actions/checkout@v3
+      with:
+        repository: FFmpeg/FFmpeg
+        ref: n6.1
+        path: ffmpeg
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: false
+        # NOTE: we need install msys/make and avoid make:p version of make
+        # since it has limitation on command line lenght which is critical
+        # for ffmpeg build
+        pacboy: >-
+          cmake:p
+          diffutils:p
+          gcc:p
+          msys/make
+          nasm:p
+          pkgconf:p
+    # Here we build dependencies (libvpl and ffmpeg) under msys2
+    - shell: msys2 {0}
+      working-directory: libvpl
+      run: |
+        cmake -B _build -G Ninja \
+          -DCMAKE_INSTALL_PREFIX=$(pwd)/../_install \
+          -DBUILD_TOOLS=OFF \
+          -DBUILD_PREVIEW=OFF \
+          -DINSTALL_EXAMPLE_CODE=OFF
+        ninja -C _build
+        ninja install -C _build
+        # copy runtime dependencies due to C++ compilation with gcc
+        cp $(where libgcc_s_seh-1.dll) ../_install/bin/
+        cp $(where libstdc++-6.dll) ../_install/bin/
+    - shell: msys2 {0}
+      working-directory: ffmpeg
+      run: |
+        export PKG_CONFIG_PATH=../_install/lib/pkgconfig
+        ./configure \
+          --disable-doc \
+          --enable-shared \
+          --enable-libvpl \
+          --prefix=$(pwd)/../_install
+        make -j$(nproc)
+        make install
+    # Below steps are executed under default shell (pwsh)
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -61,9 +125,8 @@ jobs:
     - run: '.github\workflows\EnterDevShell.ps1 amd64'
       shell: pwsh
     - name: 'Configure'
-      run: meson setup _build --backend=vs --wrap-mode=forcefallback
+      run: meson setup _build --backend=${{ matrix.backend }} -Dprebuilt-path=_install
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'
       run: meson install -C _build
-

--- a/.github/workflows/wincg.yml
+++ b/.github/workflows/wincg.yml
@@ -44,7 +44,7 @@ jobs:
     - run: '.github\workflows\EnterDevShell.ps1 amd64'
       shell: pwsh
     - name: 'Configure'
-      run: meson setup _build --wrap-mode=forcefallback -Dstreamer=disabled
+      run: meson setup _build --wrap-mode=forcefallback
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'
@@ -61,7 +61,7 @@ jobs:
     - run: '.github\workflows\EnterDevShell.ps1 amd64'
       shell: pwsh
     - name: 'Configure'
-      run: meson setup _build --backend=vs --wrap-mode=forcefallback -Dstreamer=disabled
+      run: meson setup _build --backend=vs --wrap-mode=forcefallback
     - name: 'Build'
       run: meson compile -C _build
     - name: 'Install'

--- a/docker/deps/windows/Dockerfile
+++ b/docker/deps/windows/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /opt/build && mkdir -p /opt/dist
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    cmake \
     git \
     make \
     mingw-w64 \
@@ -31,6 +32,23 @@ RUN cd /opt/build && \
     shared mingw64 && \
   make -j$(nproc) && make install_sw
 
+RUN cd /opt/build && \
+  git clone https://github.com/intel/libvpl.git libvpl && cd libvpl && \
+  git checkout v2023.3.1 && \
+  cmake -B _build \
+    -DCMAKE_SYSTEM_NAME=Windows \
+    -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc \
+    -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ \
+    -DCMAKE_INSTALL_PREFIX=/opt/dist/build-deps/windows-x86_64 \
+    -DBUILD_TOOLS=OFF \
+    -DBUILD_PREVIEW=OFF \
+    -DINSTALL_EXAMPLE_CODE=OFF \
+    && \
+  make -j$(nproc) -C _build && \
+  make install -C _build
+
+ENV PKG_CONFIG_PATH=/opt/dist/build-deps/windows-x86_64/lib/pkgconfig
+
 # d3d11va AV1 decoder requires mingw >= 10.x (Ubuntu 22.10 and later)
 RUN cd /opt/build && \
   wget -O FFmpeg-n6.1.zip https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n6.1.zip && \
@@ -42,6 +60,11 @@ RUN cd /opt/build && \
     --cross-prefix=x86_64-w64-mingw32- \
     --disable-doc \
     --enable-shared \
+    --enable-libvpl \
     --prefix=/opt/dist/build-deps/windows-x86_64 && \
   make -j$(nproc) && \
   make install
+
+RUN cd /opt/dist/build-deps/windows-x86_64/bin && \
+  cp /usr/lib/gcc/x86_64-w64-mingw32/12-win32/libgcc_s_seh-1.dll . && \
+  cp /usr/lib/gcc/x86_64-w64-mingw32/12-win32/libstdc++-6.dll .

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,8 +12,14 @@ option('encoder',
 
 option('streamer',
   type : 'feature',
-  value : 'enabled',
+  value : 'auto',
   description : 'Build streamer service ingredients',
+)
+
+option('capture',
+  type : 'feature',
+  value : 'auto',
+  description : 'Build desktop capture ingredients',
 )
 
 option('client',

--- a/prebuilt/meson.build
+++ b/prebuilt/meson.build
@@ -108,6 +108,14 @@ if host_machine.system() == 'windows'
       include_directories : include_directories(prebuilt_path / 'include'),
       ))
 
+    meson.override_dependency('vpl', declare_dependency(
+      dependencies : cc.find_library('vpl.dll', dirs : prebuilt_path_abs / 'lib'),
+      include_directories : include_directories(
+        prebuilt_path / 'include',
+        prebuilt_path / 'include' / 'vpl',
+        ),
+      ))
+
     # Install required binaries to run project targets.
     if not fs.is_samepath(get_option('prefix') / get_option('bindir'), prebuilt_path_abs / 'bin')
       install_data(
@@ -123,6 +131,11 @@ if host_machine.system() == 'windows'
           # openssl
           prebuilt_path_abs / 'bin' / 'libcrypto-3-x64.dll',
           prebuilt_path_abs / 'bin' / 'libssl-3-x64.dll',
+          # vpl
+          prebuilt_path_abs / 'bin' / 'libvpl.dll',
+          # C++ deps
+          prebuilt_path_abs / 'bin' / 'libgcc_s_seh-1.dll',
+          prebuilt_path_abs / 'bin' / 'libstdc++-6.dll',
           ),
         install_dir : get_option('bindir'))
     endif

--- a/prebuilt/meson.build
+++ b/prebuilt/meson.build
@@ -69,75 +69,86 @@ if host_machine.system() == 'linux'
 endif
 
 if host_machine.system() == 'windows'
-  meson.override_dependency('owt', declare_dependency(
-    include_directories : include_directories(prebuilt_path / 'include'),
-    compile_args : ['-DWEBRTC_WIN'],
-    dependencies : cpp.find_library('owt', dirs : prebuilt_path_abs / 'lib'),
-    ))
-
-  if build_machine.cpu_family() == 'x86_64'
-    meson.override_dependency('owt-client', declare_dependency(
+  if cpp.find_library('owt', dirs : prebuilt_path_abs / 'lib', required: false).found()
+    meson.override_dependency('owt', declare_dependency(
       include_directories : include_directories(prebuilt_path / 'include'),
       compile_args : ['-DWEBRTC_WIN'],
-      dependencies : cpp.find_library('owt-client', dirs : prebuilt_path_abs / 'lib'),
+      dependencies : cpp.find_library('owt', dirs : prebuilt_path_abs / 'lib'),
       ))
+  endif
+
+  if build_machine.cpu_family() == 'x86_64'
+    if cpp.find_library('owt-client', dirs : prebuilt_path_abs / 'lib', required: false).found()
+      meson.override_dependency('owt-client', declare_dependency(
+        include_directories : include_directories(prebuilt_path / 'include'),
+        compile_args : ['-DWEBRTC_WIN'],
+        dependencies : cpp.find_library('owt-client', dirs : prebuilt_path_abs / 'lib'),
+        ))
+    endif
 
     # NOTE : cc.find_library('xxx.dll') searches for the static library named libxxx.dll.a
 
-    meson.override_dependency('libcrypto', declare_dependency(
-      include_directories : include_directories(prebuilt_path / 'include'),
-      dependencies : cc.find_library('crypto.dll', dirs : prebuilt_path_abs / 'lib'),
-      ))
+    install_files = []
 
-    meson.override_dependency('libssl', declare_dependency(
-      include_directories : include_directories(prebuilt_path / 'include'),
-      dependencies : cc.find_library('ssl.dll', dirs : prebuilt_path_abs / 'lib'),
-      ))
+    if (cpp.find_library('crypto.dll', dirs : prebuilt_path_abs / 'lib', required: false).found() and
+        cpp.find_library('ssl.dll', dirs : prebuilt_path_abs / 'lib', required: false).found())
+      meson.override_dependency('libcrypto', declare_dependency(
+        include_directories : include_directories(prebuilt_path / 'include'),
+        dependencies : cc.find_library('crypto.dll', dirs : prebuilt_path_abs / 'lib'),
+        ))
+      meson.override_dependency('libssl', declare_dependency(
+        include_directories : include_directories(prebuilt_path / 'include'),
+        dependencies : cc.find_library('ssl.dll', dirs : prebuilt_path_abs / 'lib'),
+        ))
+      meson.override_dependency('openssl', declare_dependency(
+        dependencies: [dependency('libcrypto'), dependency('libssl')],
+        ))
+      install_files += files(
+        prebuilt_path_abs / 'bin' / 'libcrypto-3-x64.dll',
+        prebuilt_path_abs / 'bin' / 'libssl-3-x64.dll',
+        )
+    endif
 
-    meson.override_dependency('openssl', declare_dependency(
-      dependencies: [dependency('libcrypto'), dependency('libssl')],
-      ))
+    if (cpp.find_library('avcodec.dll', dirs : prebuilt_path_abs / 'lib', required: false).found() and
+        cpp.find_library('avutil.dll', dirs : prebuilt_path_abs / 'lib', required: false).found())
+      meson.override_dependency('libavcodec', declare_dependency(
+        dependencies : cc.find_library('avcodec.dll', dirs : prebuilt_path_abs / 'lib'),
+        include_directories : include_directories(prebuilt_path / 'include'),
+        ))
+      meson.override_dependency('libavutil', declare_dependency(
+        dependencies : cc.find_library('avutil.dll', dirs : prebuilt_path_abs / 'lib'),
+        include_directories : include_directories(prebuilt_path / 'include'),
+        ))
+      install_files += files(
+        prebuilt_path_abs / 'bin' / 'avcodec-60.dll',
+        prebuilt_path_abs / 'bin' / 'avdevice-60.dll',
+        prebuilt_path_abs / 'bin' / 'avfilter-9.dll',
+        prebuilt_path_abs / 'bin' / 'avformat-60.dll',
+        prebuilt_path_abs / 'bin' / 'swresample-4.dll',
+        prebuilt_path_abs / 'bin' / 'swscale-7.dll',
+        prebuilt_path_abs / 'bin' / 'avutil-58.dll',
+        )
+    endif
 
-    meson.override_dependency('libavcodec', declare_dependency(
-      dependencies : cc.find_library('avcodec.dll', dirs : prebuilt_path_abs / 'lib'),
-      include_directories : include_directories(prebuilt_path / 'include'),
-      ))
-
-    meson.override_dependency('libavutil', declare_dependency(
-      dependencies : cc.find_library('avutil.dll', dirs : prebuilt_path_abs / 'lib'),
-      include_directories : include_directories(prebuilt_path / 'include'),
-      ))
-
-    meson.override_dependency('vpl', declare_dependency(
-      dependencies : cc.find_library('vpl.dll', dirs : prebuilt_path_abs / 'lib'),
-      include_directories : include_directories(
-        prebuilt_path / 'include',
-        prebuilt_path / 'include' / 'vpl',
-        ),
-      ))
+    if cpp.find_library('vpl.dll', dirs : prebuilt_path_abs / 'lib', required: false).found()
+      meson.override_dependency('vpl', declare_dependency(
+        dependencies : cc.find_library('vpl.dll', dirs : prebuilt_path_abs / 'lib'),
+        include_directories : include_directories(
+          prebuilt_path / 'include',
+          prebuilt_path / 'include' / 'vpl',
+          ),
+        ))
+      install_files += files(
+        prebuilt_path_abs / 'bin' / 'libvpl.dll',
+        # C++ deps
+        prebuilt_path_abs / 'bin' / 'libgcc_s_seh-1.dll',
+        prebuilt_path_abs / 'bin' / 'libstdc++-6.dll',
+        )
+    endif
 
     # Install required binaries to run project targets.
     if not fs.is_samepath(get_option('prefix') / get_option('bindir'), prebuilt_path_abs / 'bin')
-      install_data(
-        files(
-          # ffmpeg
-          prebuilt_path_abs / 'bin' / 'avcodec-60.dll',
-          prebuilt_path_abs / 'bin' / 'avdevice-60.dll',
-          prebuilt_path_abs / 'bin' / 'avfilter-9.dll',
-          prebuilt_path_abs / 'bin' / 'avformat-60.dll',
-          prebuilt_path_abs / 'bin' / 'avutil-58.dll',
-          prebuilt_path_abs / 'bin' / 'swresample-4.dll',
-          prebuilt_path_abs / 'bin' / 'swscale-7.dll',
-          # openssl
-          prebuilt_path_abs / 'bin' / 'libcrypto-3-x64.dll',
-          prebuilt_path_abs / 'bin' / 'libssl-3-x64.dll',
-          # vpl
-          prebuilt_path_abs / 'bin' / 'libvpl.dll',
-          # C++ deps
-          prebuilt_path_abs / 'bin' / 'libgcc_s_seh-1.dll',
-          prebuilt_path_abs / 'bin' / 'libstdc++-6.dll',
-          ),
-        install_dir : get_option('bindir'))
+      install_data(install_files, install_dir : get_option('bindir'))
     endif
   endif
 endif

--- a/sources/apps/enum-adapters/meson.build
+++ b/sources/apps/enum-adapters/meson.build
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+summary({'enum-adapters' : true}, bool_yn : true, section: 'Targets')
+
 srcs = [cgver_file, cgvcs_tgt]
 srcs += files(
   'enum-adapters.cpp',

--- a/sources/apps/idd-setup-tool/meson.build
+++ b/sources/apps/idd-setup-tool/meson.build
@@ -14,6 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+summary({'idd-setup-tool' : true}, bool_yn : true, section: 'Targets')
+
 srcs = [cgver_file, cgvcs_tgt]
 srcs += files(
   'ChangeDisplaySettings.cpp',

--- a/sources/apps/meson.build
+++ b/sources/apps/meson.build
@@ -16,6 +16,9 @@
 
 subdir('idd-setup-tool')
 subdir('enum-adapters')
+if get_option('capture').allowed()
+  subdir('screen-grab')
+endif
 if get_option('client').allowed()
   subdir('webrtc-client')
 endif

--- a/sources/apps/screen-grab/meson.build
+++ b/sources/apps/screen-grab/meson.build
@@ -14,33 +14,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cgvcs_tgt = vcs_tag(
-  command : [ 'git', 'rev-parse', '--short', 'HEAD'],
-  input : 'cg-vcs.h.in',
-  output : 'cg-vcs.h',
-  fallback : 'tarball',
+if not capture_dep.found()
+  warning('screen-grab will NOT be built due to missing dependencies')
+  summary({'screen-grab' : false}, bool_yn : true, section: 'Targets')
+  subdir_done()
+endif
+
+summary({'screen-grab' : true}, bool_yn : true, section: 'Targets')
+
+srcs = files(
+  'screen-grab.cpp',
   )
 
-ver = meson.project_version().split('.')
+srcs += windows.compile_resources(
+  files('screen-grab.rc'),
+  args : winres_args,
+  depend_files : [ cgver_file, files('resource.h') ],
+  depends : cgvcs_tgt,
+  )
 
-cgver_file = configure_file(
-  input : 'cg-version.h.in',
-  output : 'cg-version.h',
-  configuration : {
-    'VER_MAJOR' : ver[0],
-    'VER_MINOR' : ver[1],
-    'VER_MICRO' : ver[2],
-    'VER_REV'   : 0,
-    },
-)
+cpp_args = ['-DNOMINMAX']
 
-if host_machine.system() == 'linux'
-  subdir('encoder')
-endif
-
-subdir('streamer')
-
-if host_machine.system() == 'windows' and build_machine.cpu_family() != 'x86'
-  subdir('drivers')
-  subdir('apps')
-endif
+executable('screen-grab', srcs,
+  cpp_args : cpp_args,
+  dependencies: [ga_dep, capture_dep],
+  install : true,
+  )

--- a/sources/apps/screen-grab/resource.h
+++ b/sources/apps/screen-grab/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by screen-capture.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/sources/apps/screen-grab/screen-grab.cpp
+++ b/sources/apps/screen-grab/screen-grab.cpp
@@ -1,0 +1,350 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ga-common.h"
+#include "ga-conf.h"
+
+#include <charconv>
+#include <csignal>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+
+#include "dt-capture.h"
+
+static const char* default_bitrate = "3000000";
+static const char* default_bitstream_frames_count = "-1";
+static const char* default_codec = "h264";
+static const char* default_display = ":0";
+static const char* default_fps = "60";
+static const char* default_gop = default_fps;
+static const char* default_loglevel = "none";
+static const char* default_rc = "vbr";
+
+void usage(const char* app) {
+    printf("usage: %s [options] <output_file>\n", app);
+    printf("\n");
+    printf("<output_file> is raw bitstream. For avc, hevc or av1 codecs bitstream format\n");
+    printf("is defined by Annex B of respective codec specification.\n");
+    printf("\n");
+    printf("Global options:\n");
+    printf("  -h, --help              Print this help\n");
+    printf("  --loglevel <level>      Loglevel to use (default: %s)\n", default_loglevel);
+    printf("              error         Only errors will be printed\n");
+    printf("              warning       Errors and warnings will be printed\n");
+    printf("              info          Errors, warnings and info messages will be printed\n");
+    printf("              debug         Everything will be printed, including lowlevel debug messages\n");
+    printf("              none          Don't write logs to file (errors will still be printed to stdout)'\n");
+    printf("\n");
+    printf("Capture options:\n");
+    printf("  --display <display>     Display output to grab (default: %s)\n", default_display);
+    printf("  -n <int>                Number of encoded frames to dump (-1 means infinite). (default: %s)\n", default_bitstream_frames_count);
+    printf("\n");
+    printf("Video encoding options:\n");
+    printf("  --codec <codec>         Video codec (default: %s)\n", default_codec);
+    printf("          av1\n");
+    printf("          h264 or avc\n");
+    printf("          h265 or hevc\n");
+    printf("  --bitrate <int>         Video bitrate (default: %s)\n", default_bitrate);
+    printf("  --fps <int>             Video fps (default: %s)\n", default_fps);
+    printf("  --gop <int>             Video GOP (default: %s)\n", default_gop);
+    printf("  --rc cqp|vbr            Video rate control mode (default: %s)\n", default_rc);
+}
+
+bool arg_to_int(const std::string& arg, int& value) {
+    auto result = std::from_chars(arg.c_str(), arg.c_str() + arg.size(), value);
+    if (result.ec != std::errc{})
+        return false; // error
+
+    return true; // ok
+}
+
+static HRESULT convert_utf8_to_utf16(const std::string& src, std::wstring& dst) {
+    if (src.empty()) {
+        dst = L"";
+        return S_OK;
+    }
+
+    int dst_len = MultiByteToWideChar(CP_UTF8, 0, src.data(), src.size(), nullptr, 0);
+    if (dst_len <= 0)
+        return HRESULT_FROM_WIN32(GetLastError());
+
+    std::wstring utf16_str(dst_len, L'\0');
+    dst_len = MultiByteToWideChar(CP_UTF8, 0, src.data(), src.size(), utf16_str.data(), dst_len);
+    if (dst_len <= 0)
+        return HRESULT_FROM_WIN32(GetLastError());
+
+    dst = std::move(utf16_str);
+    return S_OK;
+};
+
+static std::string to_string(DTCaptureParams::OutputFormat format) {
+    switch (format) {
+    case DTCaptureParams::OutputFormat::rgb:
+        return "rgb";
+    case DTCaptureParams::OutputFormat::nv12:
+        return "nv12";
+    }
+    return "unknown";
+}
+
+static void log_capture_params(const DTCaptureParams& params) {
+    const std::string prefix = "desktop-capture:";
+
+    fprintf(stdout, "%s --- capture config:\n", prefix.c_str());
+    fprintf(stdout, "%s %s = %S\n", prefix.c_str(), "display_device_name", params.display_device_name.c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "output_format", to_string(params.output_format).c_str());
+
+    ga_logger(Severity::INFO, "%s --- capture config:\n", prefix.c_str());
+    ga_logger(Severity::INFO, "%s %s = %S\n", prefix.c_str(), "display_device_name", params.display_device_name.c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "output_format", to_string(params.output_format).c_str());
+}
+
+static void log_encode_params(const EncoderParams& params) {
+    const std::string prefix = "desktop-capture:";
+
+    fprintf(stdout, "%s --- encode config:\n", prefix.c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "codec", to_string(params.codec).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "preset", to_string(params.preset).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "rate_control", to_string(params.rate_control).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "target_bitrate", std::to_string(params.target_bitrate).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "key_frame_interval", std::to_string(params.key_frame_interval).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "frame_rate", std::to_string(params.frame_rate).c_str());
+    fprintf(stdout, "%s %s = %s\n", prefix.c_str(), "output_chroma_format", to_string(params.output_chroma_format).c_str());
+    fprintf(stdout, "%s %s = 0x%x:0x%x\n", prefix.c_str(), "adapter_luid", params.adapter_luid.HighPart, params.adapter_luid.LowPart);
+
+    ga_logger(Severity::INFO, "%s --- encode config:\n", prefix.c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "codec", to_string(params.codec).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "preset", to_string(params.preset).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "rate_control", to_string(params.rate_control).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "target_bitrate", std::to_string(params.target_bitrate).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "key_frame_interval", std::to_string(params.key_frame_interval).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "frame_rate", std::to_string(params.frame_rate).c_str());
+    ga_logger(Severity::INFO, "%s %s = %s\n", prefix.c_str(), "output_chroma_format", to_string(params.output_chroma_format).c_str());
+    ga_logger(Severity::INFO, "%s %s = 0x%x:0x%x\n", prefix.c_str(), "adapter_luid", params.adapter_luid.HighPart, params.adapter_luid.LowPart);
+}
+
+namespace {
+    std::mutex g_mutex;
+    std::condition_variable g_cv;
+    bool g_stop = false;
+}
+
+static void signal_handler(int signal) {
+    if (signal == SIGTERM || signal == SIGINT) {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_stop  = true;
+        printf("\nCTRL+C: user requested to stop pipeline.\n");
+        g_cv.notify_one();
+    }
+}
+
+int main(int argc, char* argv[]) {
+    std::string bitrate = default_bitrate;
+    std::string bitstream_frames_count = default_bitstream_frames_count;
+    std::string codec = default_codec;
+    std::string display = default_display;
+    std::string fps = default_fps;
+    std::string gop = default_gop;
+    std::string loglevel = default_loglevel;
+    std::string rc = default_rc;
+
+    int idx = 1;
+    for (/* empty */; idx < argc; ++idx) {
+        if (std::string("-h") == argv[idx] ||
+            std::string("--help") == argv[idx]) {
+            usage(argv[0]);
+            exit(0);
+        } else if (std::string("--bitrate") == argv[idx]) {
+            if (++idx >= argc) break;
+            bitrate = argv[idx];
+        } else if (std::string("--codec") == argv[idx]) {
+            if (++idx >= argc) break;
+            codec = argv[idx];
+        } else if (std::string("--display") == argv[idx]) {
+            if (++idx >= argc) break;
+            display = argv[idx];
+        } else if (std::string("--fps") == argv[idx]) {
+            if (++idx >= argc) break;
+            fps = argv[idx];
+        } else if (std::string("--gop") == argv[idx]) {
+            if (++idx >= argc) break;
+            gop = argv[idx];
+        } else if (std::string("--loglevel") == argv[idx]) {
+            if (++idx >= argc) break;
+            loglevel = argv[idx];
+        } else if (std::string("-n") == argv[idx]) {
+            if (++idx >= argc) break;
+            bitstream_frames_count = argv[idx];
+        } else if (std::string("--rc") == argv[idx]) {
+            if (++idx >= argc) break;
+            rc = argv[idx];
+        } else {
+            break;
+        }
+    }
+
+    if (idx >= argc) {
+        fprintf(stderr, "fatal: invalid option or no output file specified\n");
+        usage(argv[0]);
+        return -1;
+    }
+
+    std::fstream bitstream_file(argv[idx], std::ios_base::out | std::ios_base::binary);
+    if (bitstream_file.is_open() == false) {
+        fprintf(stderr, "fatal: failed to open output bitstream\n");
+        usage(argv[0]);
+    }
+
+    if (loglevel != std::string("none")) {
+        ga_set_loglevel(ga_get_loglevel_enum(loglevel.c_str()));
+        ga_conf_writev("logfile", "screen-grab-log.txt");
+        ga_openlog();
+    }
+
+    // setting capture parameters
+    DTCaptureParams capture_params;
+
+    capture_params.output_format = DTCaptureParams::OutputFormat::rgb;
+
+    HRESULT result = convert_utf8_to_utf16(display, capture_params.display_device_name);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": convert_utf8_to_utf16 failed for display device name\n");
+        return E_FAIL;
+    }
+
+    int num_frames = 0;
+    int target_bitstream_frames = -1;
+    if (!arg_to_int(bitstream_frames_count, target_bitstream_frames) || (target_bitstream_frames < -1)) {
+        fprintf(stderr, "fatal: unsupported bitstream frames count: %s\n", bitstream_frames_count.c_str());
+        exit(1);
+    }
+    if (target_bitstream_frames == -1) target_bitstream_frames = INT_MAX;
+
+    capture_params.on_packet_received = [&](const Packet& packet) {
+        if (packet.data.empty())
+            return;
+
+        if (bitstream_file.is_open()) {
+            bitstream_file.write(reinterpret_cast<const char*>(packet.data.data()), packet.data.size());
+            // flush on keyframe
+            if (packet.flags & Packet::flag_keyframe)
+                bitstream_file.flush();
+        }
+
+        // count only till the limit to have correct final number of frames written to a file
+        if (num_frames < target_bitstream_frames)
+            ++num_frames;
+
+        // stop capture after target encoded frame count is reached
+        if (num_frames >= target_bitstream_frames) {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            g_stop = true;
+            g_cv.notify_one();
+        }
+        if (num_frames % 100 == 0)
+            printf("frames: %d\r", num_frames);
+    };
+
+    // [todo] implement cursor coordinates file dump
+    capture_params.on_cursor_received = [](const CursorState&){};
+
+    capture_params.on_error = [&](const std::string& msg, HRESULT res) {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        fprintf(stderr, "error: %s: 0x%08x\n", msg.c_str(), result);
+        result = res;
+        g_stop = true;
+        g_cv.notify_one();
+    };
+
+    // setting encoder paramters
+    EncoderParams encode_params;
+
+    // codec
+    if (ga_is_h264(codec))
+        encode_params.codec = EncoderParams::Codec::avc;
+    else if (ga_is_h265(codec))
+        encode_params.codec = EncoderParams::Codec::hevc;
+    else if (ga_is_av1(codec))
+        encode_params.codec = EncoderParams::Codec::av1;
+    else {
+        fprintf(stderr, "fatal: unsupported codec: %s\n", codec.c_str());
+        exit(1);
+    }
+
+    int target_bitrate = -1;
+    if (!arg_to_int(bitrate, target_bitrate) || (target_bitrate <= 0)) {
+        fprintf(stderr, "fatal: unsupported bitrate: %s\n", bitrate.c_str());
+        exit(1);
+    }
+    encode_params.target_bitrate = static_cast<uint32_t>(target_bitrate);
+
+    int target_fps = -1;
+    if (!arg_to_int(fps, target_fps) || (target_fps <= 0)) {
+        fprintf(stderr, "fatal: unsupported fps: %s\n", fps.c_str());
+        exit(1);
+    }
+    encode_params.frame_rate = static_cast<uint32_t>(target_fps);
+
+    int key_frame_interval = -1;
+    if (!arg_to_int(gop, key_frame_interval) || (key_frame_interval <= 0)) {
+        fprintf(stderr, "fatal: unsupported gop: %s\n", gop.c_str());
+        exit(1);
+    }
+    encode_params.key_frame_interval = static_cast<uint32_t>(key_frame_interval);
+
+    std::string rate_control = rc;
+    if (rate_control == "cqp")
+        encode_params.rate_control = EncoderParams::RateControl::cqp;
+    else if (rate_control == "vbr")
+        encode_params.rate_control = EncoderParams::RateControl::vbr;
+    else {
+        fprintf(stderr, "fatal: unsupported rate control: %s\n", rc.c_str());
+        exit(1);
+    }
+
+    std::unique_ptr<DTCapture> capture_object = DTCapture::create(capture_params, encode_params);
+    if (capture_object == nullptr) {
+        fprintf(stderr, "fatal: failed to create capture object\n");
+        exit(1);
+    }
+
+    log_capture_params(capture_params);
+    log_encode_params(encode_params);
+    printf("\n"); // step out from params printout
+
+    result = capture_object->start();
+    if (FAILED(result)) {
+        fprintf(stderr, "fatal: failed to start capture\n");
+        exit(1);
+    }
+
+    std::signal(SIGTERM, signal_handler);
+    std::signal(SIGINT, signal_handler);
+
+    {
+        std::unique_lock<std::mutex> lock(g_mutex);
+        g_cv.wait(lock, []{ return g_stop; });
+    }
+    printf("frames: %d\n", num_frames);
+
+    capture_object->stop();
+
+    if (FAILED(result))
+        return 1;
+    return 0;
+}

--- a/sources/apps/screen-grab/screen-grab.rc
+++ b/sources/apps/screen-grab/screen-grab.rc
@@ -1,0 +1,106 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+#include "cg-version.h"
+
+#define DESCRIPTION         "Capture screen and dump encoded bitstream"
+#define INTERNALNAME        "screen-grab.exe"
+#define ORIGINALFILENAME    "screen-grab.exe"
+
+#ifndef _DEBUG
+#define VER_DEBUG   0x00000000L
+#else
+#define VER_DEBUG   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    CG_FILEVERSION
+ PRODUCTVERSION CG_PRODUCTVERSION
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      VER_DEBUG
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_APP
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",        CG_MANUFACTURER
+            VALUE "FileDescription",    DESCRIPTION
+            VALUE "FileVersion",        CG_VERSION_STR
+            VALUE "InternalName",       INTERNALNAME
+            VALUE "LegalCopyright",     CG_LEGALCOPYRIGHT
+            VALUE "OriginalFilename",   ORIGINALFILENAME
+            VALUE "ProductName",        CG_PRODUCTNAME
+            VALUE "ProductVersion",     CG_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/sources/apps/webrtc-client/meson.build
+++ b/sources/apps/webrtc-client/meson.build
@@ -42,7 +42,7 @@ deps = [
 # dependencies search above (due to 'required: true').
 foreach dep : deps
   if not dep.found()
-    warning('webrtc-client will NOT be built because some dependencies are missing')
+    warning('webrtc-client will NOT be built due to missing dependencies')
     summary({'webrtc-client' : false}, bool_yn : true, section: 'Targets')
     subdir_done()
   endif

--- a/sources/encoder/server/meson.build
+++ b/sources/encoder/server/meson.build
@@ -19,6 +19,8 @@ libdrm_dep = dependency('libdrm', required : true)
 libva_dep = dependency('libva', required : true)
 libvhal_dep = dependency('vhal-client', required : true)
 
+summary({'icr_encoder' : true}, bool_yn : true, section: 'Targets')
+
 srcs = files(
   'cli.cpp',
   'display_server.cpp',

--- a/sources/streamer/capture/av-qsv-encoder.cpp
+++ b/sources/streamer/capture/av-qsv-encoder.cpp
@@ -1,0 +1,836 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "av-qsv-encoder.h"
+
+extern "C" {
+#include "libavcodec/avcodec.h"
+#include "libavutil/opt.h"
+#include "libavutil/hwcontext.h"
+#include "libavutil/hwcontext_qsv.h"
+}
+
+#include "mfxdispatcher.h"
+
+#include "dx-utils.h"
+
+#if 1 // [fixme] bitstream dump
+#include <fstream>
+#endif
+
+AVQSVEncoder::~AVQSVEncoder() {
+    // [fixme] destructor
+}
+
+std::unique_ptr<AVQSVEncoder> AVQSVEncoder::create(const EncoderParams& enc_params) {
+    // [fixme] move to separate func
+    // validate enc params
+    if (enc_params.codec == EncoderParams::Codec::unknown) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": codec is not set\n");
+        return nullptr;
+    }
+    if (enc_params.target_bitrate == 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": target bitrate is not set\n");
+        return nullptr;
+    }
+    if (enc_params.frame_rate == 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": frame rate is not set\n");
+        return nullptr;
+    }
+
+    auto instance = std::unique_ptr<AVQSVEncoder>(new AVQSVEncoder);
+    instance->m_desc = enc_params;
+
+    // query target adapter
+    CComPtr<IDXGIAdapter> adapter;
+    HRESULT result = utils::enum_adapter_by_luid(&adapter, enc_params.adapter_luid);
+    if (adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_adapter_by_luid failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_adapter = adapter;
+
+    DXGI_ADAPTER_DESC adapter_desc = {};
+    result = adapter->GetDesc(&adapter_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->GetDesc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_adapter_desc = adapter_desc;
+
+    // check vendor
+    constexpr UINT vendor_intel = 0x8086;
+    if (adapter_desc.VendorId != vendor_intel) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": unsupported adapter, this encoder supports Intel devices only\n");
+        return nullptr;
+    }
+
+    // create d3d11 encoder device
+    result = utils::create_d3d11_device(adapter, &instance->m_device, &instance->m_device_context, &instance->m_device_context_lock);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::create_d3d11_device failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    result = instance->m_device->CreateFence(0, D3D11_FENCE_FLAG_SHARED, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&instance->m_fence));
+    if (FAILED(result) || instance->m_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->CreateFence failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    result = instance->m_fence->CreateSharedHandle(nullptr, GENERIC_ALL, nullptr, &instance->m_fence_shared_handle);
+    if (FAILED(result) || instance->m_fence_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->CreateSharedHandle failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    return instance;
+}
+
+bool AVQSVEncoder::is_format_supported(DXGI_FORMAT format) const {
+    switch (format) {
+    case DXGI_FORMAT_NV12:
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+        return true;
+    }
+    return false;
+}
+
+HRESULT AVQSVEncoder::start() {
+    // do nothing here
+    // encode starts on first frame received
+    return S_OK;
+}
+
+void AVQSVEncoder::stop() {
+    // [fixme] drain encoder
+}
+
+static AVPixelFormat dxgi_format_to_av_pixel_format(DXGI_FORMAT format) {
+    switch (format) {
+    case DXGI_FORMAT_NV12:
+        return AV_PIX_FMT_NV12;
+    case DXGI_FORMAT_B8G8R8A8_UNORM:
+        return AV_PIX_FMT_BGRA;
+    }
+    return AV_PIX_FMT_NONE;
+}
+
+static std::string get_codec_name(const EncoderParams::Codec& codec) {
+    switch (codec) {
+    case EncoderParams::Codec::avc:
+        return "h264_qsv";
+    case EncoderParams::Codec::hevc:
+        return "hevc_qsv";
+    case EncoderParams::Codec::av1:
+        return "av1_qsv";
+    }
+
+    return std::string();
+}
+
+HRESULT AVQSVEncoder::init_av_context(uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format) {
+    // [fixme] cleanup prev context
+
+    // fetch encoder config
+    auto& enc_params = m_desc;
+
+    // init av context
+    int av_error = 0;
+
+    // find codec
+    auto codec_name = get_codec_name(enc_params.codec);
+    if (codec_name.empty()) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": codec is not supported\n");
+        return E_FAIL;
+    }
+
+    const AVCodec* av_codec = avcodec_find_encoder_by_name(codec_name.c_str());
+    if (av_codec == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": avcodec_find_encoder_by_name failed\n");
+        return E_FAIL;
+    }
+
+    // allocate codec context
+    auto av_context = std::unique_ptr<AVCodecContext, utils::deleter::av_context>(avcodec_alloc_context3(av_codec));
+    if (av_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": avcodec_alloc_context3 failed, context is nullptr\n");
+        return E_FAIL;
+    }
+
+    // fill codec params
+    // target bitrate
+    av_context->bit_rate = enc_params.target_bitrate;
+    // gop params
+    av_context->gop_size = enc_params.key_frame_interval;
+    av_context->max_b_frames = 0;
+    // frame rate
+    av_context->time_base = { 1, enc_params.frame_rate };
+    av_context->framerate = { enc_params.frame_rate, 1 };
+    // quality preset
+    av_opt_set(av_context->priv_data, "preset", "medium", 0);
+    // force IDR frame when pict_type is AV_PICTURE_TYPE_I
+    av_opt_set(av_context->priv_data, "forced_idr", "1", 0);
+    // P-ref strategy : 0 - default, 1 - simple, 2 - pyramid
+    av_opt_set(av_context->priv_data, "p_strategy", "1", 0);
+    // B-ref strategy : 0 - default, 1 - off, 2 - pyramid
+    av_opt_set(av_context->priv_data, "b_strategy", "1", 0);
+    // set qsv op queue depth to 1 for low-latency encode
+    av_opt_set(av_context->priv_data, "async_depth", "1", 0);
+    // resolution
+    av_context->width = frame_width;
+    av_context->height = frame_height;
+    // pixel format
+    av_context->pix_fmt = AV_PIX_FMT_QSV;
+    av_context->sw_pix_fmt = dxgi_format_to_av_pixel_format(frame_format);
+
+    // init hw device context
+    HRESULT result = init_av_hw_device_context(&av_context->hw_device_ctx);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": init_av_hw_device_context failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // init hw frame context
+    result = init_av_hw_frames_context(&av_context->hw_frames_ctx, av_context->hw_device_ctx,
+        frame_width, frame_height, frame_format);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": init_av_hw_frames_context failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // init av context
+    av_error = avcodec_open2(av_context.get(), av_codec, nullptr);
+    if (av_error < 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": avcodec_open2 failed, result = %d, what = %s\n", 
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    // set new av context
+    m_av_context.reset();
+    m_av_context = std::move(av_context);
+    // set new frame format
+    m_frame_width = frame_width;
+    m_frame_height = frame_height;
+    m_frame_format = frame_format;
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::init_av_hw_device_context(AVBufferRef** hw_device_ctx) {
+    if (hw_device_ctx == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (*hw_device_ctx != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    auto context = std::unique_ptr<AVBufferRef, utils::deleter::av_buffer_ref>(av_hwdevice_ctx_alloc(AV_HWDEVICE_TYPE_QSV));
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hwdevice_ctx_alloc failed\n");
+        return E_FAIL;
+    }
+
+    AVHWDeviceContext* av_hw_context = reinterpret_cast<AVHWDeviceContext*>(context->data);
+    if (av_hw_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hw_context is nullptr\n");
+        return E_FAIL;
+    }
+
+    AVQSVDeviceContext* av_qsv_context = reinterpret_cast<AVQSVDeviceContext*>(av_hw_context->hwctx);
+    if (av_qsv_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_qsv_context is nullptr\n");
+        return E_FAIL;
+    }
+
+    // init qsv hw device context
+    HRESULT result = init_av_qsv_device_context(av_qsv_context);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": init_av_qsv_device_context failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    int av_error = av_hwdevice_ctx_init(context.get());
+    if (av_error < 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hwdevice_ctx_init failed, result = %d, what = %s\n",
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    *hw_device_ctx = context.release();
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::init_av_hw_frames_context(AVBufferRef** hw_frames_ctx, AVBufferRef* hw_device_ctx,
+    uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format) {
+    // check input arguments
+    if (hw_frames_ctx == nullptr || hw_device_ctx == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (*hw_frames_ctx != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (frame_width == 0 || frame_height == 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // init hw device context
+    auto context = std::unique_ptr<AVBufferRef, utils::deleter::av_buffer_ref>(av_hwframe_ctx_alloc(hw_device_ctx));
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hwframe_ctx_alloc failed\n");
+        return E_FAIL;
+    }
+
+    AVHWFramesContext* av_hw_context = reinterpret_cast<AVHWFramesContext*>(context->data);
+    if (av_hw_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hw_context is nullptr\n");
+        return E_FAIL;
+    }
+
+    av_hw_context->format = AV_PIX_FMT_QSV;
+    av_hw_context->sw_format = dxgi_format_to_av_pixel_format(frame_format);
+    av_hw_context->width = frame_width;
+    av_hw_context->height = frame_height;
+    // QSV encoder uses fixed pool size
+    av_hw_context->initial_pool_size = m_init_pool_size;
+
+    AVQSVFramesContext* av_qsv_context = reinterpret_cast<AVQSVFramesContext*>(av_hw_context->hwctx);
+    if (av_qsv_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_qsv_context is nullptr\n");
+        return E_FAIL;
+    }
+
+    // init qsv hw device context
+    HRESULT result = init_av_qsv_frames_context(av_qsv_context);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": init_av_qsv_frames_context failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    int av_error = av_hwframe_ctx_init(context.get());
+    if (av_error < 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hwframe_ctx_init failed, result = %d, what = %s\n",
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    *hw_frames_ctx = context.release();
+    return S_OK;
+}
+
+namespace utils {
+
+    // return mfxStatus desc string
+    static std::string mfx_status_to_string(mfxStatus mfx_status) {
+        switch (mfx_status) {
+            // success code
+        case MFX_ERR_NONE: return "success";
+            // error codes
+        case MFX_ERR_UNKNOWN: return "unknown error";
+        case MFX_ERR_NULL_PTR: return "null pointer";
+        case MFX_ERR_UNSUPPORTED: return "unsupported feature";
+        case MFX_ERR_MEMORY_ALLOC: return "failed to allocate memory";
+        case MFX_ERR_NOT_ENOUGH_BUFFER: return "insufficient buffer at input/output";
+        case MFX_ERR_INVALID_HANDLE: return "invalid handle";
+        case MFX_ERR_LOCK_MEMORY: return "failed to lock the memory block";
+        case MFX_ERR_NOT_INITIALIZED: return "member function called before initialization";
+        case MFX_ERR_NOT_FOUND: return "object is not found";
+        case MFX_ERR_MORE_DATA: return "expected more data at input";
+        case MFX_ERR_MORE_SURFACE: return "expected more surfaces at output";
+        case MFX_ERR_ABORTED: return "operation aborted";
+        case MFX_ERR_DEVICE_LOST: return "hardware acceleration device lost";
+        case MFX_ERR_INCOMPATIBLE_VIDEO_PARAM: return "incompatible video parameters";
+        case MFX_ERR_INVALID_VIDEO_PARAM: return "invalid video parameters";
+        case MFX_ERR_UNDEFINED_BEHAVIOR: return "undefined behavior";
+        case MFX_ERR_DEVICE_FAILED: return "device operation failure";
+        case MFX_ERR_MORE_BITSTREAM: return "expected more bitstream buffers at output";
+        case MFX_ERR_GPU_HANG: return "device operation failure caused by GPU hang";
+        case MFX_ERR_REALLOC_SURFACE: return "bigger output surface required";
+        case MFX_ERR_RESOURCE_MAPPED: return "write access is already acquired and user requested another write access, or read access with MFX_MEMORY_NO_WAIT flag";
+        case MFX_ERR_NOT_IMPLEMENTED: return "function not implemented";
+            // warnings
+        case MFX_WRN_IN_EXECUTION: return "previous async operation is still executing";
+        case MFX_WRN_DEVICE_BUSY: return "hardware acceleration device is busy";
+        case MFX_WRN_VIDEO_PARAM_CHANGED: return "video parameters changed";
+        case MFX_WRN_PARTIAL_ACCELERATION: return "partial software acceleration is in use";
+        case MFX_WRN_INCOMPATIBLE_VIDEO_PARAM: return "incompatible video parameters";
+        case MFX_WRN_VALUE_NOT_CHANGED: return "value is saturated based on its valid range";
+        case MFX_WRN_OUT_OF_RANGE: return "value is out of range";
+        case MFX_WRN_FILTER_SKIPPED: return "one of requested filters has been skipped";
+        case MFX_ERR_NONE_PARTIAL_OUTPUT: return "frame is not ready, but bitstream contains partial output";
+        case MFX_WRN_ALLOC_TIMEOUT_EXPIRED: return "timeout expired for internal frame allocation";
+            // threading status
+        case MFX_TASK_WORKING: return "task is still executing";
+        case MFX_TASK_BUSY: return "task is waiting for resources";
+            // plugin status
+        case MFX_ERR_MORE_DATA_SUBMIT_TASK: return "return MFX_ERR_MORE_DATA but submit internal asynchronous task";
+        default: break;
+        };
+
+        if (mfx_status > 0)
+            return "unknown warning";
+
+        return "unknown error";
+    }
+
+    namespace deleter {
+
+        // mfxSession deleter for std::unique_ptr
+        struct mfx_session {
+            void operator()(_mfxSession* p) const {
+                mfxStatus mfx_status = MFXClose(p);
+                if (mfx_status != MFX_ERR_NONE)
+                    ga_logger(Severity::ERR, __FUNCTION__ ": MFXClose failed, result = %d\n", mfx_status);
+            }
+        };
+
+        // mfxLoader deleter for std::unique_ptr
+        struct mfx_loader {
+            void operator()(_mfxLoader* p) const {
+                MFXUnload(p);
+            }
+        };
+
+    } // namespace deleter
+
+} // namespace utils
+
+HRESULT AVQSVEncoder::init_av_qsv_device_context(AVQSVDeviceContext* qsv_context) {
+    if (qsv_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    mfxStatus mfx_status = MFX_ERR_NONE;
+
+    // create loader
+    auto mfx_loader = std::unique_ptr<_mfxLoader, utils::deleter::mfx_loader>(MFXLoad());
+    if (mfx_loader == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": MFXLoad failed\n");
+        return E_FAIL;
+    }
+
+    // create mfx config
+    auto mfx_config = MFXCreateConfig(mfx_loader.get());
+    if (mfx_config == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": MFXCreateConfig failed\n");
+        return E_FAIL;
+    }
+
+    // set implementation config
+    // request hardware impl
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U32;
+        mfx_variant.Data.U32 = MFX_IMPL_TYPE_HARDWARE;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxImplDescription.Impl"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set impl type, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+            return E_FAIL;
+        }
+    }
+
+    // request required api version
+    {
+        mfxVersion mfx_version = {};
+        mfx_version.Major = 2;
+        mfx_version.Minor = 0;
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U32;
+        mfx_variant.Data.U32 = mfx_version.Version;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxImplDescription.ApiVersion.Version"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set api version, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+            return E_FAIL;
+        }
+    }
+
+    // request vendor
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U16;
+        mfx_variant.Data.U16 = 0x8086; // Intel device only
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxExtendedDeviceId.VendorID"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set vendor id, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        }
+    }
+
+    // request device id
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U16;
+        mfx_variant.Data.U16 = m_adapter_desc.DeviceId;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxExtendedDeviceId.DeviceID"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set device id, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        }
+    }
+
+    // request adapter luid
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_PTR;
+        mfx_variant.Data.Ptr = &m_adapter_desc.AdapterLuid;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxExtendedDeviceId.DeviceLUID"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set device luid, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        }
+    }
+
+    // request node mask
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U32;
+        mfx_variant.Data.U32 = 0x0001;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxExtendedDeviceId.LUIDDeviceNodeMask"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set device node mask, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        }
+    }
+
+    // request d3d11 acceleration
+    {
+        mfxVariant mfx_variant = {};
+        mfx_variant.Type = MFX_VARIANT_TYPE_U32;
+        mfx_variant.Data.U32 = MFX_ACCEL_MODE_VIA_D3D11;
+        mfx_status = MFXSetConfigFilterProperty(mfx_config, reinterpret_cast<const mfxU8*>("mfxImplDescription.AccelerationMode"), mfx_variant);
+        if (mfx_status != MFX_ERR_NONE) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXSetConfigFilterProperty failed to set device node mask, mfx_status = %d, what = %s\n",
+                mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        }
+    }
+
+    // create session from loader
+    std::unique_ptr<_mfxSession, utils::deleter::mfx_session> mfx_session;
+    for (mfxU32 impl_idx = 0; mfx_status != MFX_ERR_NOT_FOUND; ++impl_idx) {
+        // enumerate all implementations
+        mfxHDL mfx_impl_desc = nullptr;
+        mfx_status = MFXEnumImplementations(mfx_loader.get(), impl_idx, MFX_IMPLCAPS_IMPLDESCSTRUCTURE, &mfx_impl_desc);
+        if (mfx_status != MFX_ERR_NONE) {
+            if (mfx_status != MFX_ERR_NOT_FOUND)
+                ga_logger(Severity::ERR, __FUNCTION__ ": MFXEnumImplementations failed, mfx_status = %d, what = %s\n",
+                    mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+            continue;
+        }
+
+        // create session
+        mfxSession session = nullptr;
+        mfx_status = MFXCreateSession(mfx_loader.get(), impl_idx, &session);
+        if (session != nullptr)
+            mfx_session.reset(session);
+
+        mfxStatus release_status = MFXDispReleaseImplDescription(mfx_loader.get(), mfx_impl_desc);
+        if (release_status != MFX_ERR_NONE)
+            ga_logger(Severity::ERR, __FUNCTION__ ": MFXEnumImplementations failed, mfx_status = %d, what = %s\n",
+                release_status, utils::mfx_status_to_string(release_status).c_str());
+        if (mfx_status == MFX_ERR_NONE)
+            break; // session created
+    }
+
+    // check creation status
+    if (mfx_status != MFX_ERR_NONE) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": MFXCreateSession failed, mfx_status = %d, what = %s\n",
+            mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        return E_FAIL;
+    }
+
+    // query impl version
+    mfxVersion mfx_impl_version = {};
+    mfx_status = MFXQueryVersion(mfx_session.get(), &mfx_impl_version);
+    if (mfx_status != MFX_ERR_NONE) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": MFXQueryVersion failed, mfx_status = %d, what = %s\n",
+            mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        return E_FAIL;
+    }
+
+    // log session
+    ga_logger(Severity::INFO, __FUNCTION__ ": initialized MFX session, api version %d.%d\n",
+        mfx_impl_version.Major, mfx_impl_version.Minor);
+
+    // set device handle
+    mfx_status = MFXVideoCORE_SetHandle(mfx_session.get(), MFX_HANDLE_D3D11_DEVICE, m_device);
+    if (mfx_status != MFX_ERR_NONE) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": MFXVideoCORE_SetHandle failed, mfx_status = %d, what = %s\n",
+            mfx_status, utils::mfx_status_to_string(mfx_status).c_str());
+        return E_FAIL;
+    }
+
+    qsv_context->loader = mfx_loader.release();
+    qsv_context->session = mfx_session.release();
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::init_av_qsv_frames_context(AVQSVFramesContext* qsv_context) {
+    if (qsv_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    qsv_context->frame_type = MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET;
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::copy_src_surface_to_encode(ID3D11Texture2D* dst, ID3D11Texture2D* src) {
+    if (src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src surface is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": dst surface is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    if (m_device_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+    if (m_device_context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context lock is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+
+    D3D11_TEXTURE2D_DESC src_desc = {};
+    src->GetDesc(&src_desc);
+
+    D3D11_TEXTURE2D_DESC dst_desc = {};
+    dst->GetDesc(&dst_desc);
+
+    if (src_desc.Format != dst_desc.Format) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": texture format mismatch\n");
+        return E_INVALIDARG;
+    }
+
+    m_device_context_lock->Enter();
+    if (src_desc.Width == dst_desc.Width && src_desc.Height == dst_desc.Height) {
+        // same size - copy whole resource
+        m_device_context->CopyResource(dst, src);
+    } else {
+        // copy subresource regino
+        m_device_context->CopySubresourceRegion(dst, 0, 0, 0, 0, src, 0, nullptr);
+    }
+    m_device_context_lock->Leave();
+
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::encode_frame(Frame* frame) {
+    // check input args
+    if (frame == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": frame is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    Surface* src_surface = frame->get_surface();
+    if (src_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": surface is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    // check if encoder reset is needed
+    bool av_context_initialized = (m_av_context != nullptr);
+    auto src_surface_width = src_surface->get_width();
+    auto src_surface_height = src_surface->get_height();
+    auto src_surface_format = src_surface->get_format();
+    bool frame_format_changed = src_surface_width != m_frame_width ||
+        src_surface_height != m_frame_height ||
+        src_surface_format != m_frame_format;
+    bool reset_required = !av_context_initialized || frame_format_changed;
+    if (reset_required) {
+        HRESULT result = init_av_context(src_surface_width, src_surface_height, src_surface_format);
+        if (FAILED(result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": init_av_context failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+    }
+
+    if (m_device_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+    if (m_device_context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context lock is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+
+    // wait source surface
+    m_device_context_lock->Enter();
+    HRESULT result = src_surface->wait_gpu_event_gpu(m_device_context);
+    m_device_context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_fence_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Texture2D> src_texture;
+    result = src_surface->open_shared_texture(m_device, &src_texture);
+    if (FAILED(result) || src_texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_texture failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // alloc av frame
+    auto av_frame = std::unique_ptr<AVFrame, utils::deleter::av_frame>(av_frame_alloc());
+    if (av_frame == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_frame_alloc failed\n");
+        return E_FAIL;
+    }
+
+    // fetch encoder surface
+    int av_error = av_hwframe_get_buffer(m_av_context->hw_frames_ctx, av_frame.get(), 0);
+    if (av_error < 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_hwframe_get_buffer failed, result = %d, what = %s\n",
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    // fetch d3d11 texture from encoder surface
+    mfxFrameSurface1* mfx_surface = reinterpret_cast<mfxFrameSurface1*>(av_frame->data[3]);
+    if (mfx_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": mfx_surface is nullptr\n");
+        return E_FAIL;
+    }
+
+    mfxHDLPair* mfx_hdl_pair = reinterpret_cast<mfxHDLPair*>(mfx_surface->Data.MemId);
+    if (mfx_hdl_pair == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": mfx_hdl_pair is nullptr\n");
+        return E_FAIL;
+    }
+
+    ID3D11Texture2D* enc_texture = reinterpret_cast<ID3D11Texture2D*>(mfx_hdl_pair->first);
+    if (enc_texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": enc_texture is nullptr\n");
+        return E_FAIL;
+    }
+
+    // copy input surface to encode
+    result = copy_src_surface_to_encode(enc_texture, src_texture);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": copy_src_surface_to_encode is nullptr\n");
+        return E_FAIL;
+    }
+
+    // signal gpu fence
+    m_device_context_lock->Enter();
+    auto fence_value = InterlockedIncrement(&m_fence_value);
+    result = m_device_context->Signal(m_fence, fence_value);
+    m_device_context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->Signal failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = src_surface->signal_gpu_event(m_fence, m_fence_shared_handle, fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->signal_gpu_event failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // signal context to wait on copy before submitting encode
+    m_device_context_lock->Enter();
+    result = m_device_context->Wait(m_fence, fence_value);
+    m_device_context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->Wait failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // allocate new packet
+    auto av_packet = std::unique_ptr<AVPacket, utils::deleter::av_packet>(av_packet_alloc());
+    if (av_packet == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": av_packet_alloc failed\n");
+        return E_FAIL;
+    }
+
+    // insert keyframe if nessesary
+    if (m_insert_key_frame) {
+        av_frame->pict_type = AV_PICTURE_TYPE_I;
+        m_insert_key_frame = 0;
+    } else {
+        av_frame->pict_type = AV_PICTURE_TYPE_P;
+    }
+
+    // encode frame
+    av_error = avcodec_send_frame(m_av_context.get(), av_frame.get());
+    if (av_error < 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": avcodec_send_frame failed, result = %d, what = %s\n",
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    // receive packets if any, avcodec_receive_packet() will return EAGAIN if there are no outstanding packets
+    std::unique_lock queue_lk(m_packet_queue_lock);
+    for (av_error = 0; av_error >= 0; /* empty */) {
+        av_error = avcodec_receive_packet(m_av_context.get(), av_packet.get());
+        if (av_error >= 0) {
+            // drop packets if queue is full
+            if (m_packet_queue.size() > m_packet_queue_max_size) {
+                ga_logger(Severity::WARNING, __FUNCTION__ ": encoded frame dropped, output queue is full\n");
+                // insert keyframe to avoid missing refs
+                m_insert_key_frame = 1;
+                continue;
+            }
+
+            // push packet to queue
+            Packet packet = {};
+            packet.data.assign(av_packet->data, av_packet->data + av_packet->size);
+            if (av_packet->flags & AV_PKT_FLAG_KEY)
+                packet.flags = Packet::flag_keyframe;
+            m_packet_queue.push_back(packet);
+        }
+    }
+    queue_lk.unlock();
+    m_packet_queue_cv.notify_one();
+
+    // check avcodec_receive_packet for error
+    if (av_error < 0 && av_error != AVERROR(EAGAIN)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": avcodec_receive_packet failed, result = %d, what = %s\n",
+            av_error, utils::av_error_to_string(av_error).c_str());
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT AVQSVEncoder::receive_packet(Packet& packet, UINT timeout_ms) {
+    // wait for new packet in queue
+    std::unique_lock queue_lk(m_packet_queue_lock);
+    auto timeout = std::chrono::milliseconds(timeout_ms);
+    auto signalled = m_packet_queue_cv.wait_for(queue_lk, timeout, [&]() -> bool { return !m_packet_queue.empty(); });
+    if (!signalled)
+        return DXGI_ERROR_WAIT_TIMEOUT;
+
+    packet = std::move(m_packet_queue.front());
+    m_packet_queue.pop_front();
+    queue_lk.unlock();
+
+    return S_OK;
+}
+
+void AVQSVEncoder::request_key_frame() {
+    m_insert_key_frame.store(1);
+}

--- a/sources/streamer/capture/av-qsv-encoder.h
+++ b/sources/streamer/capture/av-qsv-encoder.h
@@ -1,0 +1,231 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "av-utils.h"
+#include "frame.h"
+#include "encoder.h"
+
+#include <dxgi.h>
+#include <d3d11_4.h>
+#include <atlcomcli.h>
+
+#include <mutex>
+#include <fstream>
+#include <deque>
+
+struct AVCodecContext; // forward decl
+struct AVBufferRef; // forward decl
+struct AVQSVDeviceContext; // forward decl
+struct AVQSVFramesContext; // forward decl
+
+/**
+ * @brief      This class describes FFmpeg QSV video encoder implementation
+ */
+class AVQSVEncoder : public Encoder {
+public:
+    virtual ~AVQSVEncoder();
+
+    /**
+     * @brief      Create encoder instance
+     *
+     * @param[in]  enc_params  encoder parameters
+     *
+     * @return     encoder object, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<AVQSVEncoder> create(const EncoderParams& enc_params);
+
+    /**
+     * @brief      returns true if input frame format is supported
+     *             supported formats:
+     *             - DXGI_FORMAT_NV12
+     *             - DXGI_FORMAT_B8G8R8A8_UNORM
+     *
+     * @param[in]  format  DXGI format
+     *
+     * @return     true, if the specified format is format supported
+     *             false, otherwise
+     */
+    bool is_format_supported(DXGI_FORMAT format) const override;
+
+    /**
+     * @brief      Start encoder
+     *
+     * @return     0, on success
+     *             HRESULT, om error
+     */
+    HRESULT start() override;
+
+    /**
+     * @brief      Stop encoder
+     */
+    void stop() override;
+
+    /**
+     * @brief      Encode one frame
+     *
+     * @param[in]  frame  frame object
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT encode_frame(Frame* frame) override;
+
+    /**
+     * @brief      Receive bitstream packet
+     *
+     * @param[out] packet      bitstream packet
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new packet arrives
+     *             E_FAIL, on error
+     */
+    HRESULT receive_packet(Packet& packet, UINT timeout_ms) override;
+
+    /**
+     * @brief      Signal encoder to insert a key frame
+     */
+    void request_key_frame() override;
+
+private:
+    AVQSVEncoder() = default;
+
+    /**
+     * @brief      Create and initialize top-level AV codec context.
+     *             This function will call the following methods to initialize
+     *             hardware-specific state:
+     *             init_av_hw_device_context()
+     *             init_av_hw_frames_context()
+     *             init_av_qsv_device_context()
+     *             init_av_qsv_frames_context()
+     *
+     * @param[in]  frame_width   frame width
+     * @param[in]  frame_height  frame height
+     * @param[in]  frame_format  frame format
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if one or more input args are invalid
+     *             E_FAIL, on error
+     */
+    HRESULT init_av_context(uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format);
+
+    /**
+     * @brief      Create and initialize AV hardware device context
+     *             *hw_device_ctx must be nullptr.
+     *
+     * @param[out] hw_device_ctx  pointer to AVBufferRef*
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if hw_device_ctx is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT init_av_hw_device_context(AVBufferRef** hw_device_ctx);
+
+    /**
+     * @brief      Create and initialize AV hardware frame context
+     *             *hw_frames_ctx must be nullptr.
+     *             frame_width must be greater 0
+     *             frame_height must be greater 0
+     *
+     * @param[out] hw_frames_ctx  pointer to AVBufferRef*
+     * @param[in]  hw_device_ctx  AV hardware device context
+     * @param[in]  frame_width    frame width
+     * @param[in]  frame_height   frame height
+     * @param[in]  frame_format   frame format
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if hw_frames_ctx or hw_device_ctx is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT init_av_hw_frames_context(AVBufferRef** hw_frames_ctx, AVBufferRef* hw_device_ctx,
+        uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format);
+
+    /**
+     * @brief      Initialize QSV-specific device context
+     *
+     * @param      qsv_context  pointer to AVQSVDeviceContext
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT init_av_qsv_device_context(AVQSVDeviceContext* qsv_context);
+
+    /**
+     * @brief      Initialize QSV-specific frame context
+     *
+     * @param      qsv_context  pointer to AVQSVFramesContext
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT init_av_qsv_frames_context(AVQSVFramesContext* qsv_context);
+
+    /**
+     * @brief      Copy input surface to encode buffer
+     *
+     * @param      dst   encode surface
+     * @param      src   source surface
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if src or dst is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT copy_src_surface_to_encode(ID3D11Texture2D* dst, ID3D11Texture2D* src);
+
+private:
+    // encoder parameters
+    EncoderParams m_desc = {};
+
+    // adapter to run encode
+    DXGI_ADAPTER_DESC m_adapter_desc = {};
+    CComPtr<IDXGIAdapter> m_adapter;
+
+    // D3D11 device and context to run encode
+    CComPtr<ID3D11Device5> m_device;
+    CComPtr<ID3D11DeviceContext4> m_device_context;
+    CComPtr<ID3D11Multithread> m_device_context_lock;
+    CComPtr<ID3D11Fence> m_fence;
+    UINT64 m_fence_value = 0;
+    HANDLE m_fence_shared_handle = nullptr;
+
+    // top-level AV codec context
+    std::unique_ptr<AVCodecContext, utils::deleter::av_context> m_av_context;
+
+    // input frame desc
+    uint32_t m_frame_width = 0;
+    uint32_t m_frame_height = 0;
+    DXGI_FORMAT m_frame_format = DXGI_FORMAT_UNKNOWN;
+
+    // output bitstream packet queue
+    std::mutex m_packet_queue_lock;
+    std::condition_variable m_packet_queue_cv;
+    std::deque<Packet> m_packet_queue;
+
+    // signal to insert keyframe
+    std::atomic<int> m_insert_key_frame = 0;
+
+    // initial encode surface pool size
+    static constexpr uint32_t m_init_pool_size = 8;
+    // max time to wait on source surface
+    static constexpr uint32_t m_src_wait_timeout_ms = 500;
+    // maximum size for output packet queue
+    static constexpr uint32_t m_packet_queue_max_size = 4;
+};

--- a/sources/streamer/capture/av-utils.cpp
+++ b/sources/streamer/capture/av-utils.cpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "av-utils.h"
+
+extern "C" {
+#include "libavcodec/avcodec.h"
+} // extern "C"
+
+void utils::deleter::av_context::operator()(AVCodecContext* p) const {
+    AVCodecContext* tmp = p;
+    avcodec_free_context(&tmp);
+};
+
+void utils::deleter::av_buffer_ref::operator()(AVBufferRef* p) const {
+    AVBufferRef* tmp = p;
+    av_buffer_unref(&tmp);
+};
+
+void utils::deleter::av_frame::operator()(AVFrame* p) const {
+    AVFrame* tmp = p;
+    av_frame_free(&tmp);
+}
+
+void utils::deleter::av_packet::operator()(AVPacket* p) const {
+    AVPacket* tmp = p;
+    av_packet_free(&tmp);
+}
+
+std::string utils::av_error_to_string(int av_error) {
+    if (av_error >= 0)
+        return "success";
+
+    std::string error_str(AV_ERROR_MAX_STRING_SIZE, '\0');
+    auto result = av_strerror(av_error, error_str.data(), error_str.length());
+    if (result < 0)
+        return std::string("unknown error");
+
+    return error_str;
+}

--- a/sources/streamer/capture/av-utils.h
+++ b/sources/streamer/capture/av-utils.h
@@ -1,0 +1,57 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+extern "C" {
+    // forward decl
+    struct AVBufferRef;
+    struct AVCodecContext;
+    struct AVFrame;
+    struct AVPacket;
+};
+
+namespace utils {
+    namespace deleter {
+
+        // AVCodecContext deleter for std::unique_ptr
+        struct av_context {
+            void operator()(AVCodecContext* p) const;
+        };
+
+        // AVBufferRef deleter for std::unique_ptr
+        struct av_buffer_ref {
+            void operator()(AVBufferRef* p) const;
+        };
+
+        // AVFrame deleter for std::unique_ptr
+        struct av_frame {
+            void operator()(AVFrame* p) const;
+        };
+
+        // AVPacket deleter for std::unique_ptr
+        struct av_packet {
+            void operator()(AVPacket* p) const;
+        };
+
+    }; // namespace deleter
+
+    // return error desc for av_result
+    std::string av_error_to_string(int av_error);
+
+}; // namespace utils

--- a/sources/streamer/capture/cursor-provider.h
+++ b/sources/streamer/capture/cursor-provider.h
@@ -1,0 +1,60 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "frame.h"
+
+#include <memory>
+#include <vector>
+
+struct CursorState {
+    // cursor presence on the screen
+    bool visible;
+    // cursor shape is always R8G8B8A8
+    bool shape_present;
+    uint32_t shape_width;
+    uint32_t shape_height;
+    uint32_t shape_pitch;
+    // shape data - size is (height * pitch)
+    // shape data - normal color (use alpha blend for rendering)
+    std::vector<unsigned char> shape_data;
+    // shape data - inverted color (use invert blend for rendering)
+    std::vector<unsigned char> shape_xor_data;
+};
+
+/**
+ * @brief      This class describes generic cursor provider interface.
+ *             User can obtain cursor state calling receive_cursor() in a loop.
+ */
+struct CursorProvider {
+    
+    virtual ~CursorProvider() = default;
+
+    /**
+     * @brief      Block thread and wait for cursor update.
+     *             If timeout is 0 - return state immediately.
+     *             Called by user to acquire cursor state.
+     *
+     * @param      cursor_desc  cursor description
+     * @param[in]  timeout_ms   timeout in milliseconds
+     *
+     * @return     0 and cursor state, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new frame arrives
+     *             E_FAIL, on error
+     */
+    virtual HRESULT receive_cursor(CursorState& cursor_state, UINT timeout_ms) = 0;
+};

--- a/sources/streamer/capture/cursor-receiver.cpp
+++ b/sources/streamer/capture/cursor-receiver.cpp
@@ -1,0 +1,118 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "cursor-receiver.h"
+
+#include <chrono>
+
+CursorReceiver::~CursorReceiver() {
+    stop();
+}
+
+std::unique_ptr<CursorReceiver> CursorReceiver::create(CursorReceiverParams& params) {
+    auto instance = std::unique_ptr<CursorReceiver>(new CursorReceiver());
+
+    // set cursor config
+    instance->m_params = params;
+
+    return instance;
+}
+
+HRESULT CursorReceiver::register_cursor_provider(std::shared_ptr<CursorProvider> provider) {
+    std::lock_guard lk(m_acquire_lock);
+    // do not register if thread is already active
+    if (m_keep_alive)
+        return E_ACCESSDENIED;
+
+    m_provider = provider;
+    return S_OK;
+}
+
+HRESULT CursorReceiver::start() {
+    std::lock_guard lk(m_acquire_lock);
+    // do not start if thread is already active
+    if (m_keep_alive)
+        return S_OK;
+
+    // check capture source
+    if (m_provider == nullptr) {
+        ga_logger(Severity::ERR, "cursor capture provider is nullptr\n");
+        return E_FAIL;
+    }
+
+    // create thread
+    m_keep_alive = true;
+    m_thread = std::move(std::thread(CursorReceiver::thread_proc, this));
+    return S_OK;
+}
+
+void CursorReceiver::stop() {
+    std::unique_lock lk(m_acquire_lock);
+    if (!m_keep_alive)
+        return; // thread is not active
+
+    // signal thread to stop
+    m_keep_alive = false;
+    // wait for completion
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+HRESULT CursorReceiver::thread_proc(CursorReceiver* context) {
+    using namespace std::chrono_literals;
+
+    struct LogThreadLifetime {
+        LogThreadLifetime() { ga_logger(Severity::INFO, "CursorReceiver thread started\n"); }
+        ~LogThreadLifetime() { ga_logger(Severity::INFO, "CursorReceiver thread stoped\n"); }
+    } log_thread_lifetime;
+
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // check capture source
+    if (context->m_provider == nullptr) {
+        context->on_error(__FUNCTION__ ": cursor capture provider is nullptr", E_INVALIDARG);
+        ga_logger(Severity::ERR, __FUNCTION__ ": cursor capture provider is nullptr\n");
+        return E_FAIL;
+    }
+
+    // cursor state
+    CursorState state = {};
+
+    // capture initial state
+    context->m_provider->receive_cursor(state, 0);
+
+    const unsigned int timeout_ms = 100; // capture timeout
+    while (context->keep_alive()) {
+        HRESULT wait_result = context->m_provider->receive_cursor(state, timeout_ms);
+        if (wait_result == DXGI_ERROR_WAIT_TIMEOUT)
+            continue; // timed out - try again
+        else if (FAILED(wait_result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": capture cursor failed, result = 0x%08x\n", wait_result);
+            context->on_error(__FUNCTION__ ": capture cursor failed", wait_result);
+            continue;
+        }
+
+        // notify client that packet is ready
+        if (context->m_params.on_cursor_received) {
+            context->m_params.on_cursor_received(state);
+        }
+    }
+
+    return S_OK;
+}

--- a/sources/streamer/capture/cursor-receiver.h
+++ b/sources/streamer/capture/cursor-receiver.h
@@ -1,0 +1,93 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+#include "cursor-provider.h"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+struct CursorReceiverParams {
+    // notification callback that next cursor is ready
+    std::function<void(const CursorState&)> on_cursor_received;
+    // notification callback that some error has occurred
+    std::function<void(const std::string&, HRESULT)> on_error;
+};
+
+class CursorReceiver {
+public:
+    virtual ~CursorReceiver();
+
+    /**
+     * @brief      Create instance
+     *
+     * @return     pointer to new instance, on success
+     *             nullptr, on failure
+     */
+    static std::unique_ptr<CursorReceiver> create(CursorReceiverParams& params);
+
+    /**
+     * @brief      Register cursor capture callback
+     *
+     * @param[in]  callback  pointer to cursor capture callback
+     *
+     * @return     0, on success
+     *             HRESULT, on error
+     */
+    HRESULT register_cursor_provider(std::shared_ptr<CursorProvider> provider);
+
+    /**
+     * @brief      Start cursor receiver
+     *
+     * @return     0, on success
+     *             HRESULT, on error
+     */
+    HRESULT start();
+
+    /**
+     * @brief      Stop cursor receiver
+     */
+    void stop();
+
+private:
+    CursorReceiver() = default;
+
+    bool keep_alive() const { return m_keep_alive.load(); }
+
+    static HRESULT thread_proc(CursorReceiver* context);
+
+    void on_error(std::string msg, HRESULT res) const {
+        if (m_params.on_error)
+            m_params.on_error(std::move(msg), res);
+    }
+
+private:
+    // cursor receiver parameters
+    CursorReceiverParams m_params = {};
+
+    std::thread m_thread;
+    std::atomic<int> m_keep_alive = false;
+
+    std::mutex m_acquire_lock;
+
+    std::shared_ptr<CursorProvider> m_provider = nullptr;
+};

--- a/sources/streamer/capture/desktop-duplicator.cpp
+++ b/sources/streamer/capture/desktop-duplicator.cpp
@@ -1,0 +1,635 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "desktop-duplicator.h"
+
+#include "dx-utils.h"
+#include "dx11-surface-pool.h"
+
+#include <chrono>
+
+DesktopDuplicator::~DesktopDuplicator() {
+    stop();
+
+    if (m_copy_fence_shared_handle)
+        CloseHandle(m_copy_fence_shared_handle);
+}
+
+std::unique_ptr<DesktopDuplicator> DesktopDuplicator::create(const std::wstring& display_device_name) {
+
+    auto instance = std::unique_ptr<DesktopDuplicator>(new DesktopDuplicator);
+
+    HRESULT result = S_OK;
+    
+    // get adapter and output from display device name
+    CComPtr<IDXGIAdapter> adapter;
+    CComPtr<IDXGIOutput> output;
+    result = utils::enum_adapter_by_display_name(&adapter, &output, display_device_name);
+    if (result == DXGI_ERROR_NOT_FOUND) {
+        // if not found try primary display
+        result = utils::enum_primary_display(&adapter, &output);
+        if (FAILED(result) || adapter == nullptr || output == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_primary_display failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+
+        ga_logger(Severity::WARNING, __FUNCTION__ ": display device = %S is not found - using primary display\n", display_device_name.c_str());
+    } else if (FAILED(result) || adapter == nullptr || output == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_adapter_by_display_name failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // query required interface
+    CComPtr<IDXGIOutput1> output1;
+    result = output->QueryInterface<IDXGIOutput1>(&output1);
+    if (FAILED(result) || output1 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutput1->QueryInterface failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    instance->m_adapter = adapter;
+    instance->m_output = output1;
+
+    // query adapter/output desc
+    DXGI_ADAPTER_DESC adapter_desc = {};
+    result = adapter->GetDesc(&adapter_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->GetDesc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    DXGI_OUTPUT_DESC output_desc = {};
+    result = output->GetDesc(&output_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutput->GetDesc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // log adapter/ouput pair
+    ga_logger(Severity::INFO, __FUNCTION__ ": found output with device name = %S, parent adapter = %S, LUID = 0x%x:0x%x\n",
+        output_desc.DeviceName, adapter_desc.Description,
+        adapter_desc.AdapterLuid.HighPart,
+        adapter_desc.AdapterLuid.LowPart);
+
+    instance->m_adapter_desc = adapter_desc;
+    instance->m_output_desc = output_desc;
+
+    // create duplication device
+    result = utils::create_d3d11_device(adapter, &instance->m_device, &instance->m_device_context, &instance->m_device_context_lock);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::create_d3d11_device failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    if (instance->m_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return nullptr;
+    }
+
+    // create fence
+    result = instance->m_device->CreateFence(0, D3D11_FENCE_FLAG_SHARED, 
+        __uuidof(ID3D11Fence), reinterpret_cast<void**>(&instance->m_copy_fence));
+    if (FAILED(result) || instance->m_copy_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device5->CreateFence failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    result = instance->m_copy_fence->CreateSharedHandle(nullptr, GENERIC_ALL, nullptr, &instance->m_copy_fence_shared_handle);
+    if (FAILED(result) || instance->m_copy_fence_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->CreateSharedHandle failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    return instance;
+}
+
+HRESULT DesktopDuplicator::start() {
+    // start capture thread
+    m_keep_alive = 1;
+    m_thread = std::move(std::thread(DesktopDuplicator::thread_proc, this));
+    return S_OK;
+}
+
+void DesktopDuplicator::stop() {
+    // stop capture thread
+    m_keep_alive = 0;
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+HRESULT DesktopDuplicator::thread_proc(DesktopDuplicator* context) {
+    using namespace std::chrono_literals;
+    using namespace std::chrono;
+
+    struct LogThreadLifetime {
+        LogThreadLifetime() { ga_logger(Severity::INFO, "DesktopDuplicator thread started\n"); }
+        ~LogThreadLifetime() { ga_logger(Severity::INFO, "DesktopDuplicator thread stoped\n"); }
+    } log_thread_lifetime;
+
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    HRESULT result = S_OK;
+
+    const auto reset_retry_timeout = milliseconds(500);
+    const auto acq_frame_timeout = milliseconds(500);
+
+    bool reset_required = true;
+    int reset_attempt_count = 0;
+    constexpr int max_reset_attempts = 20;
+
+    // capture loop
+    while (context->keep_alive()) {
+        // check if reset is required
+        if (reset_required) {
+            // max reset attempts reached - exit
+            if (reset_attempt_count > max_reset_attempts)
+                break;
+
+            // yield thread to allow DWM transition
+            auto awake_time = steady_clock::now() + reset_retry_timeout;
+            std::this_thread::sleep_until(awake_time);
+
+            // perform reset
+            result = context->reset();
+            if (FAILED(result)) {
+                // reset failed - try again
+                ga_logger(Severity::ERR, __FUNCTION__ ": DesktopDuplicator->reset failed, result = 0x%08x\n", result);
+                reset_attempt_count++;
+                continue;
+            } else {
+                // reset succeeded
+                reset_required = false;
+                reset_attempt_count = 0;
+            }
+        }
+
+        // request new frame
+        const UINT acq_frame_timeout_ms = duration_cast<milliseconds>(acq_frame_timeout).count();
+        result = context->acquire_surface(acq_frame_timeout_ms);
+        if (result == DXGI_ERROR_WAIT_TIMEOUT) {
+            continue; // timeout, no new frame - try again
+        } else if (FAILED(result)) {
+            reset_required = true;
+            continue; // try reset
+        }
+
+        // stage copy
+        result = context->copy_surface();
+        if (FAILED(result)) {
+            // other error - try reset
+            reset_required = true;
+            continue;
+        }
+
+        // release frame
+        result = context->release_surface();
+        if (FAILED(result)) {
+            // output mode change - reset
+            reset_required = true;
+            continue;
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::reset() {
+    // reset duplication objects
+    m_duplication = nullptr;
+    m_duplication_desc = {};
+
+    if (m_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_output == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": output is nullptr\n");
+        return E_FAIL;
+    }
+
+    CComPtr<IDXGIOutputDuplication> duplication;
+    HRESULT result = m_output->DuplicateOutput(m_device, &duplication);
+    if (FAILED(result) || duplication == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutput1->DuplicateOutput failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    DXGI_OUTDUPL_DESC duplication_desc = {};
+    duplication->GetDesc(&duplication_desc);
+
+    m_duplication = duplication;
+    m_duplication_desc = duplication_desc;
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::acquire_surface(UINT timeout_ms) {
+    if (m_duplication == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": duplication object is nullptr\n");
+        return E_FAIL;
+    }
+
+    // acquire next frame
+    CComPtr<IDXGIResource> resource;
+    DXGI_OUTDUPL_FRAME_INFO frame_info = {};
+
+    HRESULT result = m_duplication->AcquireNextFrame(timeout_ms, &frame_info, &resource);
+    if (result == DXGI_ERROR_ACCESS_LOST)
+        return DXGI_ERROR_ACCESS_LOST; // mode changed, reset needed
+    else if (result == DXGI_ERROR_WAIT_TIMEOUT)
+        return DXGI_ERROR_WAIT_TIMEOUT; // timeout
+    else if (FAILED(result) || resource == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutputDuplication->AcquireNextFrame failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // query d3d11 texture interface
+    CComPtr<ID3D11Texture2D> texture;
+    result = resource->QueryInterface<ID3D11Texture2D>(&texture);
+    if (FAILED(result) || texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Texture2D->QueryInterface failed, result = 0x%08x\n", result);
+        std::ignore = m_duplication->ReleaseFrame();
+        return E_FAIL;
+    }
+
+    // update input texture
+    m_desktop_texture = texture;
+
+    // update cursor
+    update_cursor_visibility(frame_info);
+    update_cursor_shape(frame_info);
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::copy_surface() {
+    if (m_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+    if (m_device_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+    if (m_device_context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context lock is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+
+    CComPtr<ID3D11Texture2D> src = m_desktop_texture;
+    if (src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src texture is nullptr\n");
+        return E_FAIL;
+    }
+
+    HRESULT result = S_OK;
+
+    D3D11_TEXTURE2D_DESC src_desc = {};
+    src->GetDesc(&src_desc);
+
+    // reset dst surface pool if needed
+    bool reset_surface_pool = (m_surface_pool == nullptr);
+    if (m_surface_pool != nullptr) {
+        auto dst_desc = m_surface_pool->get_texture_desc();
+        reset_surface_pool = src_desc.Width != dst_desc.Width
+            || src_desc.Height != dst_desc.Height
+            || src_desc.Format != dst_desc.Format;
+    }
+    if (reset_surface_pool) {
+        // create surface pool
+        DX11SurfacePool::Desc pool_desc = {};
+        pool_desc.device = m_device;
+        pool_desc.texture_desc.Width = src_desc.Width;
+        pool_desc.texture_desc.Height = src_desc.Height;
+        pool_desc.texture_desc.MipLevels = 1;
+        pool_desc.texture_desc.ArraySize = 1;
+        pool_desc.texture_desc.Format = src_desc.Format;
+        pool_desc.texture_desc.SampleDesc.Count = 1;
+        pool_desc.texture_desc.SampleDesc.Quality = 0;
+        pool_desc.texture_desc.Usage = D3D11_USAGE_DEFAULT;
+        pool_desc.texture_desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+        pool_desc.texture_desc.CPUAccessFlags = 0; // no cpu access
+        pool_desc.texture_desc.MiscFlags = D3D11_RESOURCE_MISC_SHARED | D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
+        m_surface_pool = DX11SurfacePool::create(pool_desc);
+        if (m_surface_pool == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": failed to create surface pool, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+    }
+
+    // acquire dst surface
+    auto dst_surface = m_surface_pool->acquire();
+    if (dst_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": DX12SurfacePool->acquire failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Texture2D> dst;
+    result = dst_surface->open_shared_texture(m_device, &dst);
+    if (FAILED(result) || dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": DX12Surface->open_shared_texture failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // stage copy
+    m_device_context_lock->Enter();
+    m_device_context->CopyResource(dst, src);
+    m_device_context->Flush();
+
+    // signal gpu fence
+    auto fence_value = InterlockedIncrement(&m_copy_fence_value);
+    result = m_device_context->Signal(m_copy_fence, fence_value);
+    m_device_context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext4->Signal failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = dst_surface->signal_gpu_event(m_copy_fence, m_copy_fence_shared_handle, fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->signal_gpu_fence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // update capture surface
+    std::unique_lock lk(m_acquire_frame_lock);
+    m_output_frame = Frame::create(std::move(dst_surface), m_surface_pool);
+    lk.unlock();
+    m_acquire_frame_cv.notify_one();
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::release_surface() {
+    m_desktop_texture = nullptr;
+
+    HRESULT result = m_duplication->ReleaseFrame();
+    if (result == DXGI_ERROR_ACCESS_LOST) {
+        return DXGI_ERROR_ACCESS_LOST; // mode changed, reset needed
+    } else if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutputDuplication->ReleaseFrame failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+void DesktopDuplicator::update_cursor_visibility(const DXGI_OUTDUPL_FRAME_INFO& frame_info) {
+    bool prev = m_cursor_state.visible;
+    bool next = frame_info.PointerPosition.Visible;
+    m_cursor_state.visible = next;
+    if (prev != next) {
+        std::unique_lock lk(m_acquire_cursor_lock);
+        m_cursor_visibility_updated = true;
+        lk.unlock();
+        m_acquire_cursor_cv.notify_one();
+    }
+}
+
+void DesktopDuplicator::update_cursor_shape(const DXGI_OUTDUPL_FRAME_INFO& frame_info) {
+    if (m_duplication == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": duplication object is nullptr\n");
+        return;
+    }
+
+    const UINT buffer_size = frame_info.PointerShapeBufferSize;
+    if (buffer_size == 0)
+        return; // no update
+
+    if (m_shape_buffer.size() < buffer_size) {
+        m_shape_buffer.resize(buffer_size);
+    }
+
+    UINT required_size = 0;
+    DXGI_OUTDUPL_POINTER_SHAPE_INFO shape_info = {};
+    HRESULT result = m_duplication->GetFramePointerShape(buffer_size, m_shape_buffer.data(), &required_size, &shape_info);
+    if (FAILED(result)) {
+        ga_logger(Severity::DBG, __FUNCTION__ ": IDXGIOutputDuplication->GetFramePointerShape failed, result = 0x%08x\n", result);
+        return;
+    }
+
+    switch (shape_info.Type) {
+    case DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MONOCHROME:
+        update_cursor_shape_monochrome(m_cursor_state, shape_info, m_shape_buffer);
+        break;
+    case DXGI_OUTDUPL_POINTER_SHAPE_TYPE_COLOR:
+        update_cursor_shape_color(m_cursor_state, shape_info, m_shape_buffer);
+        break;
+    case DXGI_OUTDUPL_POINTER_SHAPE_TYPE_MASKED_COLOR:
+        update_cursor_shape_masked_color(m_cursor_state, shape_info, m_shape_buffer);
+        break;
+    default:
+        ga_logger(Severity::ERR, __FUNCTION__ ": unexpected cursor shape type\n");
+        return;
+    };
+
+    std::unique_lock lk(m_acquire_cursor_lock);
+    m_cursor_shape_updated =
+        m_cursor_state.shape_present != m_output_cursor.shape_present ||
+        m_cursor_state.shape_width != m_output_cursor.shape_width ||
+        m_cursor_state.shape_height != m_output_cursor.shape_height ||
+        m_cursor_state.shape_pitch != m_output_cursor.shape_pitch ||
+        m_cursor_state.shape_data != m_output_cursor.shape_data ||
+        m_cursor_state.shape_xor_data != m_output_cursor.shape_xor_data;
+    m_output_cursor = m_cursor_state;
+    lk.unlock();
+    m_acquire_cursor_cv.notify_one();
+}
+
+HRESULT DesktopDuplicator::update_cursor_shape_monochrome(CursorState& state,
+    const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data) {
+
+    // check args
+    const uint32_t expected_in_data_size = shape_info.Pitch * shape_info.Height;
+    if (shape_data.size() < expected_in_data_size)
+        return E_INVALIDARG;
+
+    const uint32_t width = shape_info.Width;
+    const uint32_t height = shape_info.Height / 2;
+    const uint32_t pitch = shape_info.Width * 4;
+
+    state.shape_present = true;
+    state.shape_width = width;
+    state.shape_height = height;
+    state.shape_pitch = pitch;
+
+    state.shape_data.resize(pitch * height);
+    state.shape_xor_data.resize(pitch * height);
+
+    const uint32_t xor_mask_offset = shape_info.Pitch * shape_info.Height / 2;
+    const uint8_t* src_and = shape_data.data();
+    const uint8_t* src_xor = shape_data.data() + xor_mask_offset;
+    const uint32_t src_pitch = shape_info.Pitch;
+
+    uint8_t* dst_and = state.shape_data.data();
+    uint8_t* dst_xor = state.shape_xor_data.data();
+    const uint32_t dst_pitch = pitch;
+
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            uint32_t bit_off = (x / 8) + y * src_pitch;
+            uint32_t bit_shr = x & 7;
+            uint32_t aa = ((src_and[bit_off] >> bit_shr) & 1);
+            uint32_t xx = ((src_xor[bit_off] >> bit_shr) & 1);
+            uint32_t dst_off = 4 * x + y * dst_pitch;
+
+            if (aa == 0 && xx == 0) {
+                // solid black
+                dst_and[dst_off + 0] = 0;
+                dst_and[dst_off + 1] = 0;
+                dst_and[dst_off + 2] = 0;
+                dst_and[dst_off + 3] = 0xFF;
+                // transparent
+                dst_xor[dst_off + 0] = 0;
+                dst_xor[dst_off + 1] = 0;
+                dst_xor[dst_off + 2] = 0;
+                dst_xor[dst_off + 3] = 0;
+            } else if (aa == 0 && xx == 1) {
+                // solid white
+                dst_and[dst_off + 0] = 0xFF;
+                dst_and[dst_off + 1] = 0xFF;
+                dst_and[dst_off + 2] = 0xFF;
+                dst_and[dst_off + 3] = 0xFF;
+                // transparent
+                dst_xor[dst_off + 0] = 0;
+                dst_xor[dst_off + 1] = 0;
+                dst_xor[dst_off + 2] = 0;
+                dst_xor[dst_off + 3] = 0;
+            } else if (aa == 1 && xx == 0) {
+                // transparent
+                dst_and[dst_off + 0] = 0;
+                dst_and[dst_off + 1] = 0;
+                dst_and[dst_off + 2] = 0;
+                dst_and[dst_off + 3] = 0;
+                // transparent
+                dst_xor[dst_off + 0] = 0;
+                dst_xor[dst_off + 1] = 0;
+                dst_xor[dst_off + 2] = 0;
+                dst_xor[dst_off + 3] = 0;
+            } else /* (aa == 1 && xx == 1) */ {
+                // transparent
+                dst_and[dst_off + 0] = 0;
+                dst_and[dst_off + 1] = 0;
+                dst_and[dst_off + 2] = 0;
+                dst_and[dst_off + 3] = 0;
+                // solid white - invert color
+                dst_xor[dst_off + 0] = 0xFF;
+                dst_xor[dst_off + 1] = 0xFF;
+                dst_xor[dst_off + 2] = 0xFF;
+                dst_xor[dst_off + 3] = 0xFF;
+            }
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::update_cursor_shape_color(CursorState& state,
+    const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data) {
+    // check args
+    const uint32_t expected_in_data_size = shape_info.Pitch * shape_info.Height;
+    if (shape_data.size() < expected_in_data_size)
+        return E_INVALIDARG;
+
+    const uint32_t width = shape_info.Width;
+    const uint32_t height = shape_info.Height;
+    const uint32_t pitch = shape_info.Pitch;
+
+    state.shape_present = true;
+    state.shape_width = width;
+    state.shape_height = height;
+    state.shape_pitch = pitch;
+
+    const uint32_t shape_size = pitch * height;
+    state.shape_data.resize(shape_size);
+    state.shape_xor_data.clear();
+    state.shape_data.assign(shape_data.begin(), shape_data.begin() + shape_size);
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::update_cursor_shape_masked_color(CursorState& state,
+    const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data) {
+    // check args
+    const uint32_t expected_in_data_size = shape_info.Pitch * shape_info.Height;
+    if (shape_data.size() < expected_in_data_size)
+        return E_INVALIDARG;
+
+    const uint32_t width = shape_info.Width;
+    const uint32_t height = shape_info.Height;
+    const uint32_t pitch = shape_info.Pitch;
+
+    state.shape_present = true;
+    state.shape_width = width;
+    state.shape_height = height;
+    state.shape_pitch = pitch;
+
+    const uint32_t shape_size = pitch * height;
+    state.shape_data.resize(shape_size);
+    state.shape_xor_data.resize(shape_size);
+    state.shape_data.assign(shape_data.begin(), shape_data.begin() + shape_size);
+    state.shape_xor_data.assign(shape_data.begin(), shape_data.begin() + shape_size);
+
+    // alpha bits are xor mask - fix alpha channel
+    for (uint32_t y = 0; y < height; ++y) {
+        for (uint32_t x = 0; x < width; ++x) {
+            uint32_t off = (4 * x) + 3 + (y * pitch);
+            state.shape_data[off] = shape_data[off] ? 0 : 0xFF;
+            state.shape_xor_data[off] = shape_data[off] ? 0xFF : 0;
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::receive_frame(std::shared_ptr<Frame>& frame, UINT timeout_ms) {
+    // wait for a new frame
+    std::unique_lock lk(m_acquire_frame_lock);
+    auto timeout = std::chrono::milliseconds(timeout_ms);
+    auto signalled = m_acquire_frame_cv.wait_for(lk, timeout, [&]() -> bool { return m_output_frame != nullptr; });
+    if (!signalled)
+        return DXGI_ERROR_WAIT_TIMEOUT;
+
+    // assign new frame
+    frame = m_output_frame;
+    m_output_frame.reset();
+    return S_OK;
+}
+
+HRESULT DesktopDuplicator::receive_cursor(CursorState& cursor_state, UINT timeout_ms) {
+    // wait for cursor update
+    std::unique_lock lk(m_acquire_cursor_lock);
+    // if timeout is 0 - return state immediately
+    if (timeout_ms == 0) {
+        cursor_state = m_output_cursor;
+        return S_OK;
+    }
+
+    auto timeout = std::chrono::milliseconds(timeout_ms);
+    auto signalled = m_acquire_cursor_cv.wait_for(lk, timeout, [&]() -> bool { 
+        return m_cursor_visibility_updated || m_cursor_shape_updated; 
+    });
+    if (!signalled)
+        return DXGI_ERROR_WAIT_TIMEOUT;
+
+    // assign cursor state
+    cursor_state = m_output_cursor;
+    return S_OK;
+}

--- a/sources/streamer/capture/desktop-duplicator.h
+++ b/sources/streamer/capture/desktop-duplicator.h
@@ -1,0 +1,246 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "frame.h"
+#include "frame-provider.h"
+#include "cursor-provider.h"
+
+#include <atlcomcli.h>
+#include <dxgi1_2.h>
+#include <d3d11_4.h>
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <string>
+
+class DX11SurfacePool; // forward decl
+
+/**
+ * @brief      Frame provider class for a single desktop output duplication.
+ *             This class uses IDXGIOutputDuplication interface to acquire
+ *             desktop texture for futher processing by performing
+ *             the following operations in a loop within a thread:
+ *             1. acquire desktop texture from Desktop Window Manager (DWM)
+ *             2. copy dektop texture to staging texture
+ *             3. release desktop texture
+ *             User can obtain last captured frame by calling receive_frame()
+ *             in a loop. Captured frame has the same size and format as desktop
+ *             texture provided by DWM. Upon receiving a frame user must obtain
+ *             underlying surface by calling Frame::get_surface() and then
+ *             wait on gpu operation completion by calling Surface::wait_gpu_fence_*()
+ *             When desktop display mode is changed this class resets internal
+ *             state to adjust resolution and/or output format.
+ */
+class DesktopDuplicator : public FrameProvider, public CursorProvider {
+public:
+    virtual ~DesktopDuplicator();
+
+    /**
+     * @brief      Create instance from display device name (for ex. "\\.\DISPLAY1")
+     *             representing a single dektop.
+     *             Display device name can be obtained by the following calls
+     *             1. IDXGIOutput->GetDesc() : from DXGI_OUTPUT_DESC struct and DeviceName member
+     *             2. GetMonitorInfo() : from MONITORINFOEXW struct szDevice member
+     *
+     * @param[in]  display_device_name  display device name
+     *
+     * @return     pointer to new instance, on success
+     *             nullptr, on failure
+     */
+    static std::unique_ptr<DesktopDuplicator> create(const std::wstring& display_device_name);
+
+    /**
+     * @brief      Start frame capture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT start() override;
+
+    /**
+     * @brief      Stop frame capture
+     */
+    void stop() override;
+
+    /**
+     * @brief      Block thread and wait for a new frame with timeout.
+     *             Called by user to acquire new frame from display output.
+     *
+     * @param      frame       frame object
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0 and frame object, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new frame arrives
+     *             E_FAIL, on error
+     */
+    HRESULT receive_frame(std::shared_ptr<Frame>& frame, UINT timeout_ms) override;
+
+    /**
+     * @brief      Block thread and wait for cursor update.
+     *             Called by user to acquire cursor state.
+     *
+     * @param      cursor_state  cursor state
+     * @param[in]  timeout_ms    timeout in milliseconds
+     *
+     * @return     0 and cursor description, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new frame arrives
+     *             E_FAIL, on error
+     */
+    HRESULT receive_cursor(CursorState& cursor_state, UINT timeout_ms) override;
+
+    /**
+     * @brief      Returns DXGI adapter connected to display
+     *
+     * @return     IDXGIAdapter interface pointer
+     */
+    IDXGIAdapter* get_display_adapter() const { return m_adapter; }
+
+    /**
+     * @brief      Returns DXGI output used for display
+     *
+     * @return     IDXGIOutput interface pointer
+     */
+    IDXGIOutput* get_display_output() const { return m_output; }
+
+private:
+    DesktopDuplicator() = default;
+
+    bool keep_alive() const { return m_keep_alive.load(); }
+
+    /**
+     * @brief      Thread function for desktop duplication
+     *
+     * @param      context  class interface
+     *
+     * @return     thread exit code
+     *             0, on success
+     *             HRESULT, on error
+     */
+    static HRESULT thread_proc(DesktopDuplicator* context);
+
+    /**
+     * @brief      Reset internal output duplication interface
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT reset();
+
+    /**
+     * @brief      Acquire latest desktop texture from DWM
+     *
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_ACCESS_LOST, if DWM mode changes (for ex.
+     *             resolution change or DWM transitions to fullscreen application)
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses
+     *             before new desktop texture is available
+     *             E_FAIL, on error
+     */
+    HRESULT acquire_surface(UINT timeout_ms);
+
+    /**
+     * @brief      Allocate new surface and copy acquired desktop texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT copy_surface();
+    
+    /**
+     * @brief      Release desktop texture
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_ACCESS_LOST, if DWM mode changes (for ex.
+     *             resolution change or DWM transitions to fullscreen application)
+     *             E_FAIL, on error
+     */
+    HRESULT release_surface();
+
+    void update_cursor_visibility(const DXGI_OUTDUPL_FRAME_INFO& frame_info);
+
+    void update_cursor_shape(const DXGI_OUTDUPL_FRAME_INFO& frame_info);
+
+    HRESULT update_cursor_shape_monochrome(CursorState& desc,
+        const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data);
+
+    HRESULT update_cursor_shape_color(CursorState& desc,
+        const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data);
+
+    HRESULT update_cursor_shape_masked_color(CursorState& desc,
+        const DXGI_OUTDUPL_POINTER_SHAPE_INFO& shape_info, const std::vector<uint8_t>& shape_data);
+
+private:
+    // selected output display device and desc
+    std::wstring m_device_name;
+    CComPtr<IDXGIAdapter> m_adapter;
+    CComPtr<IDXGIOutput1> m_output;
+
+    DXGI_ADAPTER_DESC m_adapter_desc = {};
+    DXGI_OUTPUT_DESC m_output_desc = {};
+
+    // dx11 context used to perform a copy
+    CComPtr<ID3D11Device5> m_device;
+    CComPtr<ID3D11DeviceContext4> m_device_context;
+    CComPtr<ID3D11Multithread> m_device_context_lock;
+    CComPtr<ID3D11Fence> m_copy_fence;
+    HANDLE m_copy_fence_shared_handle = nullptr;
+    UINT64 m_copy_fence_value = 0;
+
+    // output duplication interface
+    CComPtr<IDXGIOutputDuplication> m_duplication;
+    DXGI_OUTDUPL_DESC m_duplication_desc = {};
+
+    // surface pool for output frame
+    std::shared_ptr<DX11SurfacePool> m_surface_pool;
+
+    // desktop texture reference, owned by DWM
+    CComPtr<ID3D11Texture2D> m_desktop_texture;
+
+    // internal cursor state
+    std::atomic<POINT> m_cursor_position = {};
+    CursorState m_cursor_state = {};
+
+    std::vector<uint8_t> m_shape_buffer;
+    std::vector<uint8_t> m_argb_shape_buffer;
+    DXGI_OUTDUPL_POINTER_SHAPE_INFO m_shape_info = {};
+
+    // syncronization for frame receiver
+    std::mutex m_acquire_frame_lock;
+    std::condition_variable m_acquire_frame_cv;
+
+    // latest captured frame
+    std::shared_ptr<Frame> m_output_frame;
+
+    // syncronization for cursor receiver
+    std::mutex m_acquire_cursor_lock;
+    std::condition_variable m_acquire_cursor_cv;
+
+    // latest captured cursor
+    bool m_cursor_visibility_updated = false;
+    bool m_cursor_shape_updated = false;
+    CursorState m_output_cursor = {};
+
+    // processing thread
+    std::thread m_thread;
+    std::atomic<int> m_keep_alive = false;
+};

--- a/sources/streamer/capture/dt-capture.cpp
+++ b/sources/streamer/capture/dt-capture.cpp
@@ -1,0 +1,304 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dt-capture.h"
+
+#include "dx-utils.h"
+#include "desktop-duplicator.h"
+#include "video-processor.h"
+#include "av-qsv-encoder.h"
+
+DTCapture::~DTCapture() {
+    stop();
+}
+
+std::unique_ptr<DTCapture> DTCapture::create(DTCaptureParams& capture_params, EncoderParams& encode_params) {
+    auto instance = std::unique_ptr<DTCapture>(new DTCapture);
+
+    // set capture config
+    instance->m_params = capture_params;
+
+    // create capture object
+    instance->m_duplicator = DesktopDuplicator::create(capture_params.display_device_name);
+    if (instance->m_duplicator == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": DesktopDuplicator->create failed\n");
+        return nullptr;
+    }
+
+    HRESULT result = S_OK;
+
+    // configure processing device
+    CComPtr<IDXGIAdapter> display_adapter = instance->m_duplicator->get_display_adapter();
+    if (display_adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": display adapter is nullptr\n");
+        return nullptr;
+    }
+
+    DXGI_ADAPTER_DESC display_adapter_desc = {};
+    result = display_adapter->GetDesc(&display_adapter_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->GetDesc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    constexpr UINT vendor_intel = 0x8086;
+
+    CComPtr<IDXGIAdapter> encode_adapter;
+    if (display_adapter_desc.VendorId != vendor_intel) {
+        ga_logger(Severity::WARNING, __FUNCTION__ ": encode is supported only on Intel adapters, selecting first Intel device\n");
+        HRESULT result = utils::enum_adapter_by_vendor(&encode_adapter, vendor_intel);
+        if (FAILED(result) || encode_adapter == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_adapter_by_vendor failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+    } else {
+        encode_adapter = display_adapter;
+    }
+
+    DXGI_ADAPTER_DESC encode_adapter_desc = {};
+    result = encode_adapter->GetDesc(&encode_adapter_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->GetDesc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // create video processor
+    VideoProcessor::Desc vp_desc = {};
+    vp_desc.adapter_luid = encode_adapter_desc.AdapterLuid;
+    vp_desc.frame_rate = encode_params.frame_rate;
+    switch (capture_params.output_format) {
+    case DTCaptureParams::OutputFormat::nv12:
+        vp_desc.output_format = DXGI_FORMAT_NV12;
+        break;
+    case DTCaptureParams::OutputFormat::rgb:
+    default:
+        vp_desc.output_format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        break;
+    }
+
+    instance->m_video_processor = VideoProcessor::create(vp_desc);
+    if (instance->m_video_processor == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": VideoProcessor->create failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    result = instance->m_video_processor->register_frame_provider(instance->m_duplicator);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": VideoProcessor->register_frame_provider failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // create encoder
+    encode_params.adapter_luid = vp_desc.adapter_luid;
+    instance->m_encoder = AVQSVEncoder::create(encode_params);
+    if (instance->m_video_processor == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": VideoProcessor->create failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // create cursor receiver
+    CursorReceiverParams cursor_params = {};
+
+    cursor_params.on_error = capture_params.on_error;
+    cursor_params.on_cursor_received = capture_params.on_cursor_received;
+
+    instance->m_cursor_receiver = CursorReceiver::create(cursor_params);
+    if (instance->m_cursor_receiver == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": CursorReceiver->create failed\n");
+        return nullptr;
+    }
+    instance->m_cursor_receiver->register_cursor_provider(instance->m_duplicator);
+
+    return instance;
+}
+
+HRESULT DTCapture::start() {
+    if (m_duplicator == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": capture provider is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_video_processor == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": video processor is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_encoder == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": encoder is nullptr\n");
+        return E_FAIL;
+    }
+
+    HRESULT result = S_OK;
+
+    // start capture
+    result = m_duplicator->start();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": failed to start capture, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // start video processor
+    result = m_video_processor->start();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": failed to start video processor, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    ga_logger(Severity::INFO, __FUNCTION__ ": capture started\n");
+
+    // start encode
+    result = m_encoder->start();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": failed to start encode, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // start cursor receiver
+    result = m_cursor_receiver->start();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": failed to start cursor receiver, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // start threads
+    m_keep_alive = 1;
+    m_capture_thread = std::move(std::thread(DTCapture::capture_thread_proc, this));
+    m_encode_thread = std::move(std::thread(DTCapture::encode_thread_proc, this));
+
+    ga_logger(Severity::INFO, __FUNCTION__ ": encode started\n");
+
+    return S_OK;
+}
+
+void DTCapture::stop() {
+    if (m_duplicator)
+        m_duplicator->stop();
+    if (m_video_processor)
+        m_video_processor->stop();
+
+    ga_logger(Severity::INFO, __FUNCTION__ ": capture stopped\n");
+
+    if (m_encoder)
+        m_encoder->stop();
+    if (m_cursor_receiver)
+        m_cursor_receiver->stop();
+
+    // stop threads
+    m_keep_alive = 0;
+    if (m_capture_thread.joinable())
+        m_capture_thread.join();
+    if (m_encode_thread.joinable())
+        m_encode_thread.join();
+
+    ga_logger(Severity::INFO, __FUNCTION__ ": encode stopped\n");
+}
+
+void DTCapture::on_key_frame_request() {
+    if (m_encoder)
+        m_encoder->request_key_frame();
+}
+
+HRESULT DTCapture::capture_thread_proc(DTCapture* context) {
+    struct LogThreadLifetime {
+        LogThreadLifetime() { ga_logger(Severity::INFO, "DTCapture capture thread started\n"); }
+        ~LogThreadLifetime() { ga_logger(Severity::INFO, "DTCapture capture thread stoped\n"); }
+    } log_thread_lifetime;
+
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    if (context->m_video_processor == nullptr) {
+        context->on_error(__FUNCTION__ ": frame provider object is nullptr", E_INVALIDARG);
+        ga_logger(Severity::ERR, __FUNCTION__ ": frame provider object is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    if (context->m_encoder == nullptr) {
+        context->on_error(__FUNCTION__ ": encoder object is nullptr", E_INVALIDARG);
+        ga_logger(Severity::ERR, __FUNCTION__ ": encoder object is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    const auto video_processor = context->m_video_processor.get();
+    const auto encoder = context->m_encoder.get();
+    const auto capture_timeout_ms = context->m_capture_timeout;
+
+    // capture loop
+    while (context->keep_alive()) {
+        // capture last processed frame
+        std::shared_ptr<Frame> captured_frame;
+        HRESULT capture_result = video_processor->receive_frame(captured_frame, capture_timeout_ms);
+        if (capture_result == DXGI_ERROR_WAIT_TIMEOUT) {
+            continue; // timed out - try again
+        } else if (FAILED(capture_result)) {
+            context->on_error(__FUNCTION__ ": video_processor->receive_frame failed", capture_result);
+            ga_logger(Severity::ERR, __FUNCTION__ ": video_processor->receive_frame failed, result = 0x%08x\n", capture_result);
+            continue;
+        }
+
+        // encode frame
+        auto encode_result = encoder->encode_frame(captured_frame.get());
+        if (FAILED(encode_result)) {
+            context->on_error(__FUNCTION__ ": encoder->encode_frame failed", encode_result);
+            ga_logger(Severity::ERR, __FUNCTION__ ": encoder->encode_frame failed, result = 0x%08x\n", encode_result);
+            continue;
+        }
+    }
+
+    return S_OK;
+}
+
+HRESULT DTCapture::encode_thread_proc(DTCapture* context) {
+    struct LogThreadLifetime {
+        LogThreadLifetime() { ga_logger(Severity::INFO, "DTCapture encode thread started\n"); }
+        ~LogThreadLifetime() { ga_logger(Severity::INFO, "DTCapture encode thread stoped\n"); }
+    } log_thread_lifetime;
+
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    if (context->m_encoder == nullptr) {
+        context->on_error(__FUNCTION__ ": encoder object is nullptr", E_INVALIDARG);
+        ga_logger(Severity::ERR, __FUNCTION__ ": encoder object is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    const auto encoder = context->m_encoder.get();
+    const auto encode_timeout_ms = context->m_encode_timeout;
+
+    // encode loop
+    while (context->keep_alive()) {
+        // receive packet from encoder
+        Packet packet;
+        HRESULT encode_result = encoder->receive_packet(packet, encode_timeout_ms);
+        if (encode_result == DXGI_ERROR_WAIT_TIMEOUT) {
+            continue; // timed out - try again
+        } else if (FAILED(encode_result)) {
+            context->on_error(__FUNCTION__ ": encoder->receive_packet failed", encode_result);
+            ga_logger(Severity::ERR, __FUNCTION__ ": encoder->receive_packet failed, result = 0x%08x\n", encode_result);
+            continue;
+        }
+
+        // notify client that packet is ready
+        if (context->m_params.on_packet_received) {
+            context->m_params.on_packet_received(packet);
+        }
+    }
+
+    return S_OK;
+}

--- a/sources/streamer/capture/dt-capture.h
+++ b/sources/streamer/capture/dt-capture.h
@@ -1,0 +1,154 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "frame-provider.h"
+#include "encoder.h"
+#include "cursor-receiver.h"
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <thread>
+
+class DesktopDuplicator; // forward decl
+class VideoProcessor; // forward decl
+
+struct DTCaptureParams {
+    enum class OutputFormat {
+        rgb,
+        nv12,
+    };
+    
+    // display device name
+    std::wstring display_device_name;
+    // capture output surface format
+    OutputFormat output_format;
+    // notification callback that next packet is ready
+    std::function<void(const Packet& packet)> on_packet_received;
+    // notification callback that next cursor is ready
+    std::function<void(const CursorState&)> on_cursor_received;
+    // notification callback that some error has occurred
+    std::function<void(const std::string&, HRESULT)> on_error;
+};
+
+/**
+ * @brief      This class describes a desktop capture interface
+ */
+class DTCapture {
+public:
+    virtual ~DTCapture();
+
+    /**
+     * @brief      Create new capture instance
+     *             This call may adjust capture or encode params
+     *
+     * @param      capture_params  capture parameters
+     * @param      encode_params   encode parameters
+     *
+     * @return     capture object, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<DTCapture> create(DTCaptureParams& capture_params, EncoderParams& encode_params);
+
+    /**
+     * @brief      Start capture
+     *
+     * @return     0, on success
+     *             HRESULT, on error
+     */
+    HRESULT start();
+
+    /**
+     * @brief      Stop capture
+     */
+    void stop();
+
+    /**
+     * @brief      Callback - request encoder to insert key frame
+     */
+    void on_key_frame_request();
+
+private:
+    DTCapture() = default;
+
+    bool keep_alive() const { return m_keep_alive.load(); }
+
+    /**
+     * @brief      Capture and encode submission thread
+     *
+     * @param      context  DTCapture instance
+     *
+     * @return     thread exit code
+     *             0, on success
+     *             HRESULT, on error
+     */
+    static HRESULT capture_thread_proc(DTCapture* context);
+
+    /**
+     * @brief      Encode receiver thread
+     *
+     * @param      context  DTCapture instance
+     *
+     * @return     thread exit code
+     *             0, on success
+     *             HRESULT, on error
+     */
+    static HRESULT encode_thread_proc(DTCapture* context);
+
+    /**
+     * @brief      Send packet over network
+     *
+     * @param[in]  packet  packet struct
+     *
+     * @return     0, on success
+     *             HRESULT, on error
+     */
+    HRESULT send_packet(const Packet& packet);
+
+    /**
+     * @brief      Safe wrapper to call on_error_cb
+     *
+     * @param[in]  msg  error message
+     * @param[in]  res  error status
+     */
+    void on_error(std::string msg, HRESULT res) const {
+        if (m_params.on_error)
+            m_params.on_error(std::move(msg), res);
+    }
+
+private:
+    // desktop capture parameters
+    DTCaptureParams m_params = {};
+
+    // pipeline objects
+    std::shared_ptr<DesktopDuplicator> m_duplicator;
+    std::unique_ptr<VideoProcessor> m_video_processor;
+    std::unique_ptr<Encoder> m_encoder;
+    std::unique_ptr<CursorReceiver> m_cursor_receiver;
+
+    // timeout config
+    static constexpr UINT m_capture_timeout = 500;
+    static constexpr UINT m_encode_timeout = 500;
+
+    // processing thread
+    std::thread m_capture_thread;
+    std::thread m_encode_thread;
+    std::atomic<int> m_keep_alive = false;
+};

--- a/sources/streamer/capture/dx-utils.cpp
+++ b/sources/streamer/capture/dx-utils.cpp
@@ -1,0 +1,348 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dx-utils.h"
+
+#include <dxgi1_2.h>
+#include <atlcomcli.h>
+
+HRESULT utils::enum_adapter_by_luid(IDXGIAdapter** pp_adapter, const LUID& luid) {
+    if (pp_adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": adapter is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_adapter != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // create factory
+    CComPtr<IDXGIFactory4> factory;
+    HRESULT result = CreateDXGIFactory1(__uuidof(IDXGIFactory4), reinterpret_cast<void**>(&factory));
+    if (FAILED(result) || factory == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateDXGIFactory1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<IDXGIAdapter> adapter;
+    result = factory->EnumAdapterByLuid(luid, __uuidof(IDXGIAdapter), reinterpret_cast<void**>(&adapter));
+    if (FAILED(result) || adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIFactory4->EnumAdapterByLuid failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    *pp_adapter = adapter.Detach();
+    return S_OK;
+}
+
+HRESULT utils::enum_adapter_by_display_name(IDXGIAdapter** pp_adapter, IDXGIOutput** pp_output, const std::wstring& display_device_name) {
+    if (pp_adapter == nullptr && pp_output == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": both adapter and output are nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_adapter != nullptr && *pp_adapter != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (pp_output != nullptr && *pp_output != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // create factory
+    CComPtr<IDXGIFactory1> factory;
+    HRESULT result = CreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory));
+    if (FAILED(result) || factory == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateDXGIFactory1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // find output device and parent adapter matching desc
+    CComPtr<IDXGIAdapter1> adapter;
+    CComPtr<IDXGIOutput> output;
+    for (UINT adapter_idx = 0; SUCCEEDED(factory->EnumAdapters1(adapter_idx, &adapter)); ++adapter_idx) {
+        if (adapter == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIFactory1->EnumAdapters1 failed, adapter_idx = %d, result = 0x%08x\n", adapter_idx, result);
+            return E_FAIL;
+        }
+
+        for (UINT output_idx = 0; SUCCEEDED(adapter->EnumOutputs(output_idx, &output)); ++output_idx) {
+            if (output == nullptr) {
+                ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->EnumOutputs failed, adapter_idx = %d, output_idx = %d, result = 0x%08x\n", adapter_idx, output_idx, result);
+                return E_FAIL;
+            }
+
+            DXGI_OUTPUT_DESC desc = {};
+            result = output->GetDesc(&desc);
+            if (FAILED(result)) {
+                ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIOutput->GetDesc failed, adapter_idx = %d, output_idx = %d, result = 0x%08x\n", adapter_idx, output_idx, result);
+                return E_FAIL;
+            }
+
+            std::wstring device_name(desc.DeviceName);
+            if (display_device_name == device_name)
+                break; // found matching display output
+
+            // reset output
+            output = nullptr;
+        }
+
+        if (output != nullptr)
+            break; // found matching output
+        else
+            adapter = nullptr; // reset adapter
+    }
+
+    if (adapter == nullptr || output == nullptr)
+        return DXGI_ERROR_NOT_FOUND;
+
+    if (pp_adapter != nullptr)
+        *pp_adapter = adapter.Detach();
+    if (pp_output != nullptr)
+        *pp_output = output.Detach();
+
+    return S_OK;
+}
+
+HRESULT utils::enum_adapter_by_vendor(IDXGIAdapter** pp_adapter, UINT vendor_id) {
+    if (pp_adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": adapter is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_adapter != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // create factory
+    CComPtr<IDXGIFactory1> factory;
+    HRESULT result = CreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory));
+    if (FAILED(result) || factory == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateDXGIFactory1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // find output device and parent adapter matching desc
+    CComPtr<IDXGIAdapter1> adapter;
+    for (UINT adapter_idx = 0; SUCCEEDED(factory->EnumAdapters1(adapter_idx, &adapter)); ++adapter_idx) {
+        if (adapter == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIFactory1->EnumAdapters1 failed, adapter_idx = %d, result = 0x%08x\n", adapter_idx, result);
+            return E_FAIL;
+        }
+
+        DXGI_ADAPTER_DESC adapter_desc = {};
+        result = adapter->GetDesc(&adapter_desc);
+        if (adapter_desc.VendorId == vendor_id)
+            break;
+
+        adapter = nullptr; // reset adapter
+    }
+
+    if (adapter == nullptr)
+        return DXGI_ERROR_NOT_FOUND;
+
+    if (pp_adapter != nullptr)
+        *pp_adapter = adapter.Detach();
+
+    return S_OK;
+}
+
+HRESULT utils::enum_primary_display(IDXGIAdapter** pp_adapter, IDXGIOutput** pp_output) {
+    if (pp_adapter == nullptr && pp_output == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": both adapter and output are nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_adapter != nullptr && *pp_adapter != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (pp_output != nullptr && *pp_output != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // create factory
+    CComPtr<IDXGIFactory1> factory;
+    HRESULT result = CreateDXGIFactory1(__uuidof(IDXGIFactory1), reinterpret_cast<void**>(&factory));
+    if (FAILED(result) || factory == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateDXGIFactory1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<IDXGIAdapter1> adapter;
+    result = factory->EnumAdapters1(0, &adapter);
+    if (FAILED(result) || adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIFactory1->EnumAdapters1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<IDXGIOutput> output;
+    result = adapter->EnumOutputs(0, &output);
+    if (FAILED(result) || output == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIFactory1->EnumAdapters1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    if (adapter == nullptr || output == nullptr)
+        return DXGI_ERROR_NOT_FOUND;
+
+    if (pp_adapter != nullptr)
+        *pp_adapter = adapter.Detach();
+    if (pp_output != nullptr)
+        *pp_output = output.Detach();
+
+    return S_OK;
+}
+
+HRESULT utils::create_d3d11_device(IDXGIAdapter* adapter, ID3D11Device5** pp_device, ID3D11DeviceContext4** pp_context, ID3D11Multithread** pp_context_lock) {
+    if (pp_device != nullptr && *pp_device != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (pp_context != nullptr && *pp_context != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    if (pp_context_lock != nullptr && *pp_context_lock != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    CComPtr<ID3D11Device> device;
+    CComPtr<ID3D11DeviceContext> context;
+
+#ifndef NDEBUG
+    UINT device_flags = D3D11_CREATE_DEVICE_DEBUG;
+#else
+    UINT device_flags = 0;
+#endif
+
+    // shared NT handles require feature level 11.1
+    D3D_FEATURE_LEVEL feature_level = D3D_FEATURE_LEVEL_11_1;
+    HRESULT result = D3D11CreateDevice(adapter, D3D_DRIVER_TYPE_UNKNOWN, nullptr /* sw_rasterizer_handle */,
+        device_flags, &feature_level, 1, D3D11_SDK_VERSION, &device,
+        nullptr /* feature_level_out */, &context);
+    if (FAILED(result) || device == nullptr || context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": D3D11CreateDevice failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    feature_level = device->GetFeatureLevel();
+    if (feature_level < D3D_FEATURE_LEVEL_11_1) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": D3D11 device does not support feature level 11.1\n");
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Device5> device5;
+    result = device->QueryInterface<ID3D11Device5>(&device5);
+    if (FAILED(result) || device5 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11DeviceContext4> context4;
+    result = context->QueryInterface<ID3D11DeviceContext4>(&context4);
+    if (FAILED(result) || context4 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // set multithread protection
+    CComPtr<ID3D11Multithread> context_lock;
+    result = context->QueryInterface<ID3D11Multithread>(&context_lock);
+    if (FAILED(result) || context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    std::ignore = context_lock->SetMultithreadProtected(true);
+
+    if (pp_device != nullptr)
+        *pp_device = device5.Detach();
+    if (pp_context != nullptr)
+        *pp_context = context4.Detach();
+    if (pp_context_lock != nullptr)
+        *pp_context_lock = context_lock.Detach();
+
+    return S_OK;
+}
+
+HRESULT utils::create_d3d12_device(IDXGIAdapter* adapter, ID3D12Device** pp_device) {
+    if (pp_device != nullptr && *pp_device != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    CComPtr<ID3D12Device> device;
+    HRESULT result = D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_12_0,
+        __uuidof(ID3D12Device), reinterpret_cast<void**>(&device));
+    if (FAILED(result) || device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": D3D12CreateDevice failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    if (pp_device != nullptr)
+        *pp_device = device.Detach();
+
+    return S_OK;
+}
+
+LUID utils::get_adapter_luid_from_device(ID3D11Device* device) {
+    LUID luid = {};
+
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return luid;
+    }
+
+    CComPtr<IDXGIDevice> dxgi_device;
+    HRESULT result = device->QueryInterface<IDXGIDevice>(&dxgi_device);
+    if (FAILED(result) || dxgi_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+        return luid;
+    }
+
+    CComPtr<IDXGIAdapter> adapter;
+    result = dxgi_device->GetAdapter(&adapter);
+    if (FAILED(result) || adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIDevice->GetAdapter failed, result = 0x%08x\n", result);
+        return luid;
+    }
+
+    DXGI_ADAPTER_DESC adapter_desc = {};
+    result = adapter->GetDesc(&adapter_desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIAdapter->GetDesc failed, result = 0x%08x\n", result);
+        return luid;
+    }
+
+    return adapter_desc.AdapterLuid;
+}
+
+LUID utils::get_adapter_luid_from_device(ID3D12Device* device) {
+    LUID luid = {};
+
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return luid;
+    }
+
+    return device->GetAdapterLuid();
+}
+
+bool utils::is_same_luid(const LUID& lhs, const LUID& rhs) {
+    return lhs.LowPart == rhs.LowPart && lhs.HighPart == rhs.HighPart;
+}

--- a/sources/streamer/capture/dx-utils.h
+++ b/sources/streamer/capture/dx-utils.h
@@ -1,0 +1,127 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include <atlcomcli.h>
+#include <dxgi.h>
+#include <d3d11_4.h>
+#include <d3d12.h>
+
+#include <string>
+
+namespace utils {
+    /**
+     * @brief      Enumerate DXGI adapter matching target LUID
+     *
+     * @param[out] pp_adapter  pointer to DXGI adapter interface
+     * @param[in]  luid        target adapter luid
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT enum_adapter_by_luid(IDXGIAdapter** pp_adapter, const LUID& luid);
+
+    /**
+     * @brief      Enumerate DXGI output and adapter matching display name
+     *
+     * @param[out] pp_adapter           pointer to DXGI adapter interface
+     * @param[out] pp_output            pointer to DXGI output interface
+     * @param[in]  display_device_name  target display device name
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_NOT_FOUND, if output with given display name is not found
+     *             E_FAIL, on error
+     */
+    HRESULT enum_adapter_by_display_name(IDXGIAdapter** pp_adapter, IDXGIOutput** pp_output, 
+        const std::wstring& display_device_name);
+
+    /**
+     * @brief      Enumerate DXGI adapter matching vendor id
+     *
+     * @param[out] pp_adapter  pointer to DXGI adapter interface
+     * @param[in]  vendor_id   vendor identifier
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_NOT_FOUND, if output with given display name is not found
+     *             E_FAIL, on error
+     */
+    HRESULT enum_adapter_by_vendor(IDXGIAdapter** pp_adapter, UINT vendor_id);
+
+    /**
+     * @brief      Enumerate DXGI primary output and adapter
+     *
+     * @param[out] pp_adapter  pointer to DXGI adapter interface
+     * @param[out] pp_output   pointer to DXGI output interface
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_NOT_FOUND, if output with given display name is not found
+     *             E_FAIL, on error
+     */
+    HRESULT enum_primary_display(IDXGIAdapter** pp_adapter, IDXGIOutput** pp_output);
+
+    /**
+     * @brief      Create D3D11 device and context
+     *
+     * @param[in]  adapter          target adapter
+     * @param[out] pp_device        pointer to D3D11 device interface
+     * @param[out] pp_context       pointer to D3D11 device context interface
+     * @param[out] pp_context_lock  pointer to D3D11 device context lock interface
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT create_d3d11_device(IDXGIAdapter* adapter, ID3D11Device5** pp_device,
+        ID3D11DeviceContext4** pp_context, ID3D11Multithread** pp_context_lock);
+
+    /**
+     * @brief      Create D3D12 device and context
+     *
+     * @param[in]  adapter    target adapter
+     * @param[out] pp_device  pointer to D3D12 device interface
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT create_d3d12_device(IDXGIAdapter* adapter, ID3D12Device** pp_device);
+
+    /**
+     * @brief      Get LUID of the adapter associated with device
+     *
+     * @param[in]  device  D3D11 device interface
+     *
+     * @return     adapter luid
+     */
+    LUID get_adapter_luid_from_device(ID3D11Device* device);
+
+    /**
+     * @brief      Get LUID of the adapter associated with device
+     *
+     * @param[in]  device  D3D11 device interface
+     *
+     * @return     adapter luid
+     */
+    LUID get_adapter_luid_from_device(ID3D12Device* device);
+
+    /**
+     * @return     true, if LUIDs are equal
+     *             false, otherwise
+     */
+    bool is_same_luid(const LUID& lhs, const LUID& rhs);
+
+}; // namespace utils

--- a/sources/streamer/capture/dx11-surface-pool.cpp
+++ b/sources/streamer/capture/dx11-surface-pool.cpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dx11-surface-pool.h"
+#include "dx11-surface.h"
+
+std::unique_ptr<DX11SurfacePool> DX11SurfacePool::create(DX11SurfacePool::Desc& desc) {
+    if (desc.device == nullptr)
+        return nullptr;
+
+    auto instance = std::unique_ptr<DX11SurfacePool>(new DX11SurfacePool);
+    instance->m_device = desc.device;
+    instance->m_texture_desc = desc.texture_desc;
+
+    return instance;
+}
+
+std::unique_ptr<Surface> DX11SurfacePool::acquire() {
+    std::unique_lock lk(m_acquire_lock);
+    for (auto it = m_free_list.begin(); it != m_free_list.end(); /* empty */) {
+        Surface* ptr = it->get();
+        if (ptr == nullptr) {
+            it = m_free_list.erase(it);
+            continue;
+        }
+
+        HRESULT result = ptr->wait_gpu_event_cpu(0);
+        if (result == DXGI_ERROR_WAIT_TIMEOUT) {
+            ++it;
+            continue;
+        }
+
+        auto surface = std::move(*it);
+        it = m_free_list.erase(it);
+        return surface;
+    }
+    lk.unlock();
+
+    return DX11Surface::create(m_device, &m_texture_desc);
+}
+
+void DX11SurfacePool::release(std::unique_ptr<Surface> surface) {
+    if (surface == nullptr)
+        return;
+
+    auto dx11_surface = dynamic_cast<DX11Surface*>(surface.get());
+    if (dx11_surface == nullptr)
+        return;
+
+    std::lock_guard lk(m_acquire_lock);
+
+    // check if device matches
+    if (m_device != dx11_surface->get_device())
+        return;
+
+    // check if desc matches
+    {
+        const auto& lhs = m_texture_desc;
+        const auto& rhs = dx11_surface->get_texture_desc();
+        if (lhs.Width != rhs.Width ||
+            lhs.Height != rhs.Height ||
+            lhs.MipLevels != rhs.MipLevels ||
+            lhs.ArraySize != rhs.ArraySize ||
+            lhs.Format != rhs.Format ||
+            lhs.SampleDesc.Count != rhs.SampleDesc.Count ||
+            lhs.SampleDesc.Quality != rhs.SampleDesc.Quality ||
+            lhs.Usage != rhs.Usage ||
+            lhs.BindFlags != rhs.BindFlags ||
+            lhs.CPUAccessFlags != rhs.CPUAccessFlags ||
+            lhs.MiscFlags != rhs.MiscFlags)
+            return;
+    }
+
+    // move to free list
+    m_free_list.push_back(std::move(surface));
+}
+

--- a/sources/streamer/capture/dx11-surface-pool.h
+++ b/sources/streamer/capture/dx11-surface-pool.h
@@ -1,0 +1,84 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface-pool.h"
+
+#include <atlcomcli.h>
+#include <d3d11.h>
+
+#include <list>
+#include <mutex>
+
+/**
+ * @brief      This class describes D3D11 surface pool
+ */
+class DX11SurfacePool : public SurfacePool {
+public:
+    struct Desc {
+        // D3D11 device used for surface allocation
+        ID3D11Device* device = nullptr;
+
+        // D3D11 texture description
+        D3D11_TEXTURE2D_DESC texture_desc = {};
+    };
+
+    virtual ~DX11SurfacePool() = default;
+
+    /**
+     * @brief      Create new surface pool instance
+     *
+     * @param      desc  pool description
+     *
+     * @return     new instance, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<DX11SurfacePool> create(DX11SurfacePool::Desc& desc);
+
+    /**
+     * @brief      Create new surface or return free surface
+     *
+     * @return     surface object, on success
+     *             nullptr, on error
+     */
+    std::unique_ptr<Surface> acquire() override;
+
+    /**
+     * @brief      Return surface to pool. If surface type or description
+     *             does not match pool desc surface is destroyed.
+     *
+     * @param[in]  surface  surface object
+     */
+    void release(std::unique_ptr<Surface> surface) override;
+
+    /**
+     * @return     Returns D3D11 texture description.
+     */
+    const D3D11_TEXTURE2D_DESC& get_texture_desc() const { return m_texture_desc; }
+
+private:
+    DX11SurfacePool() = default;
+
+private:
+    std::recursive_mutex m_acquire_lock;
+    std::list<std::unique_ptr<Surface>> m_free_list;
+
+    CComPtr<ID3D11Device> m_device;
+    D3D11_TEXTURE2D_DESC m_texture_desc = {};
+};

--- a/sources/streamer/capture/dx11-surface.cpp
+++ b/sources/streamer/capture/dx11-surface.cpp
@@ -1,0 +1,469 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dx11-surface.h"
+
+#include "dx-utils.h"
+
+#include <dxgi1_2.h>
+#include <d3d11_4.h>
+
+DX11Surface::~DX11Surface() {
+    // wait queued events
+    wait_gpu_event_cpu(INFINITE);
+
+    const bool is_shared_nt_handle = m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+    if (is_shared_nt_handle)
+        if (m_shared_handle != nullptr)
+            CloseHandle(m_shared_handle);
+}
+
+std::unique_ptr<DX11Surface> DX11Surface::create(ID3D11Device* device, D3D11_TEXTURE2D_DESC* desc) {
+    if (device == nullptr || desc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid arguments\n");
+        return nullptr;
+    }
+
+    // create texture
+    CComPtr<ID3D11Texture2D> texture;
+    HRESULT result = device->CreateTexture2D(desc, nullptr, &texture);
+    if (FAILED(result) || texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->CreateTexture2D failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    const bool is_shared_misc = desc->MiscFlags & D3D11_RESOURCE_MISC_SHARED;
+    const bool is_shared_nt_handle = desc->MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
+    auto instance = std::unique_ptr<DX11Surface>(new DX11Surface);
+    instance->m_device = device;
+    instance->m_texture = texture;
+    instance->m_desc = *desc;
+
+    // create shared handle
+    if (is_shared_nt_handle) {
+        CComPtr<IDXGIResource1> resource;
+        result = instance->m_texture->QueryInterface<IDXGIResource1>(&resource);
+        if (FAILED(result) || resource == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Texture2D->QueryInterface failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+
+        DWORD access_flags = DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE;
+        result = resource->CreateSharedHandle(nullptr, access_flags, nullptr, &instance->m_shared_handle);
+        if (FAILED(result) || instance->m_shared_handle == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIResource1->CreateSharedHandle failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+    } else if (is_shared_misc) {
+        CComPtr<IDXGIResource> resource;
+        result = instance->m_texture->QueryInterface<IDXGIResource>(&resource);
+        if (FAILED(result) || resource == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Texture2D->QueryInterface failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+
+        result = resource->GetSharedHandle(&instance->m_shared_handle);
+        if (FAILED(result) || instance->m_shared_handle == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": IDXGIResource->GetSharedHandle failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+    }
+
+    return instance;
+}
+
+HRESULT DX11Surface::open_shared_texture(ID3D11Device* device, ID3D11Texture2D** pp_texture) {
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": texture is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_texture != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // if device is the same return texture ref
+    if (device == m_device) {
+        CComPtr<ID3D11Texture2D> clone = m_texture;
+        *pp_texture = clone.Detach();
+        return S_OK;
+    }
+
+    // texture is not shared
+    if (m_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": shared handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    auto src_luid = utils::get_adapter_luid_from_device(m_device);
+    auto dst_luid = utils::get_adapter_luid_from_device(device);
+    if (!utils::is_same_luid(src_luid, dst_luid)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": cross adapter sharing is not allowed\n");
+        return E_FAIL;
+    }
+
+    const bool is_shared_nt_handle = m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+    const bool is_shared_misc = m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED;
+
+    // open shared texture
+    if (is_shared_nt_handle) {
+        CComPtr<ID3D11Device1> device1;
+        HRESULT result = device->QueryInterface<ID3D11Device1>(&device1);
+        if (FAILED(result) || device1 == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        CComPtr<ID3D11Texture2D> shared_texture;
+        result = device1->OpenSharedResource1(m_shared_handle, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(&shared_texture));
+        if (FAILED(result) || shared_texture == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device1->OpenSharedResource1 failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        *pp_texture = shared_texture.Detach();
+        return S_OK;
+    }
+
+    if (is_shared_misc) {
+        CComPtr<ID3D11Texture2D> shared_texture;
+        HRESULT result = device->OpenSharedResource(m_shared_handle, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(&shared_texture));
+        if (FAILED(result) || shared_texture == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->OpenSharedResource failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        *pp_texture = shared_texture.Detach();
+        return S_OK;
+    }
+
+    return E_FAIL;
+}
+
+HRESULT DX11Surface::open_shared_resource(ID3D12Device* device, ID3D12Resource** pp_resource) {
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_resource == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": resource is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_resource != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // resource is not shared
+    if (m_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": shared handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    auto src_luid = utils::get_adapter_luid_from_device(m_device);
+    auto dst_luid = utils::get_adapter_luid_from_device(device);
+    if (!utils::is_same_luid(src_luid, dst_luid)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": cross adapter sharing is not allowed\n");
+        return E_FAIL;
+    }
+
+    const bool is_shared_nt_handle = m_desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE;
+
+    // open shared resource
+    if (is_shared_nt_handle) {
+        // open shared resource
+        CComPtr<ID3D12Resource> shared_resource;
+        HRESULT result = device->OpenSharedHandle(m_shared_handle, __uuidof(ID3D12Resource), reinterpret_cast<void**>(&shared_resource));
+        if (FAILED(result) || shared_resource == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->OpenSharedHandle failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        *pp_resource = shared_resource.Detach();
+        return S_OK;
+    }
+
+    return E_FAIL;
+}
+
+HRESULT DX11Surface::signal_gpu_event(ID3D11Fence* fence, HANDLE shared_fence, UINT64 value) {
+    if (fence == nullptr || shared_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // duplicate fence handle
+    HANDLE fence_handle = nullptr;
+    bool ok = DuplicateHandle(GetCurrentProcess(), shared_fence,
+        GetCurrentProcess(), &fence_handle, 0, false, DUPLICATE_SAME_ACCESS);
+    if (!ok) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": DuplicateHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    std::lock_guard lk(m_event_queue_lock);
+
+    // acquire new event
+    m_event_queue.push_back(fence_handle, value);
+    auto& gpu_event = m_event_queue.back();
+
+    if (gpu_event.event_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // signal cpu side event
+    HRESULT result = fence->SetEventOnCompletion(value, gpu_event.event_handle);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    gpu_event.d3d11_fence = fence;
+    gpu_event.signalled = true;
+
+    return S_OK;
+}
+
+HRESULT DX11Surface::signal_gpu_event(ID3D12Fence* fence, HANDLE shared_fence, UINT64 value) {
+    if (fence == nullptr || shared_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // duplicate fence handle
+    HANDLE fence_handle = nullptr;
+    bool ok = DuplicateHandle(GetCurrentProcess(), shared_fence,
+        GetCurrentProcess(), &fence_handle, 0, false, DUPLICATE_SAME_ACCESS);
+    if (!ok) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": DuplicateHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    std::lock_guard lk(m_event_queue_lock);
+
+    // acquire new event
+    m_event_queue.push_back(fence_handle, value);
+    auto& gpu_event = m_event_queue.back();
+
+    if (gpu_event.event_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // signal cpu side event
+    HRESULT result = fence->SetEventOnCompletion(value, gpu_event.event_handle);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    gpu_event.d3d12_fence = fence;
+    gpu_event.signalled = true;
+
+    return S_OK;
+}
+
+HRESULT DX11Surface::wait_gpu_event_cpu(UINT timeout_ms) {
+    using namespace std::chrono;
+    
+    std::unique_lock lk(m_event_queue_lock);
+    // if no events signalled - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    // wait all queued events
+    while (!m_event_queue.empty()) {
+        auto& gpu_event = m_event_queue.front();
+        if (gpu_event.event_handle == nullptr) {
+            m_event_queue.pop_front();
+            continue;
+        }
+
+        auto wait_start = steady_clock::now();
+        auto wait_result = WaitForSingleObject(gpu_event.event_handle, timeout_ms);
+        auto wait_end = steady_clock::now();
+
+        if (wait_result == WAIT_TIMEOUT)
+            return DXGI_ERROR_WAIT_TIMEOUT;
+
+        gpu_event.signalled = false;
+
+        if (wait_result != WAIT_OBJECT_0) {
+            HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", result);
+        }
+
+        auto wait_time = wait_end - wait_start;
+        auto wait_time_ms = duration_cast<milliseconds>(wait_time).count();
+        if (wait_time_ms > 0)
+            timeout_ms = wait_time_ms < timeout_ms ? timeout_ms - wait_time_ms : 0;
+
+        m_event_queue.pop_front();
+    }
+
+    return S_OK;
+}
+
+HRESULT DX11Surface::wait_gpu_event_gpu(ID3D11DeviceContext* context) {
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    std::unique_lock lk(m_event_queue_lock);
+    // clear signalled events
+    m_event_queue.flush();
+
+    // if no pending events - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    HRESULT result = S_OK;
+
+    // get parent device
+    CComPtr<ID3D11Multithread> context_lock;
+    result = context->QueryInterface<ID3D11Multithread>(&context_lock);
+    if (FAILED(result) || context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Device> device;
+    context->GetDevice(&device);
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Device5> device5;
+    result = device->QueryInterface<ID3D11Device5>(&device5);
+    if (FAILED(result) || device5 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    auto& gpu_event = m_event_queue.back();
+    auto shared_fence = gpu_event.shared_fence;
+    auto shared_fence_value = gpu_event.fence_value;
+
+    // open shared fence
+    CComPtr<ID3D11Fence> fence;
+    result = device5->OpenSharedFence(shared_fence, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+    if (FAILED(result) || fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->OpenSharedResource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11DeviceContext4> context4;
+    result = context->QueryInterface<ID3D11DeviceContext4>(&context4);
+    if (FAILED(result) || context4 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // signal new event with updated fence reference
+    result = signal_gpu_event(fence, shared_fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": signal_gpu_event failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for shared fence
+    context_lock->Enter();
+    result = context4->Wait(fence, shared_fence_value);
+    context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->Wait4 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT DX11Surface::wait_gpu_event_gpu(ID3D12CommandQueue* queue) {
+    if (queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    std::unique_lock lk(m_event_queue_lock);
+    // clear signalled events
+    m_event_queue.flush();
+
+    // if no pending events - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    HRESULT result = S_OK;
+
+    // get parent device
+    CComPtr<ID3D12Device> device;
+    result = queue->GetDevice(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device));
+    if (FAILED(result) || device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->GetDevice failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    auto& gpu_event = m_event_queue.back();
+    auto shared_fence = gpu_event.shared_fence;
+    auto shared_fence_value = gpu_event.fence_value;
+
+    // open shared fence
+    CComPtr<ID3D12Fence> fence;
+    result = device->OpenSharedHandle(shared_fence, __uuidof(ID3D12Fence), reinterpret_cast<void**>(&fence));
+    if (FAILED(result) || fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->OpenSharedResource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // signal new event with updated fence reference
+    result = signal_gpu_event(fence, shared_fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": signal_gpu_event failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for shared fence
+    result = queue->Wait(fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->Wait failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+LUID DX11Surface::get_device_luid() {
+    return utils::get_adapter_luid_from_device(m_device);
+}
+
+UINT DX11Surface::get_width() {
+    return m_desc.Width;
+}
+
+UINT DX11Surface::get_height() {
+    return m_desc.Height;
+}
+
+DXGI_FORMAT DX11Surface::get_format() {
+    return m_desc.Format;
+}

--- a/sources/streamer/capture/dx11-surface.h
+++ b/sources/streamer/capture/dx11-surface.h
@@ -1,0 +1,189 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface.h"
+#include "event-queue.h"
+
+#include <atlcomcli.h>
+#include <d3d11_4.h>
+
+#include <deque>
+#include <memory>
+#include <mutex>
+
+/**
+ * @brief      This class describes D3D11 surface implementation
+ */
+class DX11Surface : public Surface {
+public:
+    virtual ~DX11Surface();
+
+    /**
+     * @brief      Allocate new D3D11 texture and return surface object
+     *             This function uses ID3D11Device::CreateTexture2D for allocation
+     *
+     * @param[in]  device  D3D11 device to allocate
+     * @param[in]  desc    texture description
+     *
+     * @return     surface object, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<DX11Surface> create(ID3D11Device* device, D3D11_TEXTURE2D_DESC* desc);
+    
+    /**
+     * @return     Returns D3D11 device used for resource allocation
+     */
+    ID3D11Device* get_device() const { return m_device; }
+
+    /**
+     * @return     Returns D3D11 texture description.
+     */
+    const D3D11_TEXTURE2D_DESC& get_texture_desc() const { return m_desc; }
+
+    /**
+     * @brief      Open D3D11 texture allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying texture reference.
+     *             Cross-adapted sharing is not supported.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_texture  output texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT open_shared_texture(ID3D11Device* device, ID3D11Texture2D** pp_texture) override;
+
+    /**
+     * @brief      Open D3D12 resource allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying resource reference.
+     *             Cross-adapted sharing is not supported.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_texture  output texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT open_shared_resource(ID3D12Device* device, ID3D12Resource** pp_resource) override;
+
+    /**
+     * @brief      Signal gpu event, both fence and shared handle must point to the same object
+     *             Shared handle must be created by ID3D11Fence::CreateSharedHandle
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT signal_gpu_event(ID3D11Fence* fence, HANDLE shared_fence, UINT64 value) override;
+
+    /**
+     * @brief      Signal gpu event, both fence and shared handle must point to the same object
+     *             Shared handle must be created by ID3D12Device::CreateSharedHandle
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT signal_gpu_event(ID3D12Fence* fence, HANDLE shared_fence, UINT64 value) override;
+
+    /**
+     * @brief      Block current thread and wait for gpu fence reach last stored value
+     *
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before gpu fence clears
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_cpu(UINT timeout_ms) override;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d11 device context
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_gpu(ID3D11DeviceContext* context) override;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d12 command queue
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_gpu(ID3D12CommandQueue* queue) override;
+
+    /**
+     * @return     return adapter LUID on which surface was allocated
+     */
+    LUID get_device_luid() override;
+
+    /**
+     * @return     return surface width
+     */
+    UINT get_width() override;
+
+    /**
+     * @return     return surface height
+     */
+    UINT get_height() override;
+
+    /**
+     * @return     return surface format
+     */
+    DXGI_FORMAT get_format() override;
+
+private:
+    DX11Surface() = default;
+
+private:
+    // texture and device ref
+    CComPtr<ID3D11Device> m_device;
+    CComPtr<ID3D11Texture2D> m_texture;
+    D3D11_TEXTURE2D_DESC m_desc = {};
+
+    // shared texture handle
+    HANDLE m_shared_handle = nullptr;
+
+    // gpu event queue
+    std::recursive_mutex m_event_queue_lock;
+    EventQueue m_event_queue;
+};
+

--- a/sources/streamer/capture/dx12-surface-pool.cpp
+++ b/sources/streamer/capture/dx12-surface-pool.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dx12-surface-pool.h"
+#include "dx12-surface.h"
+
+std::unique_ptr<DX12SurfacePool> DX12SurfacePool::create(DX12SurfacePool::Desc& desc) {
+    if (desc.device == nullptr)
+        return nullptr;
+
+    auto instance = std::unique_ptr<DX12SurfacePool>(new DX12SurfacePool);
+    instance->m_device = desc.device;
+    instance->m_heap_props = desc.heap_props;
+    instance->m_heap_flags = desc.heap_flags;
+    instance->m_resource_desc = desc.resource_desc;
+
+    return instance;
+}
+
+std::unique_ptr<Surface> DX12SurfacePool::acquire() {
+    std::unique_lock lk(m_acquire_lock);
+    for (auto it = m_free_list.begin(); it != m_free_list.end(); /* empty */) {
+        Surface* ptr = it->get();
+        if (ptr == nullptr) {
+            it = m_free_list.erase(it);
+            continue;
+        }
+
+        HRESULT result = ptr->wait_gpu_event_cpu(0);
+        if (result == DXGI_ERROR_WAIT_TIMEOUT) {
+            ++it;
+            continue;
+        }
+
+        auto surface = std::move(*it);
+        it = m_free_list.erase(it);
+        return surface;
+    }
+    lk.unlock();
+
+    return DX12Surface::create(m_device, &m_heap_props, m_heap_flags, &m_resource_desc);
+}
+
+void DX12SurfacePool::release(std::unique_ptr<Surface> surface) {
+    if (surface == nullptr)
+        return;
+
+    auto dx12_surface = dynamic_cast<DX12Surface*>(surface.get());
+    if (dx12_surface == nullptr)
+        return;
+
+    std::lock_guard lk(m_acquire_lock);
+
+    // check if device matches
+    if (m_device != dx12_surface->get_device())
+        return;
+    // check if heap props match
+    {
+        const auto& lhs = m_heap_props;
+        const auto& rhs = dx12_surface->get_heap_props();
+        if (lhs.Type != rhs.Type ||
+            lhs.CPUPageProperty != rhs.CPUPageProperty ||
+            lhs.MemoryPoolPreference != rhs.MemoryPoolPreference ||
+            lhs.CreationNodeMask != rhs.CreationNodeMask ||
+            lhs.VisibleNodeMask != rhs.VisibleNodeMask)
+            return;
+    }
+    // check if heap flags match
+    if (m_heap_flags != dx12_surface->get_heap_flags())
+        return;
+    // check if resource desc matches
+    {
+        const auto& lhs = m_resource_desc;
+        const auto& rhs = dx12_surface->get_resource_desc();
+        if (lhs.Dimension != rhs.Dimension ||
+            lhs.Alignment != rhs.Alignment ||
+            lhs.Width != rhs.Width ||
+            lhs.Height != rhs.Height ||
+            lhs.DepthOrArraySize != rhs.DepthOrArraySize ||
+            lhs.MipLevels != rhs.MipLevels ||
+            lhs.Format != rhs.Format ||
+            lhs.SampleDesc.Count != rhs.SampleDesc.Count ||
+            lhs.SampleDesc.Quality != rhs.SampleDesc.Quality ||
+            lhs.Layout != rhs.Layout ||
+            lhs.Flags != rhs.Flags)
+            return;
+    }
+
+    // move to free list
+    m_free_list.push_back(std::move(surface));
+}

--- a/sources/streamer/capture/dx12-surface-pool.h
+++ b/sources/streamer/capture/dx12-surface-pool.h
@@ -1,0 +1,102 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface-pool.h"
+
+#include <atlcomcli.h>
+#include <d3d12.h>
+
+#include <list>
+#include <mutex>
+
+/**
+ * @brief      This class describes D3D12 resource pool
+ */
+class DX12SurfacePool : public SurfacePool {
+public:
+    struct Desc {
+        // D3D12 device used for surface allocation
+        ID3D12Device* device = nullptr;
+
+        // D3D12 heap properties
+        D3D12_HEAP_PROPERTIES heap_props = {};
+
+        // D3D12 heap flags
+        D3D12_HEAP_FLAGS heap_flags = {};
+
+        // D3D12 resource desc
+        D3D12_RESOURCE_DESC resource_desc = {};
+    };
+
+    virtual ~DX12SurfacePool() = default;
+
+    /**
+     * @brief      Create new surface pool instance
+     *
+     * @param      desc  pool description
+     *
+     * @return     new instance, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<DX12SurfacePool> create(DX12SurfacePool::Desc& desc);
+
+    /**
+     * @brief      Create new surface or return free surface
+     *
+     * @return     surface object, on success
+     *             nullptr, on error
+     */
+    std::unique_ptr<Surface> acquire() override;
+
+    /**
+     * @brief      Return surface to pool. If surface type or description
+     *             does not match pool desc surface is destroyed.
+     *
+     * @param[in]  surface  surface object
+     */
+    void release(std::unique_ptr<Surface> surface) override;
+
+    /**
+     * @return     Returns D3D12 heap properties
+     */
+    const D3D12_HEAP_PROPERTIES& get_heap_props() const { return m_heap_props; }
+
+    /**
+     * @return     Returns D3D12 heap flags
+     */
+    const D3D12_HEAP_FLAGS& get_heap_flags() const { return m_heap_flags; }
+
+    /**
+     * @return     Returns D3D12 resource description
+     */
+    const D3D12_RESOURCE_DESC& get_resource_desc() const { return m_resource_desc; }
+
+private:
+    DX12SurfacePool() = default;
+
+private:
+    std::recursive_mutex m_acquire_lock;
+    std::list<std::unique_ptr<Surface>> m_free_list;
+
+    CComPtr<ID3D12Device> m_device;
+    D3D12_HEAP_PROPERTIES m_heap_props = {};
+    D3D12_HEAP_FLAGS m_heap_flags = {};
+    D3D12_RESOURCE_DESC m_resource_desc = {};
+};

--- a/sources/streamer/capture/dx12-surface.cpp
+++ b/sources/streamer/capture/dx12-surface.cpp
@@ -1,0 +1,431 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "dx12-surface.h"
+
+#include "dx-utils.h"
+
+DX12Surface::~DX12Surface() {
+    // wait queued events
+    wait_gpu_event_cpu(INFINITE);
+
+    if (m_shared_handle != nullptr)
+        CloseHandle(m_shared_handle);
+}
+
+std::unique_ptr<DX12Surface> DX12Surface::create(ID3D12Device* device,
+    const D3D12_HEAP_PROPERTIES* heap_props, D3D12_HEAP_FLAGS heap_flags, 
+    const D3D12_RESOURCE_DESC* resource_desc) {
+
+    if (device == nullptr || heap_props == nullptr || resource_desc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid arguments\n");
+        return nullptr;
+    }
+
+    D3D12_RESOURCE_STATES init_res_state = D3D12_RESOURCE_STATE_COMMON;
+    if (heap_props->Type == D3D12_HEAP_TYPE_UPLOAD)
+        init_res_state |= D3D12_RESOURCE_STATE_GENERIC_READ;
+    if (heap_props->Type == D3D12_HEAP_TYPE_READBACK)
+        init_res_state |= D3D12_RESOURCE_STATE_COPY_DEST;
+
+    // create resource
+    CComPtr<ID3D12Resource> resource;
+    HRESULT result = device->CreateCommittedResource(heap_props, heap_flags, resource_desc,
+        init_res_state, nullptr /* opt_clear_value */, __uuidof(ID3D12Resource),
+        reinterpret_cast<void**>(&resource));
+    if (FAILED(result) || resource == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommittedResource failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    auto instance = std::unique_ptr<DX12Surface>(new DX12Surface);
+    instance->m_device = device;
+    instance->m_resource = resource;
+    instance->m_heap_props = *heap_props;
+    instance->m_heap_flags = heap_flags;
+    instance->m_resource_desc = *resource_desc;
+
+    // create shared handle
+    if (heap_flags & D3D12_HEAP_FLAG_SHARED) {
+        result = device->CreateSharedHandle(resource, nullptr, GENERIC_ALL, nullptr, &instance->m_shared_handle);
+        if (FAILED(result) || instance->m_shared_handle == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateSharedHandle failed, result = 0x%08x\n", result);
+            return nullptr;
+        }
+    }
+
+    return instance;
+}
+
+HRESULT DX12Surface::open_shared_texture(ID3D11Device* device, ID3D11Texture2D** pp_texture) {
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": texture is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_texture != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // texture is not shared
+    if (m_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": shared handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // check cross-adapter sharing
+    auto src_luid = utils::get_adapter_luid_from_device(m_device);
+    auto dst_luid = utils::get_adapter_luid_from_device(device);
+    if (!utils::is_same_luid(src_luid, dst_luid)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": cross adapter sharing is not allowed\n");
+        return E_FAIL;
+    }
+
+    // open shared texture
+    CComPtr<ID3D11Device1> device1;
+    HRESULT result = device->QueryInterface<ID3D11Device1>(&device1);
+    if (FAILED(result) || device1 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Texture2D> shared_texture;
+    result = device1->OpenSharedResource1(m_shared_handle, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(&shared_texture));
+    if (FAILED(result) || shared_texture == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device1->OpenSharedResource1 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    *pp_texture = shared_texture.Detach();
+    return S_OK;
+}
+
+HRESULT DX12Surface::open_shared_resource(ID3D12Device* device, ID3D12Resource** pp_resource) {
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (pp_resource == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": resource is nullptr\n");
+        return E_INVALIDARG;
+    }
+    if (*pp_resource != nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    // if device is the same - return fence ref
+    if (device == m_device) {
+        CComPtr<ID3D12Resource> clone = m_resource;
+        *pp_resource = clone.Detach();
+        return S_OK;
+    }
+
+    // resource is not shared
+    if (m_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": shared handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // check cross-adapter sharing
+    if (!(m_heap_flags & D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER)) {
+        auto src_luid = utils::get_adapter_luid_from_device(m_device);
+        auto dst_luid = utils::get_adapter_luid_from_device(device);
+        if (!utils::is_same_luid(src_luid, dst_luid)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": cross adapter sharing is not allowed\n");
+            return E_FAIL;
+        }
+    }
+
+    // open shared resource
+    CComPtr<ID3D12Resource> shared_resource;
+    HRESULT result = device->OpenSharedHandle(m_shared_handle, __uuidof(ID3D12Resource), reinterpret_cast<void**>(&shared_resource));
+    if (FAILED(result) || shared_resource == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->OpenSharedHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    *pp_resource = shared_resource.Detach();
+    return S_OK;
+}
+
+HRESULT DX12Surface::signal_gpu_event(ID3D11Fence* fence, HANDLE shared_fence, UINT64 value) {
+    if (fence == nullptr || shared_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // duplicate fence handle
+    HANDLE fence_handle = nullptr;
+    bool ok = DuplicateHandle(GetCurrentProcess(), shared_fence,
+        GetCurrentProcess(), &fence_handle, 0, false, DUPLICATE_SAME_ACCESS);
+    if (!ok) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": DuplicateHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    std::lock_guard lk(m_event_queue_lock);
+
+    // acquire new event
+    m_event_queue.push_back(fence_handle, value);
+    auto& gpu_event = m_event_queue.back();
+
+    if (gpu_event.event_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // signal cpu side event
+    HRESULT result = fence->SetEventOnCompletion(value, gpu_event.event_handle);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    gpu_event.d3d11_fence = fence;
+    gpu_event.signalled = true;
+
+    return S_OK;
+}
+
+HRESULT DX12Surface::signal_gpu_event(ID3D12Fence* fence, HANDLE shared_fence, UINT64 value) {
+    if (fence == nullptr || shared_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // duplicate fence handle
+    HANDLE fence_handle = nullptr;
+    bool ok = DuplicateHandle(GetCurrentProcess(), shared_fence,
+        GetCurrentProcess(), &fence_handle, 0, false, DUPLICATE_SAME_ACCESS);
+    if (!ok) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": DuplicateHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    std::lock_guard lk(m_event_queue_lock);
+
+    // acquire new event
+    m_event_queue.push_back(fence_handle, value);
+    auto& gpu_event = m_event_queue.back();
+
+    if (gpu_event.event_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+
+    // signal cpu side event
+    HRESULT result = fence->SetEventOnCompletion(value, gpu_event.event_handle);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    gpu_event.d3d12_fence = fence;
+    gpu_event.signalled = true;
+
+    return S_OK;
+}
+
+HRESULT DX12Surface::wait_gpu_event_cpu(UINT timeout_ms) {
+    using namespace std::chrono;
+
+    std::unique_lock lk(m_event_queue_lock);
+    // if no events signalled - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    // wait all queued events
+    while (!m_event_queue.empty()) {
+        auto& gpu_event = m_event_queue.front();
+        if (gpu_event.event_handle == nullptr) {
+            m_event_queue.pop_front();
+            continue;
+        }
+
+        auto wait_start = steady_clock::now();
+        auto wait_result = WaitForSingleObject(gpu_event.event_handle, timeout_ms);
+        auto wait_end = steady_clock::now();
+
+        if (wait_result == WAIT_TIMEOUT)
+            return DXGI_ERROR_WAIT_TIMEOUT;
+
+        gpu_event.signalled = false;
+
+        if (wait_result != WAIT_OBJECT_0) {
+            HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", result);
+        }
+
+        auto wait_time = wait_end - wait_start;
+        auto wait_time_ms = duration_cast<milliseconds>(wait_time).count();
+        if (wait_time_ms > 0)
+            timeout_ms = wait_time_ms < timeout_ms ? timeout_ms - wait_time_ms : 0;
+
+        m_event_queue.pop_front();
+    }
+
+    return S_OK;
+}
+
+HRESULT DX12Surface::wait_gpu_event_gpu(ID3D11DeviceContext* context) {
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    std::unique_lock lk(m_event_queue_lock);
+    // clear signalled events
+    m_event_queue.flush();
+
+    // if no pending events - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    HRESULT result = S_OK;
+
+    // get parent device
+    CComPtr<ID3D11Multithread> context_lock;
+    result = context->QueryInterface<ID3D11Multithread>(&context_lock);
+    if (FAILED(result) || context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Device> device;
+    context->GetDevice(&device);
+    if (device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11Device5> device5;
+    result = device->QueryInterface<ID3D11Device5>(&device5);
+    if (FAILED(result) || device5 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    auto& gpu_event = m_event_queue.back();
+    auto shared_fence = gpu_event.shared_fence;
+    auto shared_fence_value = gpu_event.fence_value;
+
+    // open shared fence
+    CComPtr<ID3D11Fence> fence;
+    result = device5->OpenSharedFence(shared_fence, __uuidof(ID3D11Fence), reinterpret_cast<void**>(&fence));
+    if (FAILED(result) || fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->OpenSharedResource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D11DeviceContext4> context4;
+    result = context->QueryInterface<ID3D11DeviceContext4>(&context4);
+    if (FAILED(result) || context4 == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->QueryInterface failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // signal new event with updated fence reference
+    result = signal_gpu_event(fence, shared_fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": signal_gpu_event failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for shared fence
+    context_lock->Enter();
+    result = context4->Wait(fence, shared_fence_value);
+    context_lock->Leave();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11DeviceContext->Wait4 failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT DX12Surface::wait_gpu_event_gpu(ID3D12CommandQueue* queue) {
+    if (queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device context is nullptr\n");
+        return E_INVALIDARG;
+    }
+
+    std::unique_lock lk(m_event_queue_lock);
+    // clear signalled events
+    m_event_queue.flush();
+
+    // if no pending events - return immediately
+    if (m_event_queue.empty())
+        return S_OK;
+
+    HRESULT result = S_OK;
+
+    // get parent device
+    CComPtr<ID3D12Device> device;
+    result = queue->GetDevice(__uuidof(ID3D12Device), reinterpret_cast<void**>(&device));
+    if (FAILED(result) || device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->GetDevice failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    auto& gpu_event = m_event_queue.back();
+    auto shared_fence = gpu_event.shared_fence;
+    auto shared_fence_value = gpu_event.fence_value;
+
+    // open shared fence
+    CComPtr<ID3D12Fence> fence;
+    result = device->OpenSharedHandle(shared_fence, __uuidof(ID3D12Fence), reinterpret_cast<void**>(&fence));
+    if (FAILED(result) || fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D11Device->OpenSharedResource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // signal new event with updated fence reference
+    result = signal_gpu_event(fence, shared_fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": signal_gpu_event failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for shared fence
+    result = queue->Wait(fence, shared_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->Wait failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+LUID DX12Surface::get_device_luid() {
+    return utils::get_adapter_luid_from_device(m_device);
+}
+
+UINT DX12Surface::get_width() {
+    return m_resource_desc.Width;
+}
+
+UINT DX12Surface::get_height() {
+    return m_resource_desc.Height;
+}
+
+DXGI_FORMAT DX12Surface::get_format() {
+    return m_resource_desc.Format;
+}

--- a/sources/streamer/capture/dx12-surface.h
+++ b/sources/streamer/capture/dx12-surface.h
@@ -1,0 +1,205 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface.h"
+#include "event-queue.h"
+
+#include <atlcomcli.h>
+#include <d3d11_4.h>
+#include <d3d12.h>
+
+#include <deque>
+#include <memory>
+#include <mutex>
+
+/**
+ * @brief      This class describes D3D12 surface implementation
+ */
+class DX12Surface : public Surface {
+public:
+    virtual ~DX12Surface();
+
+    /**
+     * @brief      Allocate new D3D12 resource and return surface object
+     *             This function uses ID3D12Device::CreateCommittedResource for allocation
+     *
+     * @param      device         D3D12 device to allocate
+     * @param[in]  heap_props     D3D12 heap properties
+     * @param[in]  heap_flags     D3D12 heap flags
+     * @param[in]  resource_desc  D3D12 resource description
+     *
+     * @return     surface object, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<DX12Surface> create(ID3D12Device* device,
+        const D3D12_HEAP_PROPERTIES* heap_props, D3D12_HEAP_FLAGS heap_flags,
+        const D3D12_RESOURCE_DESC* resource_desc);
+
+    /**
+     * @return     Returns D3D12 device used for resource allocation
+     */
+    ID3D12Device* get_device() const { return m_device; }
+
+    /**
+     * @return     Returns D3D12 heap properties
+     */
+    const D3D12_HEAP_PROPERTIES& get_heap_props() const { return m_heap_props; }
+
+    /**
+     * @return     Returns D3D12 heap flags
+     */
+    const D3D12_HEAP_FLAGS& get_heap_flags() const { return m_heap_flags; }
+
+    /**
+     * @return     Returns D3D12 resource description
+     */
+    const D3D12_RESOURCE_DESC& get_resource_desc() const { return m_resource_desc; }
+
+    /**
+     * @brief      Open D3D11 texture allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying texture reference.
+     *             Cross-adapted sharing is not supported.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_texture  output texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT open_shared_texture(ID3D11Device* device, ID3D11Texture2D** pp_texture) override;
+
+    /**
+     * @brief      Open D3D12 resource allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying resource reference.
+     *             Cross-adapted sharing is not supported.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_texture  output texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT open_shared_resource(ID3D12Device* device, ID3D12Resource** pp_resource) override;
+
+    /**
+     * @brief      Signal gpu event, both fence and shared handle must point to the same object
+     *             Shared handle must be created by ID3D11Fence::CreateSharedHandle
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT signal_gpu_event(ID3D11Fence* fence, HANDLE shared_fence, UINT64 value) override;
+
+    /**
+     * @brief      Signal gpu event, both fence and shared handle must point to the same object
+     *             Shared handle must be created by ID3D12Device::CreateSharedHandle
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT signal_gpu_event(ID3D12Fence* fence, HANDLE shared_fence, UINT64 value) override;
+
+    /**
+     * @brief      Block current thread and wait for gpu fence reach last stored value
+     *
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before gpu fence clears
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_cpu(UINT timeout_ms) override;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d11 device context
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_gpu(ID3D11DeviceContext* context) override;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d12 command queue
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    HRESULT wait_gpu_event_gpu(ID3D12CommandQueue* queue) override;
+
+    /**
+     * @return     return adapter LUID on which surface was allocated
+     */
+    LUID get_device_luid() override;
+
+    /**
+     * @return     return surface width
+     */
+    UINT get_width() override;
+
+    /**
+     * @return     return surface height
+     */
+    UINT get_height() override;
+
+    /**
+     * @return     return surface format
+     */
+    DXGI_FORMAT get_format() override;
+
+private:
+    DX12Surface() = default;
+
+private:
+    // resource and device ref
+    CComPtr<ID3D12Device> m_device;
+    CComPtr<ID3D12Resource> m_resource;
+    D3D12_HEAP_PROPERTIES m_heap_props = {};
+    D3D12_HEAP_FLAGS m_heap_flags = {};
+    D3D12_RESOURCE_DESC m_resource_desc = {};
+
+    // shared resource handle
+    HANDLE m_shared_handle = nullptr;
+    
+    // gpu event queue
+    std::recursive_mutex m_event_queue_lock;
+    EventQueue m_event_queue;
+};

--- a/sources/streamer/capture/encoder.cpp
+++ b/sources/streamer/capture/encoder.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "encoder.h"
+
+std::string to_string(const EncoderParams::Codec& codec) {
+    switch (codec) {
+    case EncoderParams::Codec::avc:
+        return "avc";
+    case EncoderParams::Codec::hevc:
+        return "hevc";
+    case EncoderParams::Codec::av1:
+        return "av1";
+    }
+
+    return "unknown";
+}
+
+std::string to_string(const EncoderParams::QualityPreset& preset) {
+    switch (preset) {
+    case EncoderParams::QualityPreset::veryfast:
+        return "veryfast";
+    case EncoderParams::QualityPreset::faster:
+        return "faster";
+    case EncoderParams::QualityPreset::fast:
+        return "fast";
+    case EncoderParams::QualityPreset::medium:
+        return "medium";
+    case EncoderParams::QualityPreset::slow:
+        return "slow";
+    case EncoderParams::QualityPreset::slower:
+        return "slower";
+    case EncoderParams::QualityPreset::veryslow:
+        return "veryslow";
+    }
+
+    return "unknown";
+}
+
+std::string to_string(const EncoderParams::RateControl& rc) {
+    switch (rc) {
+    case EncoderParams::RateControl::cqp:
+        return "cqp";
+    case EncoderParams::RateControl::vbr:
+        return "vbr";
+    }
+
+    return "unknown";
+}
+
+std::string to_string(const EncoderParams::OutputChromaFormat& format) {
+    switch (format) {
+    case EncoderParams::OutputChromaFormat::chroma420:
+        return "4:2:0";
+    case EncoderParams::OutputChromaFormat::chroma444:
+        return "4:4:4";
+    }
+
+    return "unknown";
+}

--- a/sources/streamer/capture/encoder.h
+++ b/sources/streamer/capture/encoder.h
@@ -1,0 +1,163 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "frame.h"
+
+#include <cstdint>
+#include <filesystem>
+
+/**
+ * @brief      This structure describes encoder parameters
+ */
+struct EncoderParams {
+    // codec id : supported codecs avc, hevc, av1
+    enum class Codec {
+        unknown,
+        avc,
+        hevc,
+        av1,
+    };
+
+    // quality preset
+    enum class QualityPreset {
+        veryfast, // best speed
+        faster,
+        fast,
+        medium,
+        slow,
+        slower,
+        veryslow, // best quality
+    };
+
+    // rate control method
+    enum class RateControl {
+        cqp,
+        vbr,
+    };
+
+    // chroma format for encoded bitstream
+    enum class OutputChromaFormat {
+        chroma420,
+        chroma444,
+    };
+
+    // codec id
+    Codec codec = Codec::unknown;
+    // quality preset
+    QualityPreset preset = QualityPreset::medium;
+    // rate control method
+    RateControl rate_control = RateControl::vbr;
+    // target bitrate
+    uint32_t target_bitrate = 0;
+    // key frame interval
+    uint32_t key_frame_interval = 0;
+    // encoded bitstream frame rate
+    uint16_t frame_rate = 0;
+    // chroma format for encoded bitstream
+    OutputChromaFormat output_chroma_format = OutputChromaFormat::chroma420;
+    // display adapter to run encoder
+    LUID adapter_luid = {};
+};
+
+std::string to_string(const EncoderParams::Codec& codec);
+std::string to_string(const EncoderParams::QualityPreset& preset);
+std::string to_string(const EncoderParams::RateControl& rc);
+std::string to_string(const EncoderParams::OutputChromaFormat& format);
+
+/**
+ * @brief      This class describes bitstream packet representing one encoded frame
+ */
+struct Packet {
+    static constexpr uint32_t flag_keyframe = 0x1;
+
+    std::vector<uint8_t> data;
+    uint32_t flags = 0;
+};
+
+/**
+ * @brief      This class describes generic encoder interface
+ *             This API works as follows:
+ *             - create encoder instance
+ *             - create encoding thread and call encode_frame() in a loop
+ *             - create receiver thread and call receive_packet() in a loop
+ *             Encoder will initialize internal state based on the parameters
+ *             from the first frame received. If input frame parameters are changed,
+ *             encoder will flush outstanding packets and try to re-initialize
+ *             internal state based on new frame parameters.
+ */
+struct Encoder {
+
+    virtual ~Encoder() = default;
+
+    /**
+     * @brief      returns true if input frame format is supported
+     *
+     * @param[in]  format  DXGI format
+     *
+     * @return     true, if the specified format is format supported
+     *             false, otherwise
+     */
+    virtual bool is_format_supported(DXGI_FORMAT format) const = 0;
+
+    /**
+     * @brief      Start encoder
+     *
+     * @return     0, on success
+     *             HRESULT, om error
+     */
+    virtual HRESULT start() = 0;
+
+    /**
+     * @brief      Stop encoder
+     */
+    virtual void stop() = 0;
+
+    /**
+     * @brief      Encode one frame
+     *
+     * @param[in]  frame  frame object
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if frame is nullptr
+     *             E_FAIL, on error
+     */
+    virtual HRESULT encode_frame(Frame* frame) = 0;
+
+    /**
+     * @brief      Block thread and wait for a new bitstream packet with timeout.
+     *
+     * @param[out] packet      bitstream packet
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new packet arrives
+     *             E_FAIL, on error
+     */
+    virtual HRESULT receive_packet(Packet& packet, UINT timeout_ms) = 0;
+
+    // [fixme] temp desc: flush encoder
+    // [fixme] not yet implemented
+    // virtual HRESULT end_of_stream() = 0;
+
+    /**
+     * @brief      Signal encoder to insert a key frame
+     */
+    virtual void request_key_frame() = 0;
+};

--- a/sources/streamer/capture/event-queue.cpp
+++ b/sources/streamer/capture/event-queue.cpp
@@ -1,0 +1,136 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "event-queue.h"
+
+EventQueue::~EventQueue() {
+    while (!m_event_queue.empty())
+        pop_front();
+
+    for (auto& e : m_free_events) {
+        if (e.signalled && e.event_handle)
+            WaitForSingleObject(e.event_handle, INFINITE);
+        if (e.event_handle)
+            CloseHandle(e.event_handle);
+        if (e.shared_fence)
+            CloseHandle(e.shared_fence);
+    }
+}
+
+void EventQueue::push_back(HANDLE fence, UINT64 value) {
+    auto e = acquire_event();
+    e.shared_fence = fence;
+    e.fence_value = value;
+    m_event_queue.push_back(std::move(e));
+}
+
+void EventQueue::pop_front() {
+    if (m_event_queue.empty())
+        return;
+
+    release_event(m_event_queue.front());
+    m_event_queue.pop_front();
+}
+
+void EventQueue::flush() {
+    if (m_event_queue.empty())
+        return;
+
+    for (auto it = m_event_queue.begin(); it != m_event_queue.end(); /* empty */) {
+        // remove invalid entries
+        if (it->event_handle == nullptr) {
+            it->signalled = false;
+            release_event(*it);
+            it = m_event_queue.erase(it);
+            continue;
+        }
+
+        // try clear signal
+        if (it->signalled) {
+            auto wait_result = WaitForSingleObject(it->event_handle, 0);
+            if (wait_result == WAIT_TIMEOUT) {
+                ++it;
+                continue; // not signalled yet - skip
+            }
+            if (wait_result != WAIT_OBJECT_0)
+                ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+        
+            it->signalled = false;
+            release_event(*it);
+            it = m_event_queue.erase(it);
+            continue;
+        }
+
+        ++it;
+    }
+}
+
+EventQueue::Event EventQueue::acquire_event() {
+    if (!m_free_events.empty()) {
+        for (auto it = m_free_events.begin(); it != m_free_events.end(); ++it) {
+            // remove invalid entries
+            if (it->event_handle == nullptr) {
+                if (it->shared_fence != nullptr)
+                    CloseHandle(it->shared_fence);
+                it = m_free_events.erase(it);
+                continue;
+            }
+
+            // if signalled try to clear signal
+            if (it->signalled) {
+                auto wait_result = WaitForSingleObject(it->event_handle, 0);
+                if (wait_result == WAIT_TIMEOUT)
+                    continue; // not signalled yet - skip
+                if (wait_result != WAIT_OBJECT_0)
+                    ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+            }
+
+            // reset values
+            it->signalled = false;
+            if (it->shared_fence != nullptr) {
+                CloseHandle(it->shared_fence);
+                it->shared_fence = nullptr;
+            }
+
+            // remove from list
+            Event e = std::move(*it);
+            it = m_free_events.erase(it);
+            return e;
+        }
+    }
+
+    // create new object
+    Event e;
+    e.event_handle = CreateEvent(nullptr, false, false, nullptr);
+    if (e.event_handle == nullptr) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateEvent failed, result = 0x%08x\n", result);
+        return e;
+    }
+    return e;
+}
+
+void EventQueue::release_event(Event& e) {
+    if (!e.signalled) {
+        if (e.shared_fence != nullptr) {
+            CloseHandle(e.shared_fence);
+            e.shared_fence = nullptr;
+        }
+        e.d3d11_fence = nullptr;
+        e.d3d12_fence = nullptr;
+    }
+    m_free_events.push_back(std::move(e));
+}

--- a/sources/streamer/capture/event-queue.h
+++ b/sources/streamer/capture/event-queue.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include <atlcomcli.h>
+#include <d3d11_4.h>
+#include <d3d12.h>
+
+#include <deque>
+#include <vector>
+
+class EventQueue {
+public:
+    struct Event {
+        HANDLE event_handle = nullptr;
+        HANDLE shared_fence = nullptr;
+        UINT64 fence_value = 0;
+        CComPtr<ID3D11Fence> d3d11_fence;
+        CComPtr<ID3D12Fence> d3d12_fence;
+        bool signalled = false;
+    };
+
+    EventQueue() = default;
+    ~EventQueue();
+
+    bool empty() const { return m_event_queue.empty(); }
+
+    Event& front() { return m_event_queue.front(); }
+    const Event& front() const { return m_event_queue.front(); }
+
+    Event& back() { return m_event_queue.back(); }
+    const Event& back() const { return m_event_queue.back(); }
+
+    void push_back(HANDLE fence, UINT64 value);
+    
+    void pop_front();
+
+    void flush();
+
+private:
+    Event acquire_event(); 
+
+    void release_event(Event& e);
+
+private:
+    std::deque<Event> m_event_queue;
+    std::vector<Event> m_free_events;
+};

--- a/sources/streamer/capture/frame-provider.h
+++ b/sources/streamer/capture/frame-provider.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "frame.h"
+
+#include <memory>
+
+/**
+ * @brief      This class describes generic frame provider interface.
+ *             User can obtain last captured frame by calling receive_frame() in a loop.
+ */
+struct FrameProvider {
+
+    virtual ~FrameProvider() = default;
+
+    /**
+     * @brief      Start frame capture
+     *
+     * @return     0, on success
+     *             HRESULT, om error
+     */
+    virtual HRESULT start() = 0;
+
+    /**
+     * @brief      Stop frame capture
+     */
+    virtual void stop() = 0;
+
+    /**
+     * @brief      Block thread and wait for a new frame with timeout.
+     *             Called by user to acquire new frame.
+     *
+     * @param      frame       frame object
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0 and frame object, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new frame arrives
+     *             E_FAIL, on error
+     */
+    virtual HRESULT receive_frame(std::shared_ptr<Frame>& frame, UINT timeout_ms) = 0;
+};

--- a/sources/streamer/capture/frame.cpp
+++ b/sources/streamer/capture/frame.cpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "frame.h"
+
+Frame::~Frame() {
+    auto pool = m_pool.lock();
+    if (pool)
+        pool->release(std::move(m_surface));
+}
+
+std::unique_ptr<Frame> Frame::create(std::unique_ptr<Surface> surface, std::weak_ptr<SurfacePool> pool) {
+    if (surface == nullptr)
+        return nullptr;
+
+    auto instance = std::unique_ptr<Frame>(new Frame);
+    instance->m_surface = std::move(surface);
+    instance->m_pool = pool;
+    return instance;
+}
+
+

--- a/sources/streamer/capture/frame.h
+++ b/sources/streamer/capture/frame.h
@@ -1,0 +1,56 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface.h"
+#include "surface-pool.h"
+
+#include <memory>
+
+/**
+ * @brief      This class describes a frame object which encapsulates a surface.
+ *             Surface is automatically released upon destruction of this object.
+ *             If pool reference is provided, surface returns to pool for re-use.
+ */
+class Frame {
+public:
+    virtual ~Frame();
+
+    /**
+     * @brief      Create frame object from surface
+     *
+     * @param[in]  surface  surface object
+     * @param[in]  pool     reference to surface pool surface was allocated on
+     *
+     * @return     new frame object on success,
+     *             nullptr, on error
+     */
+    static std::unique_ptr<Frame> create(std::unique_ptr<Surface> surface, std::weak_ptr<SurfacePool> pool);
+
+    /**
+     * @return     Return underlying surface
+     */
+    Surface* get_surface() { return m_surface.get(); }
+
+private:
+    Frame() = default;
+
+    std::unique_ptr<Surface> m_surface;
+    std::weak_ptr<SurfacePool> m_pool;
+};

--- a/sources/streamer/capture/meson.build
+++ b/sources/streamer/capture/meson.build
@@ -1,0 +1,89 @@
+# Copyright (C) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+capture_required = get_option('capture').enabled() or get_option('streamer').enabled()
+
+libavcodec_dep = dependency('libavcodec', required : capture_required)
+libavutil_dep = dependency('libavutil', required : capture_required)
+libvpl_dep = dependency('vpl', required : capture_required)
+
+deps = [
+  libavcodec_dep,
+  libavutil_dep,
+  libvpl_dep,
+  ]
+
+foreach dep : deps
+  if not dep.found()
+    warning('capture will NOT be built due to missing dependencies')
+    capture_dep = null_dep
+    subdir_done()
+  endif
+endforeach
+
+srcs = files(
+  'av-qsv-encoder.cpp',
+  'av-qsv-encoder.h',
+  'av-utils.cpp',
+  'av-utils.h',
+  'cursor-provider.h',
+  'cursor-receiver.cpp',
+  'cursor-receiver.h',
+  'desktop-duplicator.cpp',
+  'desktop-duplicator.h',
+  'dt-capture.cpp',
+  'dt-capture.h',
+  'dx-utils.cpp',
+  'dx-utils.h',
+  'dx11-surface-pool.cpp',
+  'dx11-surface-pool.h',
+  'dx11-surface.cpp',
+  'dx11-surface.h',
+  'dx12-surface-pool.cpp',
+  'dx12-surface-pool.h',
+  'dx12-surface.cpp',
+  'dx12-surface.h',
+  'encoder.h',
+  'encoder.cpp',
+  'event-queue.h',
+  'event-queue.cpp',
+  'frame-provider.h',
+  'frame.cpp',
+  'frame.h',
+  'surface-pool.h',
+  'surface.h',
+  'video-processor.cpp',
+  'video-processor.h',
+  )
+
+cpp_args = ['-DGA_SERVER', '-DGA_MODULE']
+
+core_deps = [
+  cpp.find_library('d3d11'),
+  cpp.find_library('d3d12'),
+  cpp.find_library('dxgi')
+  ]
+
+_lib = static_library('capture', srcs,
+  cpp_args : cpp_args,
+  dependencies : [core_deps, ga_dep, deps],
+  install : false,
+  )
+
+capture_dep = declare_dependency(
+  include_directories : include_directories('.'),
+  link_with : _lib
+  )

--- a/sources/streamer/capture/surface-pool.h
+++ b/sources/streamer/capture/surface-pool.h
@@ -1,0 +1,49 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "surface.h"
+
+#include <memory>
+
+/**
+ * @brief      This class describes generic surface pool interface.
+ *             Surface pool does not hold references to surfaces in use.
+ *             User must track manualy which pool surface was allocated on.
+ */
+struct SurfacePool {
+
+    virtual ~SurfacePool() = default;
+
+    /**
+     * @brief      Create new surface or return free surface
+     *
+     * @return     surface object, on success
+     *             nullptr, on error
+     */
+    virtual std::unique_ptr<Surface> acquire() = 0;
+
+    /**
+     * @brief      Return surface to pool. If surface type or description
+     *             does not match pool desc surface is destroyed.
+     *
+     * @param[in]  surface  surface object
+     */
+    virtual void release(std::unique_ptr<Surface> surface) = 0;
+};

--- a/sources/streamer/capture/surface.h
+++ b/sources/streamer/capture/surface.h
@@ -1,0 +1,140 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include <d3d11_4.h>
+#include <d3d12.h>
+
+/**
+ * @brief      This class describes a surface interface
+ */
+struct Surface {
+
+    virtual ~Surface() = default;
+
+    /**
+     * @brief      Open D3D11 texture allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying texture reference.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_texture  output texture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    virtual HRESULT open_shared_texture(ID3D11Device* device, ID3D11Texture2D** pp_texture) = 0;
+
+    /**
+     * @brief      Open D3D12 resource allocation on specified device.
+     *             If device matches the one surface was created on,
+     *             return underlying resource reference.
+     *
+     * @param[in]  device      destination device
+     * @param[out] pp_resource output resource
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    virtual HRESULT open_shared_resource(ID3D12Device* device, ID3D12Resource** pp_resource) = 0;
+
+    /**
+     * @brief      Signal gpu event
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    virtual HRESULT signal_gpu_event(ID3D11Fence* fence, HANDLE shared_fence, UINT64 value) = 0;
+
+    /**
+     * @brief      Signal gpu event
+     *
+     * @param      fence         fence object
+     * @param[in]  shared_fence  shared fence handle
+     * @param[in]  value         fence value
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    virtual HRESULT signal_gpu_event(ID3D12Fence* fence, HANDLE shared_fence, UINT64 value) = 0;
+
+    /**
+     * @brief      Block current thread and wait for gpu fence reach last stored value
+     *
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before gpu fence clears
+     *             E_FAIL, on error
+     */
+    virtual HRESULT wait_gpu_event_cpu(UINT timeout_ms) = 0;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d11 device context
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    virtual HRESULT wait_gpu_event_gpu(ID3D11DeviceContext* context) = 0;
+
+    /**
+     * @brief      Queue GPU wait until fence reaches last stored value.
+     *             Command queue will wait (during which time no work is executed)
+     *             until the fence reaches the requested value.
+     *             Because a wait is being queued, this API returns immediately.
+     *
+     * @param      context  d3d12 command queue
+     *
+     * @return     0, on success
+     *             E_INVALIDARG, if context is nullptr
+     *             E_FAIL, on error
+     */
+    virtual HRESULT wait_gpu_event_gpu(ID3D12CommandQueue* queue) = 0;
+
+
+    /**
+     * @return     return adapter LUID on which surface was allocated
+     */
+    virtual LUID get_device_luid() = 0;
+
+    /**
+     * @return     return surface width
+     */
+    virtual UINT get_width() = 0;
+
+    /**
+     * @return     return surface height
+     */
+    virtual UINT get_height() = 0;
+
+    /**
+     * @return     return surface format
+     */
+    virtual DXGI_FORMAT get_format() = 0;
+};

--- a/sources/streamer/capture/video-processor.cpp
+++ b/sources/streamer/capture/video-processor.cpp
@@ -1,0 +1,1329 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "video-processor.h"
+
+#include "dx-utils.h"
+#include "dx12-surface-pool.h"
+#include "dx12-surface.h"
+#include "frame-provider.h"
+
+#include <dxgi1_4.h>
+
+VideoProcessor::~VideoProcessor() {
+    stop();
+
+    if (m_src_copy_fence_shared_handle)
+        CloseHandle(m_src_copy_fence_shared_handle);
+    if (m_dst_copy_fence_shared_handle)
+        CloseHandle(m_dst_copy_fence_shared_handle);
+    if (m_vp_fence_shared_handle)
+        CloseHandle(m_vp_fence_shared_handle);
+
+    if (m_src_copy_event)
+        CloseHandle(m_src_copy_event);
+    if (m_dst_copy_event)
+        CloseHandle(m_dst_copy_event);
+    if (m_vp_event)
+        CloseHandle(m_vp_event);
+}
+
+std::unique_ptr<VideoProcessor> VideoProcessor::create(const VideoProcessor::Desc& desc) {
+    // validate params
+    HRESULT result = validate_video_processor_desc(desc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": validate_video_processor_desc failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // get target adapter
+    CComPtr<IDXGIAdapter> adapter;
+    result = utils::enum_adapter_by_luid(&adapter, desc.adapter_luid);
+    if (FAILED(result) || adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_adapter_by_luid failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // create instance
+    auto instance = std::unique_ptr<VideoProcessor>(new VideoProcessor);
+
+    // create video processing device
+    CComPtr<ID3D12Device> device;
+    result = utils::create_d3d12_device(adapter, &device);
+    if (FAILED(result) || device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::create_d3d12_device failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_device = device;
+    instance->m_dst_device_luid = utils::get_adapter_luid_from_device(device);
+
+    // create video device
+    CComPtr<ID3D12VideoDevice> video_device;
+    result = device->QueryInterface<ID3D12VideoDevice>(&video_device);
+    if (FAILED(result) || video_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->QueryInterface failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_video_device = video_device;
+
+    // create video command allocator
+    CComPtr<ID3D12CommandAllocator> video_cmd_alloc;
+    result = device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_VIDEO_PROCESS, 
+        __uuidof(ID3D12CommandAllocator), reinterpret_cast<void**>(&video_cmd_alloc));
+    if (FAILED(result) || video_cmd_alloc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandAllocator failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_video_cmd_alloc = video_cmd_alloc;
+
+    // create video command queue
+    D3D12_COMMAND_QUEUE_DESC command_queue_desc = {};
+    command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_VIDEO_PROCESS;
+    command_queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+    command_queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
+
+    CComPtr<ID3D12CommandQueue> video_cmd_queue;
+    result = instance->m_device->CreateCommandQueue(&command_queue_desc, 
+        __uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&video_cmd_queue));
+    if (FAILED(result) || video_cmd_queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandQueue failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_video_cmd_queue = video_cmd_queue;
+
+    // create video command list
+    CComPtr<ID3D12VideoProcessCommandList> video_cmd_list;
+    result = device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_VIDEO_PROCESS, 
+        video_cmd_alloc, nullptr /* init_state */, 
+        __uuidof(ID3D12VideoProcessCommandList), reinterpret_cast<void**>(&video_cmd_list));
+    if (FAILED(result) || video_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandList failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_video_cmd_list = video_cmd_list;
+
+    // close video command list
+    result = video_cmd_list->Close();
+    if (FAILED(result) || video_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12VideoProcessCommandList->Close failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    CComPtr<ID3D12Fence> fence;
+    result = device->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER,
+        __uuidof(ID3D12Fence), reinterpret_cast<void**>(&fence));
+    if (FAILED(result) || fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateFence failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_vp_fence = fence;
+    instance->m_vp_fence_value = 0;
+
+    HANDLE shared_fence = nullptr;
+    result = device->CreateSharedHandle(fence, nullptr, GENERIC_ALL, nullptr, &shared_fence);
+    if (FAILED(result) || shared_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateSharedHandle failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+    instance->m_vp_fence_shared_handle = shared_fence;
+
+    // create events
+    instance->m_src_copy_event = CreateEvent(nullptr, false, false, nullptr);
+    if (instance->m_src_copy_event == nullptr) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateEvent failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    instance->m_dst_copy_event = CreateEvent(nullptr, false, false, nullptr);
+    if (instance->m_dst_copy_event == nullptr) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateEvent failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    instance->m_vp_event = CreateEvent(nullptr, false, false, nullptr);
+    if (instance->m_vp_event == nullptr) {
+        HRESULT result = HRESULT_FROM_WIN32(GetLastError());
+        ga_logger(Severity::ERR, __FUNCTION__ ": CreateEvent failed, result = 0x%08x\n", result);
+        return nullptr;
+    }
+
+    // fill params
+    instance->m_frame_rate = desc.frame_rate;
+    instance->m_output_format = desc.output_format;
+
+    using namespace std::chrono;
+    using namespace std::chrono_literals;
+
+    DXGI_RATIONAL tick_rate = {};
+    tick_rate.Numerator = 1;
+    tick_rate.Denominator = instance->m_frame_rate;
+    instance->m_frame_interval = duration_t(duration_cast<duration_t>(1s).count() * tick_rate.Numerator / tick_rate.Denominator);
+
+    return instance;
+}
+
+HRESULT VideoProcessor::start() {
+    if (m_frame_provider == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": frame provider is nullptr\n");
+        return E_FAIL;
+    }
+
+    m_keep_alive = 1;
+    m_processing_thread = std::move(std::thread(VideoProcessor::processing_thread_proc, this));
+
+    return S_OK;
+}
+
+void VideoProcessor::stop() {
+    m_keep_alive = 0;
+    if (m_processing_thread.joinable())
+        m_processing_thread.join();
+}
+
+HRESULT VideoProcessor::validate_video_processor_desc(const VideoProcessor::Desc& desc) {
+    // video processor device LUID
+    CComPtr<IDXGIAdapter> adapter;
+    HRESULT result = utils::enum_adapter_by_luid(&adapter, desc.adapter_luid);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid adapter luid\n");
+        return E_FAIL;
+    }
+
+    // video processor output frame rate
+    if (desc.frame_rate == 0) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": output frame rate should be greater 0\n");
+        return E_FAIL;
+    }
+
+    // frame output format
+    if (desc.output_format == DXGI_FORMAT_UNKNOWN) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": output frame format is unset\n");
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::receive_frame(std::shared_ptr<Frame>& frame, UINT timeout_ms) {
+    // wait for a new frame
+    std::unique_lock lk(m_output_lock);
+    auto timeout = std::chrono::milliseconds(timeout_ms);
+    auto signalled = m_output_cv.wait_for(lk, timeout, [&]() -> bool { return m_output_frame != nullptr; });
+    if (!signalled)
+        return DXGI_ERROR_WAIT_TIMEOUT;
+
+    // assign new frame
+    frame = m_output_frame;
+    m_output_frame.reset();
+    return S_OK;
+}
+
+HRESULT VideoProcessor::register_frame_provider(std::shared_ptr<FrameProvider> frame_provider) {
+    if (frame_provider == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+    
+    m_frame_provider = frame_provider;
+    return S_OK;
+}
+
+void VideoProcessor::update_input_frame(std::shared_ptr<Frame> frame) {
+    if (frame == nullptr)
+        return;
+
+    std::lock_guard lk(m_input_lock);
+    m_input_frame = frame;
+}
+
+class FrameTimeEstimator {
+public:
+    using duration_t = std::chrono::steady_clock::duration;
+
+    explicit FrameTimeEstimator(duration_t interval, uint32_t max_size) : m_interval(interval), m_max_size(max_size) {}
+
+    void push(duration_t next) {
+        if (m_ring_buffer.size() < m_max_size) {
+            m_ring_buffer.push_back(next);
+        } else {
+            if (m_pos >= m_ring_buffer.size())
+                m_pos = 0;
+            m_ring_buffer[m_pos++] = next;
+        }
+    }
+
+    void clear() { m_ring_buffer.clear(); }
+
+    duration_t next() const { 
+        duration_t avg = average();
+        duration_t est = 2 * m_interval - average();
+        return est;
+    }
+
+    duration_t average() const {
+        if (m_ring_buffer.empty())
+            return m_interval;
+        duration_t sum(0);
+        for (auto& v : m_ring_buffer)
+            sum += v;
+        duration_t avg = sum / m_ring_buffer.size();
+        return avg;
+    }
+
+private:
+    std::vector<duration_t> m_ring_buffer;
+    uint32_t m_max_size = 1;
+    duration_t m_interval;
+    uint32_t m_pos = 0;
+};
+
+HRESULT VideoProcessor::processing_thread_proc(VideoProcessor* context) {
+    using namespace std::chrono;
+    using namespace std::chrono_literals;
+
+    struct LogThreadLifetime {
+        LogThreadLifetime() { ga_logger(Severity::INFO, "VideoProcessor processing thread started\n"); }
+        ~LogThreadLifetime() { ga_logger(Severity::INFO, "VideoProcessor processing thread stoped\n"); }
+    } log_thread_lifetime;
+
+    if (context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": invalid argument\n");
+        return E_INVALIDARG;
+    }
+
+    auto frame_provider = context->get_frame_provider();
+    if (frame_provider == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": frame provider is nullptr\n");
+        return E_FAIL;
+    }
+
+    auto frame_interval = context->m_frame_interval;
+    FrameTimeEstimator fte(frame_interval, 10);
+
+    auto prev_frame_ts = steady_clock::now();
+    while (context->keep_alive()) {
+        // try to guess next frame time
+        auto estimated_frame_time = fte.next();
+
+        std::shared_ptr<Frame> frame;
+
+        // capture frame
+        const UINT capture_timeout_ms = 4; // cap input frame rate to 250fps = 4ms
+        auto capture_start = steady_clock::now();
+        HRESULT result = frame_provider->receive_frame(frame, capture_timeout_ms);
+        auto capture_end = steady_clock::now();
+        auto capture_time = capture_end - capture_start;
+
+        // process frame
+        auto proc_start = steady_clock::now();
+        if (SUCCEEDED(result) && frame != nullptr) {
+            // new frame received - update vp input
+            context->update_input_frame(frame);
+            // new frame received - process
+            result = context->process_frame();
+            if (FAILED(result)) {
+                ga_logger(Severity::ERR, __FUNCTION__ ": VideoProcessor->process_frame failed, result = 0x%08x\n", result);
+                continue;
+            }
+        }
+        auto proc_end = steady_clock::now();
+        auto proc_time = proc_end - proc_start;
+
+        // presentation timestamp
+        auto frame_ts = steady_clock::now();
+        // update output frame
+        context->update_output_frame();
+        // current frame time
+        auto frame_time = frame_ts - prev_frame_ts;
+        // update frame stats
+        prev_frame_ts = frame_ts;
+        fte.push(frame_time);
+
+        // frame rate control
+        // delay next frame capture to match frame rate
+        auto frc_start = steady_clock::now();
+        auto frc_delay_ts = frame_ts + estimated_frame_time - proc_time - capture_time;
+        if (frc_start < frc_delay_ts) {
+            auto sleep_time = frc_delay_ts - frc_start;
+            auto sleep_time_ms = duration_cast<milliseconds>(sleep_time);
+            // sleep timer resolution is not precise enough - use ms here
+            std::this_thread::sleep_for(sleep_time_ms);
+            // small extra delay for better frame pacing
+            while (steady_clock::now() < frc_delay_ts) { /* empty */ }
+        }
+        auto frc_end = steady_clock::now();
+        auto frc_time = frc_end - frc_start;
+    }
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::reset_copy_processor(const LUID& src_device_luid, uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format) {
+    // reset src to staging context
+    m_src_copy_device = nullptr;
+    m_src_copy_cmd_alloc = nullptr;
+    m_src_copy_cmd_queue = nullptr;
+    m_src_copy_cmd_list = nullptr;
+    m_src_copy_fence = nullptr;
+    if (m_src_copy_fence_shared_handle) {
+        CloseHandle(m_src_copy_fence_shared_handle);
+        m_src_copy_fence_shared_handle = nullptr;
+    }
+
+    // reset staging to dst context
+    m_dst_copy_cmd_alloc = nullptr;
+    m_dst_copy_cmd_queue = nullptr;
+    m_dst_copy_cmd_list = nullptr;
+    m_dst_copy_fence = nullptr;
+    if (m_dst_copy_fence_shared_handle) {
+        CloseHandle(m_dst_copy_fence_shared_handle);
+        m_dst_copy_fence_shared_handle = nullptr;
+    }
+
+    // reset surface pools
+    m_copy_staging_surface = nullptr;
+    m_copy_dst_surface = nullptr;
+    m_src_device_copy_src = nullptr;
+    m_src_device_copy_dst = nullptr;
+    m_dst_device_copy_src = nullptr;
+    m_dst_device_copy_dst = nullptr;
+
+    // same device - disable copy
+    if (utils::is_same_luid(src_device_luid, m_dst_device_luid)) {
+        m_src_device_luid = src_device_luid;
+        m_cross_adapter_copy_needed = false;
+        return S_OK;
+    }
+
+    // create src to staging context
+    CComPtr<IDXGIAdapter> adapter;
+    HRESULT result = utils::enum_adapter_by_luid(&adapter, src_device_luid);
+    if (FAILED(result) || adapter == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::enum_adapter_by_luid failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D12Device> device;
+    result = utils::create_d3d12_device(adapter, &device);
+    if (FAILED(result) || device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": utils::create_d3d12_device failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D12Device> src_device = device;
+    CComPtr<ID3D12Device> dst_device = m_device;
+    m_src_copy_device = src_device;
+
+    CComPtr<ID3D12CommandAllocator> src_copy_cmd_alloc;
+    result = src_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY,
+        __uuidof(ID3D12CommandAllocator), reinterpret_cast<void**>(&src_copy_cmd_alloc));
+    if (FAILED(result) || src_copy_cmd_alloc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandAllocator failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_cmd_alloc = src_copy_cmd_alloc;
+
+    D3D12_COMMAND_QUEUE_DESC command_queue_desc = {};
+    command_queue_desc.Type = D3D12_COMMAND_LIST_TYPE_COPY;
+    command_queue_desc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+    command_queue_desc.Priority = D3D12_COMMAND_QUEUE_PRIORITY_NORMAL;
+
+    CComPtr<ID3D12CommandQueue> src_copy_cmd_queue;
+    result = src_device->CreateCommandQueue(&command_queue_desc,
+        __uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&src_copy_cmd_queue));
+    if (FAILED(result) || src_copy_cmd_queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandQueue failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_cmd_queue = src_copy_cmd_queue;
+
+    CComPtr<ID3D12GraphicsCommandList> src_copy_cmd_list;
+    result = src_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY,
+        src_copy_cmd_alloc, nullptr /* init_state */,
+        __uuidof(ID3D12GraphicsCommandList), reinterpret_cast<void**>(&src_copy_cmd_list));
+    if (FAILED(result) || src_copy_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandList failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    result = src_copy_cmd_list->Close();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->Close failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_cmd_list = src_copy_cmd_list;
+
+    CComPtr<ID3D12Fence> src_copy_fence;
+    result = src_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER,
+        __uuidof(ID3D12Fence), reinterpret_cast<void**>(&src_copy_fence));
+    if (FAILED(result) || src_copy_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateFence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_fence = src_copy_fence;
+    m_src_copy_fence_value = 0;
+
+    HANDLE src_copy_fence_shared_handle = nullptr;
+    result = src_device->CreateSharedHandle(src_copy_fence, nullptr, GENERIC_ALL, nullptr, &src_copy_fence_shared_handle);
+    if (FAILED(result) || src_copy_fence_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateSharedHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_fence_shared_handle = src_copy_fence_shared_handle;
+
+    // create staging to dst context
+    CComPtr<ID3D12CommandAllocator> dst_copy_cmd_alloc;
+    result = dst_device->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COPY,
+        __uuidof(ID3D12CommandAllocator), reinterpret_cast<void**>(&dst_copy_cmd_alloc));
+    if (FAILED(result) || dst_copy_cmd_alloc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandAllocator failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_cmd_alloc = dst_copy_cmd_alloc;
+
+    CComPtr<ID3D12CommandQueue> dst_copy_cmd_queue;
+    result = dst_device->CreateCommandQueue(&command_queue_desc,
+        __uuidof(ID3D12CommandQueue), reinterpret_cast<void**>(&dst_copy_cmd_queue));
+    if (FAILED(result) || dst_copy_cmd_queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandQueue failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_cmd_queue = dst_copy_cmd_queue;
+
+    CComPtr<ID3D12GraphicsCommandList> dst_copy_cmd_list;
+    result = dst_device->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COPY,
+        dst_copy_cmd_alloc, nullptr /* init_state */,
+        __uuidof(ID3D12GraphicsCommandList), reinterpret_cast<void**>(&dst_copy_cmd_list));
+    if (FAILED(result) || dst_copy_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateCommandList failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    result = dst_copy_cmd_list->Close();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->Close failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_cmd_list = dst_copy_cmd_list;
+
+    CComPtr<ID3D12Fence> dst_copy_fence;
+    result = dst_device->CreateFence(0, D3D12_FENCE_FLAG_SHARED | D3D12_FENCE_FLAG_SHARED_CROSS_ADAPTER,
+        __uuidof(ID3D12Fence), reinterpret_cast<void**>(&dst_copy_fence));
+    if (FAILED(result) || dst_copy_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateFence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_fence = dst_copy_fence;
+    m_dst_copy_fence_value = 0;
+
+    HANDLE dst_copy_fence_shared_handle = nullptr;
+    result = dst_device->CreateSharedHandle(dst_copy_fence, nullptr, GENERIC_ALL, nullptr, &dst_copy_fence_shared_handle);
+    if (FAILED(result) || dst_copy_fence_shared_handle == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Device->CreateSharedHandle failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_fence_shared_handle = dst_copy_fence_shared_handle;
+
+    // create resources
+    std::unique_ptr<DX12Surface> copy_staging_surface;
+    {
+        D3D12_HEAP_PROPERTIES heap_props = {};
+        heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
+        D3D12_HEAP_FLAGS heap_flags = D3D12_HEAP_FLAG_SHARED | D3D12_HEAP_FLAG_SHARED_CROSS_ADAPTER;
+        D3D12_RESOURCE_DESC resource_desc = {};
+        resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+        resource_desc.Width = frame_width;
+        resource_desc.Height = frame_height;
+        resource_desc.DepthOrArraySize = 1;
+        resource_desc.MipLevels = 1;
+        resource_desc.Format = frame_format;
+        resource_desc.SampleDesc.Count = 1;
+        resource_desc.SampleDesc.Quality = 0;
+        resource_desc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+        resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_CROSS_ADAPTER;
+        copy_staging_surface = DX12Surface::create(src_device, &heap_props, heap_flags, &resource_desc);
+        if (copy_staging_surface == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": DX12Surface->create failed\n");
+            return E_FAIL;
+        }
+    }
+
+    std::unique_ptr<DX12Surface> copy_dst_surface;
+    {
+        D3D12_HEAP_PROPERTIES heap_props = {};
+        heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
+        D3D12_HEAP_FLAGS heap_flags = D3D12_HEAP_FLAG_NONE;
+        D3D12_RESOURCE_DESC resource_desc = {};
+        resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+        resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+        resource_desc.Width = frame_width;
+        resource_desc.Height = frame_height;
+        resource_desc.DepthOrArraySize = 1;
+        resource_desc.MipLevels = 1;
+        resource_desc.Format = frame_format;
+        resource_desc.SampleDesc.Count = 1;
+        resource_desc.SampleDesc.Quality = 0;
+        resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+        resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+        copy_dst_surface = DX12Surface::create(dst_device, &heap_props, heap_flags, &resource_desc);
+        if (copy_dst_surface == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": DX12Surface->create failed\n");
+            return E_FAIL;
+        }
+    }
+
+    CComPtr<ID3D12Resource> src_device_copy_dst;
+    result = copy_staging_surface->open_shared_resource(src_device, &src_device_copy_dst);
+    if (FAILED(result) || src_device_copy_dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D12Resource> dst_device_copy_src;
+    result = copy_staging_surface->open_shared_resource(dst_device, &dst_device_copy_src);
+    if (FAILED(result) || dst_device_copy_src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D12Resource> dst_device_copy_dst;
+    result = copy_dst_surface->open_shared_resource(dst_device, &dst_device_copy_dst);
+    if (FAILED(result) || dst_device_copy_dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // device luid 
+    m_src_device_luid = src_device_luid;
+
+    // copy surfaces and refs
+    m_copy_staging_surface = std::move(copy_staging_surface);
+    m_copy_dst_surface = std::move(copy_dst_surface);
+    m_src_device_copy_src = nullptr; // filled in on a new frame
+    m_src_device_copy_dst = src_device_copy_dst;
+    m_dst_device_copy_src = dst_device_copy_src;
+    m_dst_device_copy_dst = dst_device_copy_dst;
+
+    m_cross_adapter_copy_needed = true;
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::reset_video_processor(uint32_t src_frame_width, uint32_t src_frame_height, DXGI_FORMAT src_frame_format) {
+    if (m_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_video_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": video device is nullptr\n");
+        return E_FAIL;
+    }
+
+    m_video_processor = nullptr;
+    m_output_surface_pool = nullptr;
+
+    // destination frame format
+    uint32_t dst_frame_width = src_frame_width;
+    uint32_t dst_frame_height = src_frame_height;
+    DXGI_FORMAT dst_frame_format = m_output_format;
+
+    // create output surface pool
+    DX12SurfacePool::Desc pool_desc = {};
+    pool_desc.device = m_device;
+    pool_desc.heap_props.Type = D3D12_HEAP_TYPE_DEFAULT;
+    pool_desc.heap_flags = D3D12_HEAP_FLAG_SHARED;
+    pool_desc.resource_desc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+    pool_desc.resource_desc.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;
+    pool_desc.resource_desc.Width = dst_frame_width;
+    pool_desc.resource_desc.Height = dst_frame_height;
+    pool_desc.resource_desc.DepthOrArraySize = 1;
+    pool_desc.resource_desc.MipLevels = 1;
+    pool_desc.resource_desc.Format = dst_frame_format;
+    pool_desc.resource_desc.SampleDesc.Count = 1;
+    pool_desc.resource_desc.SampleDesc.Quality = 0;
+    pool_desc.resource_desc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+    pool_desc.resource_desc.Flags = D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_SIMULTANEOUS_ACCESS;
+    m_output_surface_pool = DX12SurfacePool::create(pool_desc);
+    if (m_output_surface_pool == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": failed to create surface pool\n");
+        return E_FAIL;
+    }
+
+    // create video processor 
+    D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC in_stream_desc = {};
+    in_stream_desc.Format = src_frame_format;
+    in_stream_desc.ColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+
+    in_stream_desc.SourceAspectRatio.Numerator = src_frame_width;
+    in_stream_desc.SourceAspectRatio.Denominator = src_frame_height;
+    in_stream_desc.DestinationAspectRatio.Numerator = src_frame_width;
+    in_stream_desc.DestinationAspectRatio.Denominator = src_frame_height;
+
+    in_stream_desc.FrameRate.Numerator = 60;
+    in_stream_desc.FrameRate.Denominator = 1;
+
+    in_stream_desc.SourceSizeRange.MaxWidth = src_frame_width;
+    in_stream_desc.SourceSizeRange.MaxHeight = src_frame_height;
+    in_stream_desc.SourceSizeRange.MinWidth = src_frame_width;
+    in_stream_desc.SourceSizeRange.MinHeight = src_frame_height;
+
+    in_stream_desc.DestinationSizeRange.MaxWidth = src_frame_width;
+    in_stream_desc.DestinationSizeRange.MaxHeight = src_frame_height;
+    in_stream_desc.DestinationSizeRange.MinWidth = src_frame_width;
+    in_stream_desc.DestinationSizeRange.MinHeight = src_frame_height;
+
+    in_stream_desc.EnableOrientation = false;
+    in_stream_desc.FilterFlags = D3D12_VIDEO_PROCESS_FILTER_FLAG_NONE;
+    in_stream_desc.StereoFormat = D3D12_VIDEO_FRAME_STEREO_FORMAT_NONE;
+    in_stream_desc.FieldType = D3D12_VIDEO_FIELD_TYPE_NONE;
+    in_stream_desc.DeinterlaceMode = D3D12_VIDEO_PROCESS_DEINTERLACE_FLAG_NONE;
+    in_stream_desc.EnableAlphaBlending = false;
+    in_stream_desc.EnableAutoProcessing = false;
+
+    D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC out_stream_desc = {};
+    out_stream_desc.Format = dst_frame_format;
+    out_stream_desc.ColorSpace = DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709;
+    out_stream_desc.AlphaFillMode = D3D12_VIDEO_PROCESS_ALPHA_FILL_MODE_OPAQUE;
+    out_stream_desc.FrameRate.Numerator = 60;
+    out_stream_desc.FrameRate.Denominator = 1;
+    out_stream_desc.EnableStereo = false;
+
+    CComPtr<ID3D12VideoProcessor> video_processor;
+    HRESULT result = m_video_device->CreateVideoProcessor(
+        1, &out_stream_desc, 1, &in_stream_desc, __uuidof(ID3D12VideoProcessor),
+        reinterpret_cast<void**>(&video_processor));
+    if (FAILED(result) || video_processor == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12VideoDevice->CreateVideoProcessor failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_video_processor = video_processor;
+    m_vp_in_stream_desc = in_stream_desc;
+    m_vp_out_stream_desc = out_stream_desc;
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::copy_src_to_staging() {
+
+    if (m_copy_src_frame == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src frame is nullptr\n");
+        return E_FAIL;
+    }
+
+    Surface* src_surface = m_copy_src_frame->get_surface();
+    Surface* dst_surface = m_copy_staging_surface.get();
+
+    if (src_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src surface is nullptr\n");
+        return E_FAIL;
+    }
+    if (dst_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": dst surface is nullptr\n");
+        return E_FAIL;
+    }
+
+    // wait for previous copy op
+    if (m_src_copy_event == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_src_copy_event_signalled) {
+        auto wait_result = WaitForSingleObject(m_src_copy_event, m_gpu_fence_timeout);
+        if (wait_result != WAIT_OBJECT_0) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+            return E_FAIL;
+        }
+        m_src_copy_event_signalled = false;
+    }
+
+    // reset src resource
+    m_src_device_copy_src = nullptr;
+
+    // open src surface on copy device
+    HRESULT result = src_surface->open_shared_resource(m_src_copy_device, &m_src_device_copy_src);
+    if (FAILED(result) || m_src_device_copy_src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    CComPtr<ID3D12Resource> src = m_src_device_copy_src;
+    CComPtr<ID3D12Resource> dst = m_src_device_copy_dst;
+
+    if (src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src resource is nullptr\n");
+        return E_FAIL;
+    }
+    if (dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": dst resource is nullptr\n");
+        return E_FAIL;
+    }
+    
+    if (m_src_copy_cmd_alloc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command allocator is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_src_copy_cmd_queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command queue is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_src_copy_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command list is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_src_copy_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // reset command allocator
+    result = m_src_copy_cmd_alloc->Reset();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandAllocator->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // fill command list
+    result = m_src_copy_cmd_list->Reset(m_src_copy_cmd_alloc, nullptr);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_before[2] = {};
+    states_before[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[0].Transition.pResource = src;
+    states_before[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+
+    states_before[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[1].Transition.pResource = dst;
+    states_before[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+
+    m_src_copy_cmd_list->ResourceBarrier(2, states_before);
+
+    // copy resource
+    m_src_copy_cmd_list->CopyResource(dst, src);
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_after[2] = {};
+    states_after[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[0].Transition.pResource = src;
+    states_after[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+    states_after[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+
+    states_after[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[1].Transition.pResource = dst;
+    states_after[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    states_after[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+    m_src_copy_cmd_list->ResourceBarrier(2, states_after);
+
+    // close command list
+    result = m_src_copy_cmd_list->Close();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->close failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for src surface
+    result = src_surface->wait_gpu_event_gpu(m_src_copy_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_fence_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait for dst surface
+    result = dst_surface->wait_gpu_event_gpu(m_src_copy_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_fence_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // execute command list
+    ID3D12CommandList* command_lists[] = { m_src_copy_cmd_list };
+    m_src_copy_cmd_queue->ExecuteCommandLists(1, command_lists);
+
+    // signal gpu fence
+    auto fence_value = InterlockedIncrement(&m_src_copy_fence_value);
+    result = m_src_copy_cmd_queue->Signal(m_src_copy_fence, m_src_copy_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->Signal failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = m_src_copy_fence->SetEventOnCompletion(m_src_copy_fence_value, m_src_copy_event);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_src_copy_event_signalled = true;
+
+    result = dst_surface->signal_gpu_event(m_src_copy_fence, m_src_copy_fence_shared_handle, m_src_copy_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->signal_gpu_fence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::copy_staging_to_dst() {
+
+    auto src_surface = m_copy_staging_surface.get();
+    auto dst_surface = m_copy_dst_surface.get();
+
+    CComPtr<ID3D12Resource> src = m_dst_device_copy_src;
+    CComPtr<ID3D12Resource> dst = m_dst_device_copy_dst;
+
+    if (src_surface == nullptr || src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": src surface is nullptr\n");
+        return E_FAIL;
+    }
+    if (dst_surface == nullptr || dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": dst surface is nullptr\n");
+        return E_FAIL;
+    }
+
+    if (m_dst_copy_cmd_alloc == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command allocator is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_dst_copy_cmd_queue == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command queue is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_dst_copy_cmd_list == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": command list is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_dst_copy_fence == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": fence is nullptr\n");
+        return E_FAIL;
+    }
+
+    // wait for previous copy op
+    if (m_dst_copy_event == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_dst_copy_event_signalled) {
+        auto wait_result = WaitForSingleObject(m_dst_copy_event, m_gpu_fence_timeout);
+        if (wait_result != WAIT_OBJECT_0) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+            return E_FAIL;
+        }
+        m_dst_copy_event_signalled = false;
+    }
+
+    // wait for previous video processing op
+    if (m_vp_event == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_vp_event_signalled) {
+        auto wait_result = WaitForSingleObject(m_vp_event, m_gpu_fence_timeout);
+        if (wait_result != WAIT_OBJECT_0) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+            return E_FAIL;
+        }
+        m_vp_event_signalled = false;
+    }
+
+    // reset command allocator
+    HRESULT result = m_dst_copy_cmd_alloc->Reset();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandAllocator->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // fill command list
+    result = m_dst_copy_cmd_list->Reset(m_dst_copy_cmd_alloc, nullptr);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_before[2] = {};
+    states_before[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[0].Transition.pResource = src;
+    states_before[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_SOURCE;
+
+    states_before[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[1].Transition.pResource = dst;
+    states_before[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COPY_DEST;
+
+    m_dst_copy_cmd_list->ResourceBarrier(2, states_before);
+
+    // copy resource
+    m_dst_copy_cmd_list->CopyResource(dst, src);
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_after[2] = {};
+    states_after[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[0].Transition.pResource = src;
+    states_after[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_SOURCE;
+    states_after[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+
+    states_after[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[1].Transition.pResource = dst;
+    states_after[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    states_after[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+    m_dst_copy_cmd_list->ResourceBarrier(2, states_after);
+
+    // close command list
+    result = m_dst_copy_cmd_list->Close();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12GraphicsCommandList->close failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait src surface
+    result = src_surface->wait_gpu_event_gpu(m_dst_copy_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_fence_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait dst surface
+    result = dst_surface->wait_gpu_event_gpu(m_dst_copy_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_fence_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // execute command list
+    ID3D12CommandList* command_lists[] = { m_dst_copy_cmd_list };
+    m_dst_copy_cmd_queue->ExecuteCommandLists(1, command_lists);
+
+    // signal gpu fence
+    auto fence_value = InterlockedIncrement(&m_dst_copy_fence_value);
+    result = m_dst_copy_cmd_queue->Signal(m_dst_copy_fence, m_dst_copy_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->Signal failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = m_dst_copy_fence->SetEventOnCompletion(m_dst_copy_fence_value, m_dst_copy_event);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_dst_copy_event_signalled = true;
+
+    result = dst_surface->signal_gpu_event(m_dst_copy_fence, m_dst_copy_fence_shared_handle, m_dst_copy_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->signal_gpu_fence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT VideoProcessor::process_frame() {
+    if (m_device == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": device is nullptr\n");
+        return E_FAIL;
+    }
+
+#if 0 // [fixme] remove
+    if (m_device_context == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": capture device context is nullptr\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+    if (m_device_context_lock == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": capture device context is invalid\n");
+        return DXGI_ERROR_DEVICE_REMOVED;
+    }
+#endif
+
+    HRESULT result = S_OK;
+
+    // get source frame
+    std::unique_lock input_lk(m_input_lock);
+    std::shared_ptr<Frame> src_frame = m_input_frame;
+    input_lk.unlock();
+
+    if (src_frame == nullptr)
+        return S_OK; // nothing to process - return
+
+    // get source surface
+    Surface* src_surface = src_frame->get_surface();
+    if (src_surface == nullptr)
+        return S_OK; // nothing to process - return
+
+    // check reset condition
+    auto src_luid = src_surface->get_device_luid();
+    const bool src_device_changed = !utils::is_same_luid(m_src_device_luid, src_luid);
+
+    auto src_width = src_surface->get_width();
+    auto src_height = src_surface->get_height();
+    auto src_format = src_surface->get_format();
+    const bool src_surface_changed =
+        src_width != m_vp_in_stream_desc.SourceSizeRange.MaxWidth ||
+        src_height != m_vp_in_stream_desc.SourceSizeRange.MaxHeight ||
+        src_format != m_vp_in_stream_desc.Format;
+
+    // reset video processor if needed
+    const bool reset_required = src_device_changed || src_surface_changed;
+    if (reset_required) {
+        // reset copy processor
+        HRESULT result = reset_copy_processor(src_luid, src_width, src_height, src_format);
+        if (FAILED(result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": reset_copy_processor failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        // reset video processor
+        result = reset_video_processor(src_width, src_height, src_format);
+        if (FAILED(result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": reset_processor failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+    }
+
+    // cross-adapter copy
+    if (m_cross_adapter_copy_needed) {
+        // get staging surface
+        m_copy_src_frame = src_frame;
+
+        // copy src to staging
+        HRESULT result = copy_src_to_staging();
+        if (FAILED(result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": copy_src_to_staging failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        // copy staging to dst
+        result = copy_staging_to_dst();
+        if (FAILED(result)) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": copy_staging_to_dst failed, result = 0x%08x\n", result);
+            return E_FAIL;
+        }
+
+        // replace src surface
+        src_surface = m_copy_dst_surface.get();
+        if (src_surface == nullptr) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": src surface is nullptr\n");
+            return E_FAIL;
+        }
+    }
+
+    // wait for previous video processing op
+    if (m_vp_event == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": event handle is nullptr\n");
+        return E_FAIL;
+    }
+    if (m_vp_event_signalled) {
+        auto wait_result = WaitForSingleObject(m_vp_event, m_gpu_fence_timeout);
+        if (wait_result != WAIT_OBJECT_0) {
+            ga_logger(Severity::ERR, __FUNCTION__ ": WaitForSingleObject failed, result = 0x%08x\n", wait_result);
+            return E_FAIL;
+        }
+        m_vp_event_signalled = false;
+    }
+
+    // reset src resource
+    m_input_src = nullptr;
+
+    // open src surface on video device
+    result = src_surface->open_shared_resource(m_device, &m_input_src);
+    if (FAILED(result) || m_input_src == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    CComPtr<ID3D12Resource> src = m_input_src;
+
+    // acquire dst surface
+    if (m_output_surface_pool == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": output surface pool is nullptr\n");
+        return E_FAIL;
+    }
+
+    auto dst_surface = m_output_surface_pool->acquire();
+    if (FAILED(result) || dst_surface == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": SurfacePool->acquire failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // open dst surface on video device
+    CComPtr<ID3D12Resource> dst;
+    result = dst_surface->open_shared_resource(m_device, &dst);
+    if (FAILED(result) || dst == nullptr) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->open_shared_resource failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // reset command allocator
+    result = m_video_cmd_alloc->Reset();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandAllocator->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // fill command list
+    result = m_video_cmd_list->Reset(m_video_cmd_alloc);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12VideoProcessCommandList->Reset failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_before[2] = {};
+    states_before[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[0].Transition.pResource = src;
+    states_before[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[0].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[0].Transition.StateAfter = D3D12_RESOURCE_STATE_VIDEO_PROCESS_READ;
+
+    states_before[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_before[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_before[1].Transition.pResource = dst;
+    states_before[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_before[1].Transition.StateBefore = D3D12_RESOURCE_STATE_COMMON;
+    states_before[1].Transition.StateAfter = D3D12_RESOURCE_STATE_VIDEO_PROCESS_WRITE;
+
+    m_video_cmd_list->ResourceBarrier(2, states_before);
+
+    // process frame
+    D3D12_RESOURCE_DESC in_resource_desc = src->GetDesc();
+    D3D12_RESOURCE_DESC out_resource_desc = dst->GetDesc();
+
+    D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS in_stream_args = {};
+    in_stream_args.InputStream[0].pTexture2D = src;
+    in_stream_args.InputStream[0].Subresource = 0;
+
+    in_stream_args.Transform.SourceRectangle.left = 0;
+    in_stream_args.Transform.SourceRectangle.top = 0;
+    in_stream_args.Transform.SourceRectangle.right = in_resource_desc.Width;
+    in_stream_args.Transform.SourceRectangle.bottom = in_resource_desc.Height;
+
+    in_stream_args.Transform.DestinationRectangle.left = 0;
+    in_stream_args.Transform.DestinationRectangle.top = 0;
+    in_stream_args.Transform.DestinationRectangle.right = out_resource_desc.Width;
+    in_stream_args.Transform.DestinationRectangle.bottom = out_resource_desc.Height;
+
+    in_stream_args.Transform.Orientation = D3D12_VIDEO_PROCESS_ORIENTATION_DEFAULT;
+
+    in_stream_args.Flags = D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAG_NONE;
+    in_stream_args.RateInfo.OutputIndex = 0;
+    in_stream_args.RateInfo.InputFrameOrField = 0;
+    in_stream_args.AlphaBlending.Enable = false;
+
+    D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS out_stream_args = {};
+    out_stream_args.OutputStream[0].pTexture2D = dst;
+    out_stream_args.OutputStream[0].Subresource = 0;
+    out_stream_args.TargetRectangle.left = 0;
+    out_stream_args.TargetRectangle.top = 0;
+    out_stream_args.TargetRectangle.right = out_resource_desc.Width;
+    out_stream_args.TargetRectangle.bottom = out_resource_desc.Height;
+    m_video_cmd_list->ProcessFrames(m_video_processor, &out_stream_args, 1, &in_stream_args);
+
+    // set resource state
+    D3D12_RESOURCE_BARRIER states_after[2] = {};
+    states_after[0].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[0].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[0].Transition.pResource = src;
+    states_after[0].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[0].Transition.StateBefore = D3D12_RESOURCE_STATE_VIDEO_PROCESS_READ;
+    states_after[0].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+
+    states_after[1].Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    states_after[1].Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+    states_after[1].Transition.pResource = dst;
+    states_after[1].Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+    states_after[1].Transition.StateBefore = D3D12_RESOURCE_STATE_VIDEO_PROCESS_WRITE;
+    states_after[1].Transition.StateAfter = D3D12_RESOURCE_STATE_COMMON;
+
+    m_video_cmd_list->ResourceBarrier(2, states_after);
+
+    // close command list
+    result = m_video_cmd_list->Close();
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12VideoProcessCommandList->Close failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = src_surface->wait_gpu_event_gpu(m_video_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_event_gpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // wait previous copy submission
+    result = dst_surface->wait_gpu_event_gpu(m_video_cmd_queue);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->wait_gpu_event_cpu failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // execute command list
+    ID3D12CommandList* command_lists[] = { m_video_cmd_list };
+    m_video_cmd_queue->ExecuteCommandLists(1, command_lists);
+
+    // signal gpu fence
+    auto fence_value = InterlockedIncrement(&m_vp_fence_value);
+    result = m_video_cmd_queue->Signal(m_vp_fence, m_vp_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12CommandQueue->Signal failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    result = m_vp_fence->SetEventOnCompletion(m_vp_fence_value, m_vp_event);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": ID3D12Fence->SetEventOnCompletion failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+    m_vp_event_signalled = true;
+
+    result = dst_surface->signal_gpu_event(m_vp_fence, m_vp_fence_shared_handle, m_vp_fence_value);
+    if (FAILED(result)) {
+        ga_logger(Severity::ERR, __FUNCTION__ ": Surface->signal_gpu_fence failed, result = 0x%08x\n", result);
+        return E_FAIL;
+    }
+
+    // update processed frame
+    m_processed_frame = Frame::create(std::move(dst_surface), m_output_surface_pool);
+    return S_OK;
+}
+
+void VideoProcessor::update_output_frame() {
+    std::unique_lock output_lk(m_output_lock);
+    m_output_frame = m_processed_frame;
+    output_lk.unlock();
+    m_output_cv.notify_one();
+}

--- a/sources/streamer/capture/video-processor.h
+++ b/sources/streamer/capture/video-processor.h
@@ -1,0 +1,294 @@
+// Copyright (C) 2023 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions
+// and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ga-common.h"
+
+#include "frame-provider.h"
+#include "frame.h"
+
+#include <atlcomcli.h>
+#include <d3d12.h>
+#include <d3d12video.h>
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <chrono>
+
+class DX12Surface; // forward decl
+class DX12SurfacePool; // forward decl
+
+/**
+ * @brief      This class describes a video processor that can be used to:
+ *             - convert input frame format
+ *             - crop frames
+ *             - copy surface across adapters
+ *             - provide frames at specified frame rate
+ *             User can obtain last processed frame by calling receive_frame() in a loop.
+ *             This class creates 2 threads:
+ *             - receiver thread : calls FrameProvider->receive_frame() in a loop
+ *               and updates input frame for video processor.
+ *             - processing thread : processes input frames in a loop and
+ *               outputs frames at specified frame rate
+ *             Video processor will initialize internal state based on the parameters of the first frame received.
+ *             If input frame parameters are changed, video processor will re-initialize internal state on the fly.
+ */
+class VideoProcessor : public FrameProvider {
+public:
+    struct Desc {
+        // video processor device LUID
+        LUID adapter_luid = {};
+        // video processor output frame rate
+        uint32_t frame_rate = 0;
+        // frame output format
+        DXGI_FORMAT output_format = DXGI_FORMAT_UNKNOWN;
+    };
+
+    ~VideoProcessor();
+
+    /**
+     * @brief      Create new video processor instance
+     *
+     * @param[in]  desc  video processor description
+     *
+     * @return     video processor object, on success
+     *             nullptr, on error
+     */
+    static std::unique_ptr<VideoProcessor> create(const VideoProcessor::Desc& desc);
+
+    /**
+     * @brief      Start frame capture
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT start() override;
+
+    /**
+     * @brief      Stop frame capture
+     */
+    void stop() override;
+
+    /**
+     * @brief      Validate video processor parameters
+     *
+     * @param[in]  desc  video processor description
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    static HRESULT validate_video_processor_desc(const VideoProcessor::Desc& desc);
+
+    /**
+     * @brief      Block thread and wait for a new frame in output buffer with timeout.
+     *             Called by user to acquire new frame from video processor.
+     *
+     * @param      frame       frame object
+     * @param[in]  timeout_ms  timeout in milliseconds
+     *
+     * @return     0 and frame object, on success
+     *             DXGI_ERROR_WAIT_TIMEOUT, if timeout interval elapses before new frame arrives
+     *             E_FAIL, on error
+     */
+    HRESULT receive_frame(std::shared_ptr<Frame>& frame, UINT timeout_ms) override;
+
+    /**
+     * @brief      Register frame provider
+     *
+     * @param[in]  frame_provider  frame provider interface
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT register_frame_provider(std::shared_ptr<FrameProvider> frame_provider);
+
+private:
+    using duration_t = std::chrono::steady_clock::duration;
+    using time_point_t = std::chrono::steady_clock::time_point;
+
+    VideoProcessor() = default;
+
+    bool keep_alive() const { return m_keep_alive.load(); }
+
+    /**
+     * @brief      Update input frame for video processor
+     *
+     * @param[in]  frame  The frame
+     */
+    void update_input_frame(std::shared_ptr<Frame> frame);
+
+    /**
+     * @brief      Thread function for frame processing
+     *
+     * @param      context  video processor interface
+     *
+     * @return     thread exit code
+     *             0, on success
+     *             HRESULT, on error
+     */
+    static HRESULT processing_thread_proc(VideoProcessor* context);
+
+    /**
+     * @brief      Reset internal state for cross-adapter copy
+     *
+     * @param[in]  src_device_luid  source device luid
+     * @param[in]  frame_width      frame width
+     * @param[in]  frame_height     frame height
+     * @param[in]  frame_format     frame format
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT reset_copy_processor(const LUID& src_device_luid, uint32_t frame_width, uint32_t frame_height, DXGI_FORMAT frame_format);
+
+    /**
+     * @brief      Reset internal state for video processing operation
+     *
+     * @param[in]  src_frame_width   source frame width
+     * @param[in]  src_frame_height  source frame height
+     * @param[in]  src_frame_format  source frame format
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT reset_video_processor(uint32_t src_frame_width, uint32_t src_frame_height, DXGI_FORMAT src_frame_format);
+
+    /**
+     * @brief      Copy input surface to cross-adapter shared local memory pool
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT copy_src_to_staging();
+
+    /**
+     * @brief      Copy staging surface from cross-adapter shared local memory pool to video processor device
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT copy_staging_to_dst();
+
+    /**
+     * @brief      Process frame :
+     *             - copy surface to target adapter if needed
+     *             - convert frame to desired format
+     *
+     * @return     0, on success
+     *             E_FAIL, on error
+     */
+    HRESULT process_frame();
+
+    /**
+     * @brief      Move processed frame to output buffer
+     */
+    void update_output_frame();
+
+    /**
+     * @return     Return frame provider object
+     */
+    std::shared_ptr<FrameProvider> get_frame_provider() { return m_frame_provider; }
+
+private:
+    // video processor options
+    UINT m_frame_rate = 0;
+    DXGI_FORMAT m_output_format = DXGI_FORMAT_UNKNOWN;
+
+    // frame interval duration for frame rate control
+    duration_t m_frame_interval = std::chrono::nanoseconds(0);
+
+    // frame provider interface
+    std::shared_ptr<FrameProvider> m_frame_provider;
+
+    // thread objects
+    std::thread m_processing_thread;
+    std::atomic<int> m_keep_alive = false;
+
+    // timeout config
+    static constexpr UINT m_gpu_fence_timeout = 500;
+
+    // source and destination device LUIDs
+    LUID m_src_device_luid = {};
+    LUID m_dst_device_luid = {};
+
+    // D3D12 video processor device and context
+    CComPtr<ID3D12Device> m_device;
+    CComPtr<ID3D12VideoDevice> m_video_device;
+    CComPtr<ID3D12CommandAllocator> m_video_cmd_alloc;
+    CComPtr<ID3D12CommandQueue> m_video_cmd_queue;
+    CComPtr<ID3D12VideoProcessCommandList> m_video_cmd_list;
+    CComPtr<ID3D12Fence> m_vp_fence;
+    HANDLE m_vp_fence_shared_handle = nullptr;
+    UINT64 m_vp_fence_value;
+    HANDLE m_vp_event = nullptr;
+    bool m_vp_event_signalled = false;
+
+    D3D12_VIDEO_PROCESS_INPUT_STREAM_DESC m_vp_in_stream_desc = {};
+    D3D12_VIDEO_PROCESS_OUTPUT_STREAM_DESC m_vp_out_stream_desc = {};
+    CComPtr<ID3D12VideoProcessor> m_video_processor;
+
+    // output surface pool
+    std::shared_ptr<SurfacePool> m_output_surface_pool;
+
+    // cross-adapter copy
+    bool m_cross_adapter_copy_needed = false;
+
+    // src to staging context
+    CComPtr<ID3D12Device> m_src_copy_device;
+    CComPtr<ID3D12CommandAllocator> m_src_copy_cmd_alloc;
+    CComPtr<ID3D12CommandQueue> m_src_copy_cmd_queue;
+    CComPtr<ID3D12GraphicsCommandList> m_src_copy_cmd_list;
+    CComPtr<ID3D12Fence> m_src_copy_fence;
+    HANDLE m_src_copy_fence_shared_handle = nullptr;
+    UINT64 m_src_copy_fence_value;
+    HANDLE m_src_copy_event = nullptr;
+    bool m_src_copy_event_signalled = false;
+
+    // staging to dst context
+    CComPtr<ID3D12CommandAllocator> m_dst_copy_cmd_alloc;
+    CComPtr<ID3D12CommandQueue> m_dst_copy_cmd_queue;
+    CComPtr<ID3D12GraphicsCommandList> m_dst_copy_cmd_list;
+    CComPtr<ID3D12Fence> m_dst_copy_fence;
+    HANDLE m_dst_copy_fence_shared_handle = nullptr;
+    UINT64 m_dst_copy_fence_value;
+    HANDLE m_dst_copy_event = nullptr;
+    bool m_dst_copy_event_signalled = false;
+
+    // copy surfaces and refs
+    std::shared_ptr<Frame> m_copy_src_frame;
+    std::unique_ptr<DX12Surface> m_copy_staging_surface;
+    std::unique_ptr<DX12Surface> m_copy_dst_surface;
+    CComPtr<ID3D12Resource> m_src_device_copy_src;
+    CComPtr<ID3D12Resource> m_src_device_copy_dst;
+    CComPtr<ID3D12Resource> m_dst_device_copy_src;
+    CComPtr<ID3D12Resource> m_dst_device_copy_dst;
+
+    // video processor input frame
+    std::mutex m_input_lock;
+    std::shared_ptr<Frame> m_input_frame;
+    CComPtr<ID3D12Resource> m_input_src;
+
+    // video processor output frame
+    std::shared_ptr<Frame> m_processed_frame;
+
+    // output buffer
+    std::mutex m_output_lock;
+    std::condition_variable m_output_cv;
+    std::shared_ptr<Frame> m_output_frame;
+};
+

--- a/sources/streamer/core/cursor.cpp
+++ b/sources/streamer/core/cursor.cpp
@@ -21,7 +21,7 @@
 #include "encoder-common.h"
 
 // Queue the cursor data into the server
-int queue_cursor(const CURSOR_INFO& info, uint8_t *pBuffer, uint32_t nLen)
+int queue_cursor(const CURSOR_INFO& info, const uint8_t *pBuffer, uint32_t nLen)
 {
     std::shared_ptr<CURSOR_DATA> cursorData = std::make_shared<CURSOR_DATA>();
     cursorData->cursorInfo = info;

--- a/sources/streamer/core/cursor.h
+++ b/sources/streamer/core/cursor.h
@@ -58,7 +58,7 @@ struct CURSOR_DATA {
 };
 
 #ifdef WIN32
-EXPORT int queue_cursor(const CURSOR_INFO& info, uint8_t *pBuffer, uint32_t nLen);
+EXPORT int queue_cursor(const CURSOR_INFO& info, const uint8_t *pBuffer, uint32_t nLen);
 #endif
 
 #endif

--- a/sources/streamer/core/libga.rc
+++ b/sources/streamer/core/libga.rc
@@ -1,0 +1,107 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+#include "cg-version.h"
+
+#define DESCRIPTION         "CG common shared Module"
+#define INTERNALNAME        "libga.dll"
+#define ORIGINALFILENAME    "libga.dll"
+
+#ifndef _DEBUG
+#define VER_DEBUG   0x00000000L
+#else
+#define VER_DEBUG   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION    CG_FILEVERSION
+ PRODUCTVERSION CG_PRODUCTVERSION
+ FILEFLAGSMASK  VS_FFI_FILEFLAGSMASK
+ FILEFLAGS      VER_DEBUG
+ FILEOS         VOS_NT_WINDOWS32
+ FILETYPE       VFT_DLL
+ FILESUBTYPE    VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",        CG_MANUFACTURER
+            VALUE "FileDescription",    DESCRIPTION
+            VALUE "FileVersion",        CG_VERSION_STR
+            VALUE "InternalName",       INTERNALNAME
+            VALUE "LegalCopyright",     CG_LEGALCOPYRIGHT
+            VALUE "OriginalFilename",   ORIGINALFILENAME
+            VALUE "ProductName",        CG_PRODUCTNAME
+            VALUE "ProductVersion",     CG_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/sources/streamer/core/meson.build
+++ b/sources/streamer/core/meson.build
@@ -42,6 +42,13 @@ if host_machine.system() == 'windows'
     'QoSMgt.cpp',
     )
 
+  srcs += windows.compile_resources(
+    files('libga.rc'),
+    args : winres_args,
+    depend_files : [ cgver_file, files('resource.h') ],
+    depends : cgvcs_tgt,
+    )
+
   cpp_public_args += [
     '-DHAVE_STRUCT_TIMESPEC',
     '-DWIN32',

--- a/sources/streamer/core/resource.h
+++ b/sources/streamer/core/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by libga.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/sources/streamer/meson.build
+++ b/sources/streamer/meson.build
@@ -14,11 +14,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-subdir('config')
-subdir('core')
-subdir('module')
-subdir('server')
+if (get_option('streamer').allowed() or
+    get_option('capture').require(host_machine.system() == 'windows').allowed())
+  subdir('core')
+  if host_machine.system() == 'windows' and build_machine.cpu_family() != 'x86'
+    subdir('capture')
+  endif
+endif
 
-if host_machine.system() == 'linux'
-  subdir('tests')
+if get_option('streamer').allowed()
+  streamer_required = get_option('streamer').enabled() or host_machine.system() == 'linux'
+
+  build_streamer = dependency('owt', required : streamer_required).found()
+
+  # These are ingredients which we don't need to configure if we can't
+  # build any of them. These are not entrypoints, so we don't need to
+  # report them in a summary as well.
+  if (build_streamer)
+    subdir('config')
+    if host_machine.system() == 'windows'
+      subdir('hook')
+      subdir('titan')
+    endif
+    subdir('module')
+  endif
+
+  subdir('server')
+
+  if host_machine.system() == 'linux'
+    subdir('tests')
+  endif
 endif

--- a/sources/streamer/server/periodic/meson.build
+++ b/sources/streamer/server/periodic/meson.build
@@ -14,6 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+if not build_streamer
+  warning('ga-server-periodic will NOT be built due to missing dependencies')
+  summary({'ga-server-periodic' : false}, bool_yn : true, section: 'Targets')
+  subdir_done()
+endif
+
+summary({'ga-server-periodic' : true}, bool_yn : true, section: 'Targets')
+
 srcs = files('ga-server-periodic.cpp')
 
 if fs.is_absolute(get_option('libdir'))


### PR DESCRIPTION
This PR adds desktop target (DT) capture library implementation for Windows along with simple sample app (screen-grab.exe) to demonstrate library usage.

DT capture library uses 1) IDXGIOutputDuplication Windows API to get access to duplicated desktop image and 2) ffmpeg to encode sequence of duplicated images into video bitstream. As of now capture library supports only AVC, HEVC and AV1 HW encoding via ffmpeg-qsv plugins path. Library also provides access to captured cursor state.

Authored-by: Pavel Evsikov <pavel.evsikov@intel.com>
Co-authored-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
